### PR TITLE
Temporarily mitigate docker apocalypse using ghcr

### DIFF
--- a/kubernetes/spack/gitlab-spack-io/runner/c5n.2xlarge/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/c5n.2xlarge/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "ghcr.io/scottwittenburg/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "ghcr.io/scottwittenburg/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/c5n.xlarge/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/c5n.xlarge/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "ghcr.io/scottwittenburg/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "ghcr.io/scottwittenburg/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/large/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/large/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "ghcr.io/scottwittenburg/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "ghcr.io/scottwittenburg/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/medium/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/medium/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "ghcr.io/scottwittenburg/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "ghcr.io/scottwittenburg/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/r5.2xlarge/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/r5.2xlarge/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "ghcr.io/scottwittenburg/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "ghcr.io/scottwittenburg/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/t2.large/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/t2.large/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "ghcr.io/scottwittenburg/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "ghcr.io/scottwittenburg/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/t3.micro/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/t3.micro/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "ghcr.io/scottwittenburg/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "ghcr.io/scottwittenburg/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/gitlab-spack-io/runner/t3.nano/deployments.yaml
+++ b/kubernetes/spack/gitlab-spack-io/runner/t3.nano/deployments.yaml
@@ -58,8 +58,11 @@ spec:
                 gitlab-runner unregister --name "$( hostname )"
 
         env:
-        - name: DOCKER_IMAGE
-          value: "ubuntu:18.04"
+        - name: KUBERNETES_IMAGE
+          value: "ghcr.io/scottwittenburg/ubuntu:18.04"
+
+        - name: KUBERNETES_HELPER_IMAGE
+          value: "ghcr.io/scottwittenburg/gitlab-gitlab-runner-helper:x86_64-ece86343"
 
         - name: CI_SERVER_URL
           value: "http://gitlab"

--- a/kubernetes/spack/kibana-spack-io/daemonset.yaml
+++ b/kubernetes/spack/kibana-spack-io/daemonset.yaml
@@ -24,7 +24,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch
+        image: ghcr.io/scottwittenburg/fluent-fluentd-kubernetes-daemonset:v1-debian-elasticsearch
         env:
           - name:  FLUENT_ELASTICSEARCH_HOST
             value: "elastic-search-es-http"

--- a/kubernetes/spack/misc/auto-updater/cron-jobs.yaml
+++ b/kubernetes/spack/misc/auto-updater/cron-jobs.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     svc: updater
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "0 */6 * * *"
   jobTemplate:
     metadata:
       labels:


### PR DESCRIPTION
Use images pushed to GitHub container registry personal account to temporarily work around recent dockerhub pull rate limits.

Supersedes #48 