### PR TITLE
Reduce number of redundant spec builds after a PR is merged

### DIFF
--- a/.github/workflows/spack_ci_bridge_docker.yml
+++ b/.github/workflows/spack_ci_bridge_docker.yml
@@ -28,7 +28,7 @@ jobs:
           context: ./gh-gl-sync
           file: ./gh-gl-sync/Dockerfile
           push: true
-          tags: zackgalbreath/spack-ci-bridge:0.0.11
+          tags: zackgalbreath/spack-ci-bridge:0.0.12
       -
         name: Image digest
         run: echo ${{ steps.docker_build_sync.outputs.digest }}

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -14,7 +14,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: zackgalbreath/spack-ci-bridge:0.0.11
+            image: zackgalbreath/spack-ci-bridge:0.0.12
             imagePullPolicy: IfNotPresent
             env:
             - name: GITHUB_TOKEN
@@ -35,5 +35,7 @@ spec:
               - "spack/spack"
               - "--pr-mirror-bucket"
               - "spack-binaries-prs"
+              - "--main-branch"
+              - "develop"
           nodeSelector:
             spack.io/node-pool: base


### PR DESCRIPTION
The goal of this PR is to reduce a lot of wasted compute time by
avoiding pushing branches where the base sha is the currently running
develop pipeline sha.  Once the develop pipeline has completed, those
branches will be pushed the next time the sync script runs.