### PR TITLE
update deployment strategies of several services to "replace"

### DIFF
--- a/kubernetes/spack/cdash-spack-io/db/deployments.yaml
+++ b/kubernetes/spack/cdash-spack-io/db/deployments.yaml
@@ -13,6 +13,8 @@ spec:
       app: cdash
       svc: db
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/kubernetes/spack/gitlab-spack-io/cache/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/cache/deployments.yaml
@@ -15,6 +15,8 @@ spec:
       svc: cache
       mode: master
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/kubernetes/spack/gitlab-spack-io/db/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/db/deployments.yaml
@@ -12,6 +12,9 @@ spec:
     matchLabels:
       app: gitlab
       svc: db
+  replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/kubernetes/spack/gitlab-spack-io/web/deployment.yaml
+++ b/kubernetes/spack/gitlab-spack-io/web/deployment.yaml
@@ -13,6 +13,8 @@ spec:
       app: gitlab
       svc: web
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/kubernetes/spack/staging-spack-io/cdash/db/deployments.yaml
+++ b/kubernetes/spack/staging-spack-io/cdash/db/deployments.yaml
@@ -13,6 +13,8 @@ spec:
       app: cdash-staging
       svc: db
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Changes the deployment strategies of several services from the default "rollout" to "replace".

Necessary for deployments with `replicas=1` and who mount persistent volumes.  With `replace` strategy, the pod running the service is completely removed before being recreated.  This strategy avoids issues where the "replacement" pod in a rollout cannot successfully start because they need resources held by the original pod.

Note that to achieve higher availability and/or zero downtime deployments require that a service be redefined in terms of replicasets and dynamic volumes.  This change only affects services that either cannot be deployed using a rolling strategy (e.g.: databases, because they do not support it) or for which we haven't gone through the trouble of redeploying them in a configuration that would support it (e.g.: gitlab).