### PR TITLE
Add slack.spack.io to spack-infrastructure

### DIFF
--- a/kubernetes/spack/slack-spack-io/web/certificates.yaml
+++ b/kubernetes/spack/slack-spack-io/web/certificates.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: tls-slack
+  namespace: spack
+spec:
+  secretName: tls-slack
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer
+  commonName: slack.spack.io
+  dnsNames:
+    - slack.spack.io

--- a/kubernetes/spack/slack-spack-io/web/deployments.yaml
+++ b/kubernetes/spack/slack-spack-io/web/deployments.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slack-spack-io
+  namespace: spack
+  labels:
+    app: slack-spack-io
+    svc: web
+spec:
+  selector:
+    matchLabels:
+      app: slack-spack-io
+      svc: web
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: slack-spack-io
+        svc: web
+    spec:
+      containers:
+      - name: web
+        image: "spack/slackin-extended:latest"
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 80
+        env:
+        - name: SLACK_SUBDOMAIN
+          value: spackpm
+        - name: SLACKIN_ANALYTICS
+          value: "UA-101208306-3"
+        - name: SLACKIN_PORT
+          value: "80"
+        - name: SLACKIN_COC
+          value: "https://github.com/spack/spack/blob/develop/.github/CODE_OF_CONDUCT.md"
+        - name: SLACK_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: spack-slackin-credentials
+              key: slack_api_token
+        - name: RECAPTCHA_SITEKEY
+          valueFrom:
+            secretKeyRef:
+              name: spack-slackin-credentials
+              key: google_captcha_sitekey
+        - name: RECAPTCHA_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: spack-slackin-credentials
+              key: google_captcha_secret
+      nodeSelector:
+        spack.io/node-pool: base

--- a/kubernetes/spack/slack-spack-io/web/ingress.yaml
+++ b/kubernetes/spack/slack-spack-io/web/ingress.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: slack-spack-io
+  namespace: spack
+spec:
+  tls:
+  - secretName: tls-slack
+  rules:
+  - host: slack.spack.io
+    http:
+      paths:
+      - backend:
+          serviceName: slack-spack-io
+          servicePort: 80

--- a/kubernetes/spack/slack-spack-io/web/services.yaml
+++ b/kubernetes/spack/slack-spack-io/web/services.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: slack-spack-io
+  namespace: spack
+  labels:
+    app: slack-spack-io
+    svc: web
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app: slack-spack-io
+    svc: web


### PR DESCRIPTION
This is a draft deployment attempting to move the [slackin](https://github.com/emedvedev/slackin-extended) app hosted at https://spackpm.herokuapp.com to https://slack.spack.io.