### PR TITLE
Add HelmRelease for one new pool of graviton runners (c6g.4xlarge)

### DIFF
--- a/k8s/runners/large-pub/release.yaml
+++ b/k8s/runners/large-pub/release.yaml
@@ -92,6 +92,7 @@ spec:
 
       nodeSelector:
         spack.io/node-pool: glr-large-pub  # pool for jobs
+        kubernetes.io/arch: amd64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/medium-pub/release.yaml
+++ b/k8s/runners/medium-pub/release.yaml
@@ -91,6 +91,7 @@ spec:
 
       nodeSelector:
         spack.io/node-pool: glr-medium-pub  # pool for jobs
+        kubernetes.io/arch: amd64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/small-pub/release.yaml
+++ b/k8s/runners/small-pub/release.yaml
@@ -92,6 +92,7 @@ spec:
 
       nodeSelector:
         spack.io/node-pool: glr-small-pub  # pool for jobs
+        kubernetes.io/arch: amd64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/xlarge-arm-pub/release.yaml
+++ b/k8s/runners/xlarge-arm-pub/release.yaml
@@ -2,10 +2,10 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: runner-huge-pub
+  name: runner-xlarge-arm-pub
   namespace: gitlab
 spec:
-  releaseName: huge-pub
+  releaseName: xlarge-arm-pub
   chart:
     name: gitlab-runner
     repository: https://charts.gitlab.io
@@ -20,7 +20,7 @@ spec:
     concurrent: 20
     checkInterval: 30
     # preEntrypointScript: |
-    #   echo "Hello, from huge-pub runner"
+    #   echo "Hello, from xlarge-pub runner"
 
     metrics:
       enabled: true
@@ -40,7 +40,7 @@ spec:
       requestConcurrency: 20
       locked: false
 
-      tags: "x86_64,avx,avx2,avx512,huge,public,spack"
+      tags: "arm,aarch64,graviton,graviton2,xlarge,public,spack"
       runUntagged: false
       privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
@@ -76,7 +76,7 @@ spec:
         # secretName: google-application-credentials
 
       builds:
-        cpuRequests: 2500m
+        cpuRequests: 9000m
 
       services: {}
       # cpuRequests: 50m
@@ -84,15 +84,21 @@ spec:
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
 
-      helpers: {}
+      helpers:
+        # Without specifying image here, we got the following error when the
+        # job was run:
+        #
+        # ERROR: Job failed (system failure): prepare environment: unable to upgrade connection: container not found ("helper").
+        #
+        image: gitlab/gitlab-runner-helper:arm-latest
       # cpuRequests: 50m
       # cpuLimit: 50m
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
 
       nodeSelector:
-        spack.io/node-pool: glr-huge-pub  # pool for jobs
-        kubernetes.io/arch: amd64
+        spack.io/node-pool: glr-xlarge-pub  # pool for jobs
+        kubernetes.io/arch: arm64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/xlarge-pub/release.yaml
+++ b/k8s/runners/xlarge-pub/release.yaml
@@ -92,6 +92,7 @@ spec:
 
       nodeSelector:
         spack.io/node-pool: glr-xlarge-pub  # pool for jobs
+        kubernetes.io/arch: amd64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/scripts/eks-node-group.yaml
+++ b/scripts/eks-node-group.yaml
@@ -164,6 +164,10 @@ Resources:
             VolumeType: gp2
             DeleteOnTermination: true
       UserData:
+        # Custom code to convert cloudformation stack tags to kubernetes node
+        # labels.  Since it's python, it should run on most architectures w/out
+        # problems.  This runs on the instance as a systemd unit when the instance
+        # starts up.
         Fn::Base64:
           !Sub |
             #!/bin/bash


### PR DESCRIPTION
In addition to the CloudFormation stack we created earlier today, this should give us one of the pools of graviton2 runners we need.  I `kubectl apply -f`'d  the release file so I could test it out, seems to be working.  See the pipeline here: 

https://gitlab.spack.io/scott/test-downstream/-/pipelines/43281

That's a private repo, but I added the reviewers as members, except Omar who doesn't seem to have an account on that instance.