### PR TITLE
Better elastic search integration

### DIFF
--- a/kubernetes/spack/gitlab-spack-io/runner/config-maps.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/config-maps.yaml
@@ -1,0 +1,248 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gitlab-runner-scripts
+  namespace: spack
+  labels:
+    app: gitlab
+    svc: runner
+data:
+  generate-pre-build: |
+    cat << EOF
+    timestamp="\$( date '+@%s' )"
+    index="spack-pre-build-\$( date --date "\$timestamp" '+%Y.%m.%d' )"
+    datetime="\$( date --date "\$timestamp" '+%Y-%m-%dT%H:%M:%S.%N%z' )"
+
+    (
+      cat << __PYTHON_EOF
+    $( cat generate-payload )
+    __PYTHON_EOF
+    ) > /generate-payload
+
+    if   which python3 ; then py=python3
+    elif which python  ; then py=python
+    else                      py=python2
+    fi &> /dev/null
+
+    export datetime
+
+    rm -f ./index.json ./payload.json
+    "\$py" /generate-payload
+    payload_index="\$( cat ./index.json )"
+    payload="\$( cat ./payload.json )"
+
+    curl -XPUT \
+      --output /dev/null \
+      -u "${ELASTIC_SEARCH_USER}:${ELASTIC_SEARCH_PASS}" \
+      "${ELASTIC_SEARCH_URL}/\${index}" \
+       -H 'Content-Type: application/json' \
+       -d"\$payload_index" &> /dev/null
+
+    curl -XPOST \
+      --output /dev/null \
+      -u "${ELASTIC_SEARCH_USER}:${ELASTIC_SEARCH_PASS}" \
+      "${ELASTIC_SEARCH_URL}/\${index}/_doc" \
+       -H 'Content-Type: application/json' \
+       -d"\$payload" &> /dev/null
+    EOF
+
+  generate-post-build: |
+    cat << EOF
+    result="\$?"
+    export result
+
+    end_timestamp="\$( date '+@%s' )"
+    index="spack-post-build-\$( date --date "\$timestamp" '+%Y.%m.%d' )"
+    end_datetime="\$( date --date "\$end_timestamp" '+%Y-%m-%dT%H:%M:%S.%N%z' )"
+
+    (
+      cat << __PYTHON_EOF
+    $( cat generate-payload )
+    __PYTHON_EOF
+    ) > /generate-payload
+
+    if   which python3 ; then py=python3
+    elif which python  ; then py=python
+    else                      py=python2
+    fi &> /dev/null
+
+    export end_datetime
+
+    rm -f ./index.json ./payload.json
+    "\$py" /generate-payload
+    payload_index="\$( cat ./index.json )"
+    payload="\$( cat ./payload.json )"
+
+    curl -XPUT \
+      --output /dev/null \
+      -u "${ELASTIC_SEARCH_USER}:${ELASTIC_SEARCH_PASS}" \
+      "${ELASTIC_SEARCH_URL}/\${index}" \
+       -H 'Content-Type: application/json' \
+       -d"\$payload_index" &> /dev/null
+
+    curl -XPOST \
+      --output /dev/null \
+      -u "${ELASTIC_SEARCH_USER}:${ELASTIC_SEARCH_PASS}" \
+      "${ELASTIC_SEARCH_URL}/\${index}/_doc" \
+       -H 'Content-Type: application/json' \
+       -d"\$payload" &> /dev/null
+    EOF
+
+  generate-payload: |
+    import json
+    import os
+    import sys
+
+    def e(key, default='', *args, **kwargs):
+        return os.environ.get(key, default, *args, **kwargs)
+
+    payload = {
+      '@timestamp' : e('datetime'),
+      'ci' : e('CI'),
+      'node_total' : e('CI_NODE_TOTAL'),
+      'pages_domain' : e('CI_PAGES_DOMAIN'),
+      'config_path' : e('CI_CONFIG_PATH'),
+      'default_branch' : e('CI_DEFAULT_BRANCH'),
+      'disposable_environment' : e('CI_DISPOSABLE_ENVIRONMENT'),
+      'gitlab_ci' : e('GITLAB_CI'),
+      'hostname' : e('HOSTNAME'),
+
+      'gitlab_features' : [
+        token.strip() for token in e('GITLAB_FEATURES').split(',')],
+
+      'build': {
+        'dir' : e('CI_BUILDS_DIR'),
+        'before_sha' : e('CI_BUILD_BEFORE_SHA'),
+        'id' : e('CI_BUILD_ID'),
+        'name' : e('CI_BUILD_NAME'),
+        'stage' : e('CI_BUILD_STAGE'),
+
+        'ref' : {
+          'value' : e('CI_BUILD_REF'),
+          'name'  : e('CI_BUILD_REF_NAME'),
+          'slug'  : e('CI_BUILD_REF_SLUG')
+        }
+      },
+
+      'commit': {
+        'branch': e('CI_COMMIT_BRANCH'),
+        'description': e('CI_COMMIT_DESCRIPTION'),
+        'message': e('CI_COMMIT_MESSAGE'),
+        'title': e('CI_COMMIT_TITLE'),
+
+        'ref': {
+          'name': e('CI_COMMIT_REF_NAME'),
+          'protected': e('CI_COMMIT_REF_PROTECTED'),
+          'slug': e('CI_COMMIT_REF_SLUG')
+        },
+
+        'sha': {
+          'before': e('CI_COMMIT_BEFORE_SHA'),
+          'full': e('CI_COMMIT_SHA'),
+          'short': e('CI_COMMIT_SHORT_SHA')
+        }
+      },
+
+      'job': {
+        'concurrent_id': e('CI_CONCURRENT_ID'),
+        'concurrent_project_id': e('CI_CONCURRENT_PROJECT_ID'),
+        'id': e('CI_JOB_ID'),
+        'image': e('CI_JOB_IMAGE'),
+        'name': e('CI_JOB_NAME'),
+        'stage': e('CI_JOB_STAGE'),
+        'url': e('CI_JOB_URL')
+      },
+
+      'pipeline': {
+        'id': e('CI_PIPELINE_ID'),
+        'iid': e('CI_PIPELINE_IID'),
+        'source': e('CI_PIPELINE_SOURCE'),
+        'url': e('CI_PIPELINE_URL')
+      },
+
+      'project': {
+        'dir': e('CI_PROJECT_DIR'),
+        'id': e('CI_PROJECT_ID'),
+        'name': e('CI_PROJECT_NAME'),
+        'namespace': e('CI_PROJECT_NAMESPACE'),
+        'path': e('CI_PROJECT_PATH'),
+        'path_slug': e('CI_PROJECT_PATH_SLUG'),
+        'title': e('CI_PROJECT_TITLE'),
+        'url': e('CI_PROJECT_URL'),
+        'visibility': e('CI_PROJECT_VISIBILITY'),
+
+        'repository_languages': [
+          token.strip() for token in
+          e('CI_PROJECT_REPOSITORY_LANGUAGES').split(',')]
+      },
+
+      'runner': {
+        'description': e('CI_RUNNER_DESCRIPTION'),
+        'executable_arch': e('CI_RUNNER_EXECUTABLE_ARCH'),
+        'id': e('CI_RUNNER_ID'),
+        'revision': e('CI_RUNNER_REVISION'),
+        'version': e('CI_RUNNER_VERSION'),
+
+        'tags': [
+          token.strip() for token in e('CI_RUNNER_TAGS').split(',')]
+      },
+
+      'server': {
+        'value': e('CI_SERVER'),
+        'host': e('CI_SERVER_HOST'),
+        'name': e('CI_SERVER_NAME'),
+        'port': e('CI_SERVER_PORT'),
+        'protocol': e('CI_SERVER_PROTOCOL'),
+        'revision': e('CI_SERVER_REVISION'),
+        'url': e('CI_SERVER_URL'),
+
+        'version': {
+          'value': e('CI_SERVER_VERSION'),
+          'major': e('CI_SERVER_VERSION_MAJOR'),
+          'minor': e('CI_SERVER_VERSION_MINOR'),
+          'patch': e('CI_SERVER_VERSION_PATCH')
+        }
+      },
+
+      'gitlab_user': {
+        'email': e('GITLAB_USER_EMAIL'),
+        'id': e('GITLAB_USER_ID'),
+        'login': e('GITLAB_USER_LOGIN'),
+        'name': e('GITLAB_USER_NAME')
+      },
+
+      'spack': {
+        'root_spec': e('SPACK_ROOT_SPEC'),
+        'spec_pkg_name': e('SPACK_JOB_SPEC_PKG_NAME'),
+        'compiler_action': e('SPACK_COMPILER_ACTION'),
+        'is_pr_pipeline': e('SPACK_IS_PR_PIPELINE')
+      }
+    }
+
+    payload_index = {
+      'mappings': {
+        'properties': {
+          '@timestamp': { 'type': 'date' }
+        }
+      }
+    }
+
+    build_end_time = e('end_datetime')
+    if build_end_time:
+        payload['@timestamp'], payload['build_start_time'] = (
+          build_end_time, payload['@timestamp'])
+        payload_index['mappings']['properties']['build_start_time'] = {
+          'type': 'date'
+        }
+
+    result = e('result')
+    if result:
+        payload['result'] = result
+
+    with open('./payload.json', 'w') as f:
+      json.dump(payload, f)
+
+    with open('./index.json', 'w') as f:
+      json.dump(payload_index, f)
+

--- a/kubernetes/spack/gitlab-spack-io/runner/large/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/large/deployments.yaml
@@ -15,7 +15,7 @@ spec:
       app: gitlab
       svc: runner
       size: large
-  replicas: 1 # One at a time
+  replicas: 3 # Three at a time
   template:
     metadata:
       labels:

--- a/kubernetes/spack/gitlab-spack-io/runner/medium/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/medium/deployments.yaml
@@ -28,8 +28,6 @@ spec:
       - name: runner
         image: "gitlab/gitlab-runner:latest"
         imagePullPolicy: Always
-        args: [--debug, --log-level=debug, run, --user=gitlab-runner,
-                --working-directory=/home/gitlab-runner]
         lifecycle:
           postStart:
             exec:

--- a/kubernetes/spack/gitlab-spack-io/runner/t3.micro/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/t3.micro/deployments.yaml
@@ -1,0 +1,130 @@
+# t3.micro gitlab runner(s)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitlab-runner-t3.micro
+  namespace: spack
+  labels:
+    app: gitlab
+    svc: runner
+    size: t3.micro
+spec:
+  selector:
+    matchLabels:
+      app: gitlab
+      svc: runner
+      size: t3.micro
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: gitlab
+        svc: runner
+        size: t3.micro
+    spec:
+      serviceAccountName: gitlab-runner
+      containers:
+      - name: runner
+        image: "gitlab/gitlab-runner:latest"
+        imagePullPolicy: Always
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - >
+                export RUNNER_NAME="$( hostname )" ;
+                gitlab-runner unregister --name "$( hostname )" ;
+                pushd /runner-scripts ;
+                RUNNER_PRE_BUILD_SCRIPT="$( bash generate-pre-build )" ;
+                RUNNER_POST_BUILD_SCRIPT="$( bash generate-post-build )" ;
+                popd ;
+                export RUNNER_PRE_BUILD_SCRIPT ;
+                export RUNNER_POST_BUILD_SCRIPT ;
+                gitlab-runner register \
+                  --kubernetes-pod-annotations \
+                    "cluster-autoscaler.kubernetes.io/safe-to-evict:false" \
+                  --kubernetes-node-selector "type:gitlab-runner" \
+                  --kubernetes-node-selector \
+                    "beta.kubernetes.io/instance-type:t3.micro" \
+          preStop:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - >
+                gitlab-runner unregister --name "$( hostname )"
+
+        env:
+        - name: DOCKER_IMAGE
+          value: "ubuntu:latest"
+
+        - name: CI_SERVER_URL
+          value: "http://gitlab"
+
+        - name: REGISTRATION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: gitlab-secrets
+              key: gitlab-runner-token
+
+        - name: ELASTIC_SEARCH_URL
+          value: "http://elastic-search-es-http.spack.svc:9200"
+
+        - name: ELASTIC_SEARCH_USER
+          value: elastic
+
+        - name: ELASTIC_SEARCH_PASS
+          valueFrom:
+            secretKeyRef:
+              name: elastic-search-es-elastic-user
+              key: elastic
+
+        - name: RUNNER_EXECUTOR
+          value: kubernetes
+
+        - name: KUBERNETES_CPU_REQUEST
+          value: "1.7" # prevent more than one job from running on a t3.micro
+
+        - name: KUBERNETES_PULL_POLICY
+          value: "always"
+
+        - name: KUBERNETES_POLL_TIMEOUT
+          value: "3600" # one hour
+
+        - name: KUBERNETES_SERVICE_ACCOUNT
+          value: "gitlab-runner"
+
+        - name: KUBERNETES_NAMESPACE
+          value: "spack"
+
+        - name: REGISTER_NON_INTERACTIVE
+          value: "true"
+
+        - name: RUNNER_REQUEST_CONCURRENCY
+          value: "32"
+
+        - name: RUNNER_LIMIT
+          value: "32"
+
+        - name: RUNNER_TAG_LIST
+          value: "spack-kube,t3.micro"
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 1m
+          limits:
+            memory: 100Mi
+            cpu: 100m
+        volumeMounts:
+        - name: runner-scripts
+          mountPath: /runner-scripts
+      volumes:
+        - name: runner-scripts
+          configMap:
+            name: gitlab-runner-scripts
+            defaultMode: 0700
+      nodeSelector:
+        "beta.kubernetes.io/instance-type": "t2.medium"

--- a/kubernetes/spack/gitlab-spack-io/web/deployment.yaml
+++ b/kubernetes/spack/gitlab-spack-io/web/deployment.yaml
@@ -179,6 +179,8 @@ spec:
               echo 'exit'
             ) | gitlab-rails console
 
+            gitlab-rake gitlab:elastic:create_empty_index
+
             gitlab-ctl restart
         - name: DB_HOST
           valueFrom:


### PR DESCRIPTION
 - Configures Gitlab service to ensure the presence of the `gitlab-*` elasticsearch indexes.
 - Removes the debugging arguments in our medium runner.
 - Increases large runners to three (3) replicas.
 - Adds a new set of t3.micro runners, currently set to five (5) replicas.  These new runners include an experimental elasticsearch integration implementation.

The details of the ES implementation are in the new `gitlab-runner-scripts` ConfigMap.  Additional mounts can't be specified for pods created by the Kubernetes executor, so the implementation works around this limitation by generating pre-build and post-build scripts, which are passed along to runners verbatim when registering.  Unfortunately, this additional level of indirection can make the script logic very tough to follow.  The general process is as follows:

First the runners (through these generated scripts) instruct the job pods to create a python script, `/generate-payload`.  This script creates two payloads, one for the record representing the build being performed (`./payload.json`) and one for specifying type metadata for that record (`./index.json`).  These payloads are populated using the environment variables of the running build job.  The pods then run the python script, and submit the payload contents as new records to the specified elasticsearch cluster using curl.

The results of this process are continuously updating elasticsearch indexes: `spack-pre-build-YYYY.MM.DD` with pre-build records for all Spack jobs that started on `MM/DD/YYYY`, and `spack-post-build-YYYY.MM.DD` with post-build records (*also*) for all Spack jobs that started on `MM/DD/YYYY` (i.e.: the record, itself might have a timestamp that falls on a later day if the job runtime spans multiple days).  To be clear: every job that starts on a day will have a pre- and post-build record in the respective indexes for *that* day, even if the job's actual end time falls on a later day.

On Kibana, three new index patterns have been created, `spack-pre-build-*`, `spack-post-build-*`, and `spack-*-build-*`, against which queries may be performed to search through pre-build records, post-build records, or both, respectively.

Example queries:
 - All records for pre-ci jobs (execute against the `spack-*-build-*` index pattern):

```
job.name: generate-pipeline
```
[link](https://kibana.spack.io/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2d,to:now))&_a=(columns:!(_source),filters:!(),index:'5b7b9f20-9b87-11ea-97a2-05d755153fd0',interval:auto,query:(language:kuery,query:'job.name:%20generate-pipeline'),sort:!(!('@timestamp',desc))))

 - Post build records for ncurses builds (execute against the `spack-post-build-*` index pattern):

```
spack.spec_pkg_name: ncurses
```
[link](https://kibana.spack.io/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2d,to:now))&_a=(columns:!(_source),filters:!(),index:be4b8e40-9b90-11ea-97a2-05d755153fd0,interval:auto,query:(language:kuery,query:'spack.spec_pkg_name:%20ncurses'),sort:!(!('@timestamp',desc))))

 - Same as above, but limit only to failed builds.

```
(spack.spec_pkg_name: ncurses) AND (NOT result: 0)
```
[link](https://kibana.spack.io/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-2d,to:now))&_a=(columns:!(_source),filters:!(),index:be4b8e40-9b90-11ea-97a2-05d755153fd0,interval:auto,query:(language:kuery,query:'(spack.spec_pkg_name:%20ncurses)%20AND%20(NOT%20result:%200)'),sort:!(!('@timestamp',desc))))

For now, the integration is limited to the new `t3.micro` runners. I plan to follow this PR up with another that extends it to the other runners.

#### Known Issues

 - Fields with empty string values need better handling, as the current implementation makes it impossible to distinguish them from non-empty string values in queries.

 - The new indexes do not include any log information, only "job-started" and "job-ended" records.  This work can be extended to collect other information (such as any generated job logs) and add them to elasticsearch.

 - The current implementation might not correctly submit post-build records in the event of a job failure.  Additional testing and development may be needed.