### PR TITLE
Bump storage for GitLab MinIO

### DIFF
--- a/k8s/gitlab/release.yaml
+++ b/k8s/gitlab/release.yaml
@@ -95,7 +95,7 @@ spec:
       nodeSelector:
         spack.io/node-pool: gitlab
       persistence:
-        size: 100Gi
+        size: 250Gi
 
     registry:
       ingress:


### PR DESCRIPTION
It's my hunch that this is the cause of the recent errors we've been
seeing in GitLab CI pipelines:

```
WARNING: Uploading artifacts as "archive" to coordinator...
failed  id=451296 responseStatus=500 Internal Server Error status=500
```

After shelling into our minio pod and running `df` I saw the following
suspicious output:

```
/dev/nvme1n1             98.3G     97.2G      1.0G  99% /export
```