### PR TITLE
mitigate docker ratelimit issues

### DIFF
--- a/kubernetes/spack/gitlab-spack-io/runner/c5n.2xlarge/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/c5n.2xlarge/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "k8s.internal/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "k8s.internal/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/c5n.xlarge/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/c5n.xlarge/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "k8s.internal/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "k8s.internal/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/large/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/large/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "k8s.internal/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "k8s.internal/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/medium/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/medium/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "k8s.internal/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "k8s.internal/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/r5.2xlarge/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/r5.2xlarge/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "k8s.internal/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "k8s.internal/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/t2.large/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/t2.large/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "k8s.internal/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "k8s.internal/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/t3.micro/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/t3.micro/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "k8s.internal/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "k8s.internal/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/t3.nano/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/t3.nano/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "k8s.internal/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "k8s.internal/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/kibana-spack-io/daemonset.yaml
+++ b/kubernetes/spack/kibana-spack-io/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch
+        image: k8s.internal/fluent-fluentd-kubernetes-daemonset:v1-debian-elasticsearch
         env:
           - name:  FLUENT_ELASTICSEARCH_HOST
             value: "elastic-search-es-http"

--- a/kubernetes/spack/misc/auto-updater/cron-jobs.yaml
+++ b/kubernetes/spack/misc/auto-updater/cron-jobs.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     svc: updater
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "0 */6 * * *"
   jobTemplate:
     metadata:
       labels:

--- a/kubernetes/spack/misc/registry/certificates.yaml
+++ b/kubernetes/spack/misc/registry/certificates.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: tls-registry
+  namespace: spack
+spec:
+  secretName: tls-registry
+  issuerRef:
+    name: self-sign
+    kind: ClusterIssuer
+  dnsNames:
+  - registry.spack.svc.cluster.local
+  - k8s.internal

--- a/kubernetes/spack/misc/registry/daemonsets.yaml
+++ b/kubernetes/spack/misc/registry/daemonsets.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: registry-ca
+  namespace: spack
+  labels:
+    k8s-app: registry-ca
+spec:
+  selector:
+    matchLabels:
+      k8s-app: registry-ca
+  template:
+    metadata:
+      labels:
+        k8s-app: registry-ca
+    spec:
+      containers:
+      - name: registry-ca
+        imagePullPolicy: IfNotPresent
+        image: alpine
+        command: [sh]
+        args:
+            - -c
+            - "   cp /ca-data/ca.crt /docker-cert/0 \
+               && cp /ca-data/ca.crt /docker-cert/1 \
+               && exec tail -f /dev/null"
+        volumeMounts:
+        - name: docker-cert0
+          mountPath: /docker-cert/0
+        - name: docker-cert1
+          mountPath: /docker-cert/1
+        - name: ca-cert
+          mountPath: /ca-data/ca.crt
+          subPath: ca.crt
+      - name: hosts-adjuster
+        imagePullPolicy: IfNotPresent
+        image: alpine
+        command: [sh]
+        args:
+            - -c
+            - "   apk add bind-tools gawk \
+               && while sleep 5 ; do \
+                    line=\"$( tail -n 1 /host-hosts )\" \
+               &&   ip=\"$( echo \"$line\" | awk '{print $1}' )\" \
+               &&   dns=\"$( echo \"$line\" | awk '{print $2}' )\" \
+               &&   if [ \"$dns\" '!=' 'registry.spack.svc.cluster.local' ] ; then \
+                       ip=\"$( host -t a registry.spack.svc.cluster.local \
+                               | tail -n 1 | cut -d' ' -f 4 )\"
+               &&      echo \"Appending entry: $ip\" \
+               &&      echo \"$ip registry.spack.svc.cluster.local k8s.internal\" >> /host-hosts \
+               ;    fi \
+               ;  done"
+        volumeMounts:
+        - name: etc-hosts
+          mountPath: /host-hosts
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: docker-cert0
+        hostPath:
+          path: /etc/docker/certs.d/registry.spack.svc.cluster.local
+      - name: docker-cert1
+        hostPath:
+          path: /etc/docker/certs.d/k8s.internal
+      - name: etc-hosts
+        hostPath:
+          path: /etc/hosts
+      - name: ca-cert
+        secret:
+          secretName: tls-registry

--- a/kubernetes/spack/misc/registry/deployments.yaml
+++ b/kubernetes/spack/misc/registry/deployments.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: spack
+  labels:
+    app: registry
+spec:
+  selector:
+    matchLabels:
+      app: registry
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+      - name: registry
+        image: "registry:2.6.0"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: REGISTRY_HTTP_SECRET
+          value: tls-registry
+        - name: REGISTRY_HTTP_ADDR
+          value: 0.0.0.0:443
+        - name: REGISTRY_HTTP_TLS_CERTIFICATE
+          value: /ca-data/tls.crt
+        - name: REGISTRY_HTTP_TLS_KEY
+          value: /ca-data/tls.key
+        ports:
+        - name: https
+          containerPort: 443
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/registry
+        - name: ca-data
+          mountPath: /ca-data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry-data
+        - name: ca-data
+          secret:
+            secretName: tls-registry
+      nodeSelector:
+        "beta.kubernetes.io/instance-type": "t2.medium"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-shell
+  namespace: spack
+  labels:
+    app: docker-shell
+spec:
+  selector:
+    matchLabels:
+      app: docker-shell
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: docker-shell
+    spec:
+      containers:
+      - name: docker
+        image: "docker:dind"
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - "sh"
+              - "-c"
+              - "  apk add bind-tools \
+                && ip=\"$( host -t A registry.spack.svc.cluster.local \
+                        | tail -n 1 | cut -d' ' -f 4 )\" \
+                && echo \"$ip k8s.internal\" >> /etc/hosts"
+        volumeMounts:
+        - name: ca-crt
+          mountPath: /etc/docker/certs.d/registry.spack.svc.cluster.local/ca.crt
+          subPath: ca.crt
+        - name: ca-crt
+          mountPath: /etc/docker/certs.d/k8s.internal/ca.crt
+          subPath: ca.crt
+        securityContext:
+          privileged: true
+      volumes:
+        - name: ca-crt
+          secret:
+            secretName: tls-registry
+      nodeSelector:
+        "beta.kubernetes.io/instance-type": "t2.medium"

--- a/kubernetes/spack/misc/registry/docker-shell.sh
+++ b/kubernetes/spack/misc/registry/docker-shell.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env sh
+
+exec kubectl exec -ti -n spack deployments/docker-shell -- sh -il

--- a/kubernetes/spack/misc/registry/list-registry.sh
+++ b/kubernetes/spack/misc/registry/list-registry.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env sh
+
+pretty() {
+    if [ '!' -t 1 ] ; then
+        tr -d '\r'
+        return
+    fi
+
+    tr -d '\r' | sed 's/^\([^ ]\+\):$/'$'\x1b[0;32m''\1'$'\x1b[0m'':/g'
+}
+
+subscript='echo "$( basename $( dirname $( dirname {} ) ) ):"'
+subscript="${subscript}"' ; find {} -mindepth 1 -maxdepth 1'
+subscript="${subscript}"'       -exec basename "{""}" ";" | sed "s/^/    /g"'
+subscript="${subscript}"' ; echo'
+
+exec kubectl exec -t -n spack deployments/registry -- \
+    find /var/lib/registry/docker/registry/v2/repositories \
+        -mindepth 3 \
+        -maxdepth 3 \
+        -iname 'tags' \
+        -exec sh -c "$subscript" ';' | pretty
+

--- a/kubernetes/spack/misc/registry/pvc.yaml
+++ b/kubernetes/spack/misc/registry/pvc.yaml
@@ -1,0 +1,14 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: registry-data
+  namespace: spack
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: us-east-1a

--- a/kubernetes/spack/misc/registry/services.yaml
+++ b/kubernetes/spack/misc/registry/services.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  namespace: spack
+  labels:
+    app: registry
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app: registry

--- a/kubernetes/spack/misc/registry/sync-image.sh
+++ b/kubernetes/spack/misc/registry/sync-image.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env sh
+
+img="$1"
+
+if [ -z "$img" ] ; then
+    echo "Usage:"
+    echo "  $0 <image>"
+    exit 1
+fi >&2
+
+new_tag="k8s.internal/$( echo "$img" | tr '/' '-' )"
+
+script="docker pull \"$img\""
+script="${script} && docker tag \"$img\" \"$new_tag\""
+script="${script} && docker push \"$new_tag\""
+
+exec kubectl exec -t -n spack deployments/docker-shell -- sh -c "$script"


### PR DESCRIPTION
 - Added a cluster-internal docker registry, accessible under the image tag prefix `k8s.internal/`.
 - Switched multiple pull policies from `Always` to `IfNotPresent`.
 - Switched multiple pod templates to pull from the internal registry instead of dockerhub.
 - Reduced the frequency of the spack auto-updater from once very five minutes to once every six hours.
 - Added convenience scripts for common tasks related to internal registry maintenance.