### PR TITLE
add several reliability improvements for Gitlab

### DIFF
--- a/kubernetes/cluster/ingress-nginx/controller/configmaps.yaml
+++ b/kubernetes/cluster/ingress-nginx/controller/configmaps.yaml
@@ -9,10 +9,11 @@ metadata:
 data:
   client-body-buffer-size: 32M
   hsts: "true"
-  proxy-body-size: 1G
+  proxy-body-size: 1024M
   proxy-buffering: "off"
   proxy-read-timeout: "600"
   proxy-send-timeout: "600"
+  worker-shutdown-timeout: "900"
   server-tokens: "false"
   ssl-redirect: "true"
   upstream-keepalive-connections: "50"

--- a/kubernetes/cluster/ingress-nginx/controller/deployments.yaml
+++ b/kubernetes/cluster/ingress-nginx/controller/deployments.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nginx-ingress-controller
   namespace: ingress-nginx
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: ingress-nginx
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.17.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.21.0
           args:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/kubernetes/spack/gitlab-spack-io/db/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/db/deployments.yaml
@@ -45,6 +45,7 @@ spec:
       - name: postgresql
         image: "postgres:9.6.2"
         imagePullPolicy: IfNotPresent
+        args: ["-c", "shared_buffers=256MB", "-c", "max_connections=1000"]
         env:
         - name: POSTGRES_USER
           valueFrom:

--- a/kubernetes/spack/gitlab-spack-io/runner/medium/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/medium/deployments.yaml
@@ -28,6 +28,8 @@ spec:
       - name: runner
         image: "gitlab/gitlab-runner:latest"
         imagePullPolicy: Always
+        args: [--debug, --log-level=debug, run, --user=gitlab-runner,
+                --working-directory=/home/gitlab-runner]
         lifecycle:
           postStart:
             exec:

--- a/kubernetes/spack/gitlab-spack-io/web/config-maps.yaml
+++ b/kubernetes/spack/gitlab-spack-io/web/config-maps.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: watchdog-script
+  namespace: spack
+  labels:
+    svc: watchdog
+data:
+  script: |
+    #! /bin/bash
+    filesystem_checks=("$@")
+    threshold=10
+
+    check_mem() {
+      mem=($( free | grep Mem | sed 's/  */ /g' | cut -d\  -f 2,7 ))
+      percent_available="$(( 100*${mem[1]}/${mem[0]} ))"
+      if [ "$percent_available" -lt "$threshold" ] ; then
+        echo "$( date ) - available memory below $threshold%"
+      fi
+    }
+
+    check_fs() {
+      fs="$1"
+      percent_available=$(
+        df -P "$fs" | tail -n 1 | sed 's/  */ /g' | cut -d\  -f 5 | cut -d% -f 1 )
+      percent_available="$(( 100 - percent_available ))"
+      if [ "$percent_available" -lt "$threshold" ] ; then
+        echo "$( date ) - available space on directory below $threshold% - $fs"
+      fi
+    }
+
+    check() {
+      check_mem
+      for fs in "${filesystem_checks[@]}" ; do
+        check_fs "$fs"
+      done
+    }
+
+    done=0
+    trap 'done=1' EXIT INT TERM QUIT
+    while [ "$done" '=' 0 ] ; do
+      check
+      if [ "$done" '=' 0 ] ; then sleep 15 ; fi
+    done
+

--- a/kubernetes/spack/gitlab-spack-io/web/deployment.yaml
+++ b/kubernetes/spack/gitlab-spack-io/web/deployment.yaml
@@ -66,13 +66,30 @@ spec:
           subPath: repo
 
       containers:
+      - name: watchdog
+        image: alpine
+        command:
+          - sh
+          - -c
+          - "apk add bash && /watchdog /gitlab-data"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: watchdog-script
+          mountPath: /watchdog
+          subPath: script
+        - name: data
+          readOnly: true
+          mountPath: /gitlab-data
       - name: gitlab
         image: "gitlab/gitlab-ee:12.8.1-ee.0"
         imagePullPolicy: IfNotPresent
         env:
         - name: GITLAB_OMNIBUS_CONFIG
           value: |
-            external_url 'http://gitlab.spack.io'
+            external_url 'https://gitlab.spack.io'
+
+            nginx['listen_port'] = 80;
+            nginx['listen_https'] = false;
 
             root_pass = ENV['GITLAB_ROOT_PASSWORD'];
             gitlab_rails['initial_root_password'] = (
@@ -212,8 +229,12 @@ spec:
           mountPath: /meta
           subPath: meta
       nodeSelector:
-        "beta.kubernetes.io/instance-type": "m4.large"
+        "beta.kubernetes.io/instance-type": "r5.xlarge"
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: gitlab-data
+        - name: watchdog-script
+          configMap:
+            name: watchdog-script
+            defaultMode: 0700

--- a/kubernetes/spack/gitlab-spack-io/web/pv.yaml
+++ b/kubernetes/spack/gitlab-spack-io/web/pv.yaml
@@ -3,12 +3,12 @@ kind: PersistentVolume
 metadata:
   name: spack-gitlab
 spec:
-  storageClassName: ""
+  storageClassName: us-east-1a
   accessModes:
   - ReadWriteOnce
   capacity:
-    storage: 20Gi
+    storage: 100Gi
   persistentVolumeReclaimPolicy: Retain
   awsElasticBlockStore:
     fsType: ext4
-    volumeID: aws://us-east-1a/vol-0ca5b4fedeba968cc
+    volumeID: aws://us-east-1a/vol-0b55fcd82511f36b5

--- a/kubernetes/spack/gitlab-spack-io/web/pvc.yaml
+++ b/kubernetes/spack/gitlab-spack-io/web/pvc.yaml
@@ -10,6 +10,6 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 20Gi
-  storageClassName: ""
+      storage: 100Gi
+  storageClassName: us-east-1a
   volumeName: spack-gitlab


### PR DESCRIPTION
 - Increase worker timeout for NGINX ingress to 15
   minutes.

 - Increase number of replicas running NGINX
   ingress to 3.

 - Bump version of NGINX controller up to 0.21.0.

 - Increase shared buffer size for POSTGRES DB to
   256 MB.

 - Increase max connections for POSTGRES DB to
   1000.

 - Increase log level of "medium" Gitlab CI
   runners to "debug".

 - Add a watchdog script that runs alongside
   Gitlab and prints a log line when the memory
   or storage utilization rises above 90%.

 - Fix a long-standing issue where Gitlab used the
   wrong external_url in its generated links and
   messages.

 - Migrated Gitlab service from running on a
   dedicated m4.large instance to a dedicated
   r5.xlarge instance.

 - Increase the storage for Gitlab from 20 GB to
   100 GB.