### PR TITLE
Fix yaml size limits issue

### DIFF
--- a/k8s/gitlab/release.yaml
+++ b/k8s/gitlab/release.yaml
@@ -117,6 +117,10 @@ spec:
           tls:
             enabled: true
             secretName: tls-gitlab-webservice
+        image:
+          pullPolicy: IfNotPresent
+          repository: ghcr.io/scottwittenburg/gitlab-org-build-cng-gitlab-webservice-ee
+          tag: v13.8.8
         minReplicas: 2
         maxReplicas: 4
         nodeSelector:
@@ -133,10 +137,18 @@ spec:
           spack.io/node-pool: gitlab
 
       sidekiq:
+        image:
+          pullPolicy: IfNotPresent
+          repository: ghcr.io/scottwittenburg/gitlab-org-build-cng-gitlab-sidekiq-ee
+          tag: v13.8.8
         nodeSelector:
           spack.io/node-pool: gitlab
 
       task-runner:
+        image:
+          pullPolicy: IfNotPresent
+          repository: ghcr.io/scottwittenburg/gitlab-org-build-cng-gitlab-task-runner-ee
+          tag: v13.8.8
         nodeSelector:
           spack.io/node-pool: gitlab
 

--- a/k8s/gitlab/sidekiq.dockerfile
+++ b/k8s/gitlab/sidekiq.dockerfile
@@ -1,0 +1,7 @@
+FROM registry.gitlab.com/gitlab-org/build/cng/gitlab-sidekiq-ee:v13.8.8
+
+RUN ss='s/return false unless Feature.enabled?(:ci_yaml_limit_size.*' \
+  ; ss="$ss/return false/g" \
+ && sed -i \
+        -e 's/MAX_YAML_SIZE = 1\.megabyte\+/MAX_YAML_SIZE = 1024\.megabyte/g' \
+        -e "$ss" /srv/gitlab/lib/gitlab/config/loader/yaml.rb

--- a/k8s/gitlab/task-runner.dockerfile
+++ b/k8s/gitlab/task-runner.dockerfile
@@ -1,0 +1,7 @@
+FROM registry.gitlab.com/gitlab-org/build/cng/gitlab-task-runner-ee:v13.8.8
+
+RUN ss='s/return false unless Feature.enabled?(:ci_yaml_limit_size.*' \
+  ; ss="$ss/return false/g" \
+ && sed -i \
+        -e 's/MAX_YAML_SIZE = 1\.megabyte\+/MAX_YAML_SIZE = 1024\.megabyte/g' \
+        -e "$ss" /srv/gitlab/lib/gitlab/config/loader/yaml.rb

--- a/k8s/gitlab/webservice.dockerfile
+++ b/k8s/gitlab/webservice.dockerfile
@@ -1,0 +1,19 @@
+FROM registry.gitlab.com/gitlab-org/build/cng/gitlab-webservice-ee:v13.8.8
+
+# TODO(opadron): At some point, we might want to reinvestigate gitlab code
+# changes as a means of working around certain limits.  If/when we do, here are
+# some spots that we had identified as potential targets for modifications:
+#
+# /srv/gitlab/lib/gitlab/ci:
+#
+#   config/entry/needs.rb:
+#     NEEDS_CROSS_PIPELINE_DEPENDENCIES_LIMIT = 5
+#
+#   config/entry/product/parallel.rb:
+#     PARALLEL_LIMIT = 50
+
+RUN ss='s/return false unless Feature.enabled?(:ci_yaml_limit_size.*' \
+  ; ss="$ss/return false/g" \
+ && sed -i \
+        -e 's/MAX_YAML_SIZE = 1\.megabyte\+/MAX_YAML_SIZE = 1024\.megabyte/g' \
+        -e "$ss" /srv/gitlab/lib/gitlab/config/loader/yaml.rb


### PR DESCRIPTION
Even though it appears we should no longer need this, we are hitting
yaml size limits when pipeline generation creates a yaml file of
around 400 KB on disk.  This change replaces the patching of docker
images we previously used to get around the yaml size limitations,
while keeping us on the latest patch release of gitlab.