### PR TITLE
Increase client_max_body_size for nginx-ingress

### DIFF
--- a/k8s/ingress-nginx/release.yaml
+++ b/k8s/ingress-nginx/release.yaml
@@ -42,6 +42,7 @@ spec:
 
         annotations:
           "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true"
+          "nginx.ingress.kubernetes.io/proxy-body-size": "10m"
 
         labels: {}
 


### PR DESCRIPTION
This should resolve the HTTP 413 errors we've seen when attempting to upload
large XML files to cdash.spack.io

https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-body-size