### PR TITLE
update specs for kubernetes 1.15

### DIFF
--- a/kubernetes/cluster/autoscaler/deployments.yaml
+++ b/kubernetes/cluster/autoscaler/deployments.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: gcr.io/google-containers/cluster-autoscaler:v1.18.1
+        - image: k8s.gcr.io/cluster-autoscaler:v1.14.7
           name: cluster-autoscaler
           resources:
             limits:

--- a/kubernetes/cluster/autoscaler/deployments.yaml
+++ b/kubernetes/cluster/autoscaler/deployments.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/cluster-autoscaler:v1.12.3
+        - image: gcr.io/google-containers/cluster-autoscaler:v1.18.1
           name: cluster-autoscaler
           resources:
             limits:

--- a/kubernetes/cluster/ingress-nginx/controller/deployments.yaml
+++ b/kubernetes/cluster/ingress-nginx/controller/deployments.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller

--- a/kubernetes/cluster/ingress-nginx/default-http-backend/deployments.yaml
+++ b/kubernetes/cluster/ingress-nginx/default-http-backend/deployments.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: default-http-backend

--- a/kubernetes/cluster/kubernetes-dashboard/heapster/deployments.yaml
+++ b/kubernetes/cluster/kubernetes-dashboard/heapster/deployments.yaml
@@ -1,16 +1,23 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster
   namespace: kube-system
+  labels:
+    app: k8s-dashboard
+    svc: heapster
 spec:
+  selector:
+    matchLabels:
+      app: k8s-dashboard
+      svc: heapster
   replicas: 1
   template:
     metadata:
       labels:
-        task: monitoring
-        k8s-app: heapster
+        app: k8s-dashboard
+        svc: heapster
     spec:
       serviceAccountName: heapster
       containers:

--- a/kubernetes/cluster/kubernetes-dashboard/influxdb/deployments.yaml
+++ b/kubernetes/cluster/kubernetes-dashboard/influxdb/deployments.yaml
@@ -1,16 +1,23 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-influxdb
   namespace: kube-system
+  labels:
+    app: k8s-dashboard
+    svc: influxdb
 spec:
+  selector:
+    matchLabels:
+      app: k8s-dashboard
+      svc: influxdb
   replicas: 1
   template:
     metadata:
       labels:
-        task: monitoring
-        k8s-app: influxdb
+        app: k8s-dashboard
+        svc: influxdb
     spec:
       containers:
       - name: influxdb

--- a/kubernetes/cluster/kubernetes-dashboard/web/deployments.yaml
+++ b/kubernetes/cluster/kubernetes-dashboard/web/deployments.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: kubernetes-dashboard
   namespace: kube-system

--- a/kubernetes/spack/gitlab-spack-io/cache/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/cache/deployments.yaml
@@ -129,7 +129,7 @@ spec:
         "beta.kubernetes.io/instance-type": "t2.medium"
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-metrics

--- a/kubernetes/spack/gitlab-spack-io/runner/large/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/large/deployments.yaml
@@ -15,7 +15,7 @@ spec:
       app: gitlab
       svc: runner
       size: large
-  replicas: 3 # Three at a time
+  replicas: 5 # Five at a time
   template:
     metadata:
       labels:

--- a/kubernetes/spack/gitlab-spack-io/web/deployment.yaml
+++ b/kubernetes/spack/gitlab-spack-io/web/deployment.yaml
@@ -252,7 +252,7 @@ spec:
           mountPath: /meta
           subPath: meta
       nodeSelector:
-        "beta.kubernetes.io/instance-type": "r5.xlarge"
+        "beta.kubernetes.io/instance-type": "r5.4xlarge"
       serviceAccount: gitlab
       volumes:
         - name: data


### PR DESCRIPTION
Also adds the following changes:

 - Upgrades cluster autoscaler from v1.12.3 to v1.14.7
 - Changes the instance type for the instance running Gitlab from `r5.xlarge` to `r5.4xlarge`.