### PR TITLE
Bump the gitlab version for update-permissions

### DIFF
--- a/kubernetes/spack/gitlab-spack-io/web/deployment.yaml
+++ b/kubernetes/spack/gitlab-spack-io/web/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       #     mountPath: /data
 
       - name: update-permissions
-        image: "gitlab/gitlab-ee:12.8.1-ee.0"
+        image: "gitlab/gitlab-ee:12.9.2-ee.0"
         imagePullPolicy: IfNotPresent
         args: ["update-permissions"]
         volumeMounts:


### PR DESCRIPTION
For posterity's sake, let it be known that this upgrade from 12.8 to 12.9 required us to run the following command from the gitlab container:

`gitlab-rake db:migrate`