### PR TITLE
Handle result pagination

### DIFF
--- a/gh-gl-sync/SpackCIBridge.py
+++ b/gh-gl-sync/SpackCIBridge.py
@@ -24,7 +24,7 @@ class SpackCIBridge(object):
         self.github_repo = ""
 
         self.py_github = Github(os.environ.get('GITHUB_TOKEN'))
-        self.py_gh_repo = self.py_github.get_repo('spack/spack')
+        self.py_gh_repo = self.py_github.get_repo('spack/spack', lazy=True)
 
     @atexit.register
     def cleanup():
@@ -243,8 +243,6 @@ class SpackCIBridge(object):
 
         post_data["target_url"] = pipeline["web_url"]
         post_data["context"] = "ci/gitlab-ci"
-
-        post_data = json.dumps(post_data).encode('utf-8')
         return post_data
 
     def dedupe_pipelines(self, api_response):

--- a/gh-gl-sync/SpackCIBridge.py
+++ b/gh-gl-sync/SpackCIBridge.py
@@ -262,7 +262,7 @@ class SpackCIBridge(object):
         return pipelines
 
     def get_pipeline_api_template(self, gitlab_host, gitlab_project):
-        dt = datetime.now(timezone.utc) + timedelta(minutes=-2)
+        dt = datetime.now(timezone.utc) + timedelta(minutes=-4)
         time_threshold = urllib.parse.quote_plus(dt.isoformat(timespec="seconds"))
         template = gitlab_host
         template += "/api/v4/projects/"

--- a/gh-gl-sync/requirements.txt
+++ b/gh-gl-sync/requirements.txt
@@ -13,6 +13,7 @@ py==1.8.2
 pycodestyle==2.6.0
 pycparser==2.20
 pyflakes==2.2.0
+PyGithub==1.54
 pyparsing==2.4.7
 pytest==5.4.3
 pytest-cov==2.10.0

--- a/gh-gl-sync/test_SpackCIBridge.py
+++ b/gh-gl-sync/test_SpackCIBridge.py
@@ -1,8 +1,43 @@
-import json
 import os
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import SpackCIBridge
+
+
+class AttrDict(dict):
+    def __init__(self, iterable, **kwargs):
+        super(AttrDict, self).__init__(iterable, **kwargs)
+        for key, value in iterable.items():
+            if isinstance(value, dict):
+                self.__dict__[key] = AttrDict(value)
+            else:
+                self.__dict__[key] = value
+
+
+def test_list_github_prs(capfd):
+    """Test the list_github_prs method."""
+    github_pr_response = [
+        AttrDict({
+            "number": 1,
+            "head": {
+                "ref": "improve_docs",
+            }
+        }),
+        AttrDict({
+            "number": 2,
+            "head": {
+                "ref": "fix_test",
+            }
+        }),
+    ]
+    gh_repo = Mock()
+    gh_repo.get_pulls.return_value = github_pr_response
+    bridge = SpackCIBridge.SpackCIBridge()
+    bridge.py_gh_repo = gh_repo
+    assert bridge.list_github_prs("open") == ["pr1_improve_docs", "pr2_fix_test"]
+    assert gh_repo.get_pulls.call_count == 1
+    out, err = capfd.readouterr()
+    assert out == "Open PRs:\n    pr1_improve_docs\n    pr2_fix_test\n"
 
 
 def test_get_synced_prs(capfd):
@@ -230,8 +265,8 @@ def test_make_status_for_pipeline():
     for test_case in test_cases:
         pipeline["status"] = test_case["input"]
         status = bridge.make_status_for_pipeline(pipeline)
-        assert json.loads(status.decode("utf-8"))["state"] == test_case["state"]
-        assert json.loads(status.decode("utf-8"))["description"] == test_case["description"]
+        assert status["state"] == test_case["state"]
+        assert status["description"] == test_case["description"]
 
 
 class FakeResponse:
@@ -253,9 +288,16 @@ def test_post_pipeline_status(capfd):
     """Test the post_pipeline_status method."""
     open_prs = ["pr1_readme"]
     template = "https://gitlab.spack.io/api/v4/projects/zack%2Fmy_test_proj/pipelines?ref={0}"
+    gh_commit = Mock()
+    gh_commit.create_status.return_value = AttrDict({"state": "error"})
+    gh_repo = Mock()
+    gh_repo.get_commit.return_value = gh_commit
+
     bridge = SpackCIBridge.SpackCIBridge()
+    bridge.py_gh_repo = gh_repo
     bridge.github_project = "zack/my_test_proj"
     os.environ["GITHUB_TOKEN"] = "my_github_token"
+
     mock_data = b'''[
         {
             "id": 1,
@@ -269,7 +311,9 @@ def test_post_pipeline_status(capfd):
     ]'''
     with patch('urllib.request.urlopen', return_value=FakeResponse(data=mock_data)) as mock_urlopen:
         bridge.post_pipeline_status(open_prs, template)
-        assert mock_urlopen.call_count == 2
+        assert mock_urlopen.call_count == 1
+        assert gh_repo.get_commit.call_count == 1
+        assert gh_commit.create_status.call_count == 1
     out, err = capfd.readouterr()
     assert out == "Posting status for pr1_readme / aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
     del os.environ["GITHUB_TOKEN"]

--- a/gh-gl-sync/test_SpackCIBridge.py
+++ b/gh-gl-sync/test_SpackCIBridge.py
@@ -5,29 +5,6 @@ from unittest.mock import patch
 import SpackCIBridge
 
 
-def test_list_github_prs(capfd):
-    """Test the list_github_prs method."""
-    bridge = SpackCIBridge.SpackCIBridge()
-    bridge.get_prs_from_github_api = lambda *args: None
-    bridge.github_pr_responses = [
-        {
-            "number": 1,
-            "head": {
-                "ref": "improve_docs",
-            }
-        },
-        {
-            "number": 2,
-            "head": {
-                "ref": "fix_test",
-            }
-        },
-    ]
-    assert bridge.list_github_prs("open") == ["pr1_improve_docs", "pr2_fix_test"]
-    out, err = capfd.readouterr()
-    assert out == "Open PRs:\n    pr1_improve_docs\n    pr2_fix_test\n"
-
-
 def test_get_synced_prs(capfd):
     """Test the get_synced_prs method."""
     bridge = SpackCIBridge.SpackCIBridge()

--- a/kubernetes/spack/internal-spack-io/gh-gl-sync/cron-jobs.yaml
+++ b/kubernetes/spack/internal-spack-io/gh-gl-sync/cron-jobs.yaml
@@ -13,7 +13,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: zackgalbreath/spack-ci-bridge:0.0.5
+            image: zackgalbreath/spack-ci-bridge:0.0.6
             imagePullPolicy: IfNotPresent
             env:
             - name: GITHUB_TOKEN


### PR DESCRIPTION
Changed all four github api requests to use PyGithub, as it provides a much simpler way to handle pagination (compared to doing it ourselves by reading the "Link" headers from the response).

It seems gitlab also paginates its api results, see [here](https://docs.gitlab.com/12.10/ee/api/README.html#pagination).  However, since we only query for pipelines associated with a single branch at a time, and since we further restrict the time range to the last few minutes, I didn't make any effort to handle pagination for the gitlab api requests.  It looks like the default is for gitlab to return 20 items per page, which seems like it might be fine for our purposes here.