### PR TITLE
Mirror <merge_commit_sha> rather than "refs/pulls/<pr_number>/head"

### DIFF
--- a/.github/workflows/spack_ci_bridge_docker.yml
+++ b/.github/workflows/spack_ci_bridge_docker.yml
@@ -28,7 +28,7 @@ jobs:
           context: ./gh-gl-sync
           file: ./gh-gl-sync/Dockerfile
           push: true
-          tags: zackgalbreath/spack-ci-bridge:0.0.7
+          tags: zackgalbreath/spack-ci-bridge:0.0.8
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/gh-gl-sync/SpackCIBridge.py
+++ b/gh-gl-sync/SpackCIBridge.py
@@ -71,16 +71,24 @@ class SpackCIBridge(object):
         """ Return a list of strings in the format: "pr<PR#>_<headref>"
         for GitHub PRs with a given state: open, closed, or all.
         """
-        pr_strings = []
+        pr_dict = {}
         pulls = self.py_gh_repo.get_pulls(state=state)
         for pull in pulls:
+            if not pull.merge_commit_sha:
+                print("PR {0} ({1}) has no 'merge_commit_sha', skipping".format(pull.number, pull.head.ref))
+                continue
             pr_string = "pr{0}_{1}".format(pull.number, pull.head.ref)
-            pr_strings.append(pr_string)
-        pr_strings = sorted(pr_strings)
+            pr_dict[pr_string] = pull.merge_commit_sha
+
+        pr_strings = sorted(pr_dict.keys())
+        merge_commit_shas = [pr_dict[s] for s in pr_strings]
         print("{0} PRs:".format(state.capitalize()))
         for pr_string in pr_strings:
             print("    {0}".format(pr_string))
-        return pr_strings
+        return {
+            "pr_strings": pr_strings,
+            "merge_commit_shas": merge_commit_shas,
+        }
 
     def list_github_protected_branches(self):
         """ Return a list of protected branch names from GitHub."""
@@ -150,15 +158,13 @@ class SpackCIBridge(object):
 
     def get_open_refspecs(self, open_prs):
         """Return lists of refspecs for fetch and push given a list of open PRs."""
-        pr_number_regexp = re.compile(r"pr([0-9]+)")
+        pr_strings = open_prs["pr_strings"]
+        merge_commit_shas = open_prs["merge_commit_shas"]
         open_refspecs = []
         fetch_refspecs = []
-        for open_pr in open_prs:
-            match = pr_number_regexp.search(open_pr)
-            if match is None:
-                continue
-            pr_num = match.group(1)
-            fetch_refspecs.append("+refs/pull/{0}/head:refs/remotes/github/{1}".format(pr_num, open_pr))
+        for open_pr, merge_commit_sha in zip(pr_strings, merge_commit_shas):
+            fetch_refspecs.append("+{0}:refs/remotes/github/{1}".format(
+                merge_commit_sha, open_pr))
             open_refspecs.append("github/{0}:github/{0}".format(open_pr))
         return open_refspecs, fetch_refspecs
 
@@ -185,7 +191,7 @@ class SpackCIBridge(object):
     def build_local_branches(self, open_prs, protected_branches):
         """Create local branches for a list of open PRs and protected branches."""
         print("Building local branches for open PRs and protected branches")
-        for branch in open_prs + protected_branches:
+        for branch in open_prs["pr_strings"] + protected_branches:
             branch_name = "github/{0}".format(branch)
             subprocess.run(["git", "branch", "-q", branch_name, branch_name], check=True)
 
@@ -342,7 +348,7 @@ class SpackCIBridge(object):
 
             # Find closed PRs that are currently synced.
             # These will be deleted from GitLab.
-            closed_refspecs = self.get_prs_to_delete(open_prs, synced_prs)
+            closed_refspecs = self.get_prs_to_delete(open_prs["pr_strings"], synced_prs)
 
             # Get refspecs for open PRs and protected branches.
             open_refspecs, fetch_refspecs = self.get_open_refspecs(open_prs)
@@ -364,7 +370,7 @@ class SpackCIBridge(object):
             # Post pipeline status to GitHub for each open PR, if enabled
             if post_status:
                 pipeline_api_template = self.get_pipeline_api_template(args.gitlab_host, args.gitlab_project)
-                self.post_pipeline_status(open_prs + protected_branches, pipeline_api_template)
+                self.post_pipeline_status(open_prs["pr_strings"] + protected_branches, pipeline_api_template)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is designed to fix the problem we discovered today where by the time the E4S pipeline runs, we might merge a much more recent `github/develop` into the PR branch than existed when the branch was committed/pushed to the spack github repo.  If we go with this, we will then drop [this part](https://gitlab.spack.io/spack/e4s/-/blob/master/.gitlab-ci.yml#L16) of our custom `before_script`.

GitHub generates a "test commit" by merging the head of the PR branch into the base (at some point).  If that commit comes back "None" in the api query for open pulls, it is likely because it cannot be merged with the base any longer, so we skip it.

Testing against a local standin for the target gitlab remote, I can look at the branches this is now pushing and see the kind of commit message GitHub is generating (which is what I expect we'll see in our spack pipelines on gitlab):

```
$ git log -n2 github/pr20463_slepc-set-arpack-dir-right
commit 82968278647d53704c2c6ce0b696a4d4ec7aaa8d (github/pr20463_slepc-set-arpack-dir-right)
Merge: 13e4d9ee3a 320b0a26cf
Author: eugeneswalker <38933153+eugeneswalker@users.noreply.github.com>
Date:   Fri Dec 18 04:48:27 2020 +0000

    Merge 320b0a26cf13d1d8988d4a642f179e7d4f1b493d into 13e4d9ee3a7eb324db6377e8f4cebb42285f7312

commit 320b0a26cf13d1d8988d4a642f179e7d4f1b493d
Author: eugeneswalker <eugenesunsetwalker@gmail.com>
Date:   Fri Dec 18 04:27:58 2020 +0000

    slepc: set --with-arpack-dir correctly
```

So the author will be correct, but we would no longer see the commit message on the latest PR commit as we do currently.