### PR TITLE
Increase minio pvc size llnl

### DIFF
--- a/k8s/gitlab/temporary/release.yaml
+++ b/k8s/gitlab/temporary/release.yaml
@@ -106,6 +106,8 @@ spec:
           secretName: tls-gitlab-minio-temp
       nodeSelector:
         spack.io/node-pool: gitlab
+      persistence:
+        size: 100Gi
 
     ## doc/charts/globals.md#configure-registry-settings
     ## NOTE(opadron): this is where the registry section is in the old version of


### PR DESCRIPTION
Looking at the StorageClass associated with the persistent volume claims in the new cluster, it seems we may have dynamic volume provisioning as described [here](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/).  So this change may be enough to cause Kubernetes to create another volume of 100GB on behalf of gitlabs minio.

Not sure how to apply this change, given that it's in a helm chart and supposed to be managed by flux.