### PR TITLE
Add a storage service compatible with S3

### DIFF
--- a/gitlab-docker/README.md
+++ b/gitlab-docker/README.md
@@ -191,11 +191,12 @@ AWS_SECRET_ACCESS_KEY=minio123
 
 Substitute whatever values you provided for `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`
 in the `docker-compose.yml` file.  Additionally, since this is not an AWS S3 service,
-the `boto3` module requires that you specify an endpoint url in your environment.  In
-this case, your build jobs will need another environment variable to provide it:
+the way spack does S3 url handling requires that you specify an endpoint url in your
+environment.  In this case, your build jobs will need another environment variable
+to provide it:
 
 ```
-AWS_ENDPOINT_URL="http://minio:9000"
+S3_ENDPOINT_URL="http://minio:9000"
 ```
 
 #### Prepare a spack environment

--- a/gitlab-docker/README.md
+++ b/gitlab-docker/README.md
@@ -153,6 +153,12 @@ spack-env
 
 #### Bring up S3-compatible storage server (optional)
 
+This section assumes you want to test out using S3-compatible storage for
+hosting your binaries.  This can safely be ignored if you prefer to use the
+file system mirror described elsewhere in this document.
+
+First bring up the service:
+
 ```
 docker-compose up -d minio
 watch 'docker-compose ps'
@@ -164,6 +170,33 @@ Navigate to "http://localhost:8083/" and log in with the name and password in
 the `my-vars.sh` file.
 
 Use the `+` button at the bottom right to create a new bucket called `spack-public`.
+To use this service as a binary mirror in your build pipelines, the mirror url
+you should set will depend on the bucket name you chose.  If using `spack-public`
+as the bucket name, then configure the mirror in your release environment as
+follows:
+
+```
+  mirrors: { "mirror": "s3://spack-public/mirror" }
+```
+
+Use of S3 for binary mirror requires access credentials, which should be supplied
+via environment variables available to your build jobs.  Navigate to
+`localhost:8080/root/spack-build/-/settings/ci_cd`, and under "Variables", set
+up the following:
+
+```
+AWS_ACCESS_KEY_ID=minio
+AWS_SECRET_ACCESS_KEY=minio123
+```
+
+Substitute whatever values you provided for `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`
+in the `docker-compose.yml` file.  Additionally, since this is not an AWS S3 service,
+the `boto3` module requires that you specify an endpoint url in your environment.  In
+this case, your build jobs will need another environment variable to provide it:
+
+```
+AWS_ENDPOINT_URL="http://minio:9000"
+```
 
 #### Prepare a spack environment
 

--- a/gitlab-docker/README.md
+++ b/gitlab-docker/README.md
@@ -151,6 +151,20 @@ spack-env
  - Browse to `localhost:8080/projects/new`
  - Create a new project called "spack-env".
 
+#### Bring up S3-compatible storage server (optional)
+
+```
+docker-compose up -d minio
+watch 'docker-compose ps'
+```
+
+Once "healthy", ctrl-c the `watch`.
+
+Navigate to "http://localhost:8083/" and log in with the name and password in
+the `my-vars.sh` file.
+
+Use the `+` button at the bottom right to create a new bucket called `spack-public`.
+
 #### Prepare a spack environment
 
 ```

--- a/gitlab-docker/docker-compose.yml
+++ b/gitlab-docker/docker-compose.yml
@@ -6,6 +6,7 @@ volumes:
   opt: {}
   psql: {}
   mysql: {}
+  s3data: {}
 services:
   gitlab:
     image: "gitlab/gitlab-ee:12.1.0-ee.0"
@@ -90,7 +91,7 @@ services:
       REGISTRATION_TOKEN: "${RUNNER_REGISTRATION_TOKEN}"
       RUNNER_EXECUTOR: shell
       REGISTER_NON_INTERACTIVE: 'true'
-      RUNNER_TAG_LIST: "shell,spack-pre-ci"
+      RUNNER_TAG_LIST: "shell,spack-pre-ci,spack-k8s"
 
   rdocker:
     image: gitlab/gitlab-runner
@@ -114,7 +115,7 @@ services:
       REGISTRATION_TOKEN: "${RUNNER_REGISTRATION_TOKEN}"
       RUNNER_EXECUTOR: docker
       REGISTER_NON_INTERACTIVE: 'true'
-      RUNNER_TAG_LIST: "docker, spack-post-ci"
+      RUNNER_TAG_LIST: "docker,spack-post-ci,spack-k8s"
 
   nginx:
     image: docker
@@ -180,4 +181,15 @@ services:
       - docker
     links:
       - docker
+
+  minio:
+    image: minio/minio:RELEASE.2019-08-07T01-59-21Z
+    volumes:
+     - s3data:/mirror
+    ports:
+     - "${MINIO_WEB_PORT}:${MINIO_INTERNAL_WEB_PORT}"
+    environment:
+     MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
+     MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+    command: server /mirror
 

--- a/gitlab-docker/docker-compose.yml
+++ b/gitlab-docker/docker-compose.yml
@@ -191,5 +191,9 @@ services:
     environment:
      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
-    command: server /mirror
+    command:
+      - server
+      - --address
+      - "0.0.0.0:${MINIO_INTERNAL_WEB_PORT}"
+      - /mirror
 

--- a/gitlab-docker/vars.sh
+++ b/gitlab-docker/vars.sh
@@ -25,7 +25,9 @@ export RUNNER_REGISTRATION_TOKEN="REQUIRED"
 ### Login name is "root@docker.container"
 # export CDASH_ROOT_PASS=cdash-secret
 
-
+### MinIO information
+# export MINIO_ACCESS_KEY=minio
+# export MINIO_SECRET_KEY=minio123
 
 ################################################
 ### OPTIONAL SETTINGS
@@ -37,6 +39,8 @@ export RUNNER_REGISTRATION_TOKEN="REQUIRED"
 # export CDASH_WEB_PORT=8081
 # export CDASH_INTERNAL_WEB_PORT=80
 # export NGINX_WEB_PORT=8082
+# export MINIO_WEB_PORT=8083
+# export MINIO_INTERNAL_WEB_PORT=10083
 
 # export GITLAB_DB_USER=gitlab-db-user
 # export GITLAB_DB_NAME=gitlab-db


### PR DESCRIPTION
This is an attempt to have a way to test the cloud deployment pipeline in the local, `docker-compose` service environment provided by this repo.