### PR TITLE
Make sure we continue posting status even if one fails

### DIFF
--- a/.github/workflows/spack_ci_bridge_docker.yml
+++ b/.github/workflows/spack_ci_bridge_docker.yml
@@ -28,7 +28,7 @@ jobs:
           context: ./gh-gl-sync
           file: ./gh-gl-sync/Dockerfile
           push: true
-          tags: zackgalbreath/spack-ci-bridge:0.0.9
+          tags: zackgalbreath/spack-ci-bridge:0.0.10
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Some status post started failing because we posted more than 1K status on a single commit.  I think there some old PRs not moving forward and we do not first check github to see if we have already posted status for a commit (we don't want to do that, unless we don't care about testing new `merge-commit-sha` for PRs when `develop` moves forward).

In this case, it's this [PR](https://github.com/spack/spack/pull/20802), where we detected it could not be merged (github had no `merge-commit-sha` for it), and we have now posted that fact as a status more times than github allows on a single commit.

Thankfully we do the unmergeables after the other statuses, so this didn't actually stop us from posting on active PRs.