### PR TITLE
Post status to the correct commit on github

### DIFF
--- a/.github/workflows/spack_ci_bridge_docker.yml
+++ b/.github/workflows/spack_ci_bridge_docker.yml
@@ -28,7 +28,7 @@ jobs:
           context: ./gh-gl-sync
           file: ./gh-gl-sync/Dockerfile
           push: true
-          tags: zackgalbreath/spack-ci-bridge:0.0.8
+          tags: zackgalbreath/spack-ci-bridge:0.0.9
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
When we changed the sync script to test the merge_commit_sha created
by github, we failed to recognize that the commit used for posting
status back to github was just whatever was found in the gitlab
pipeline api endpoint.  Posting status back to the merge commit does
not make any sense and does not result in the status being visible
on the PRs.

This change fetches the tested commit from each pipeline, and then
parses the PR sha out of the result, and we use that sha to post
status to github.