### PR TITLE
Bump 'brief threshold' from 4 to 15 minutes

### DIFF
--- a/.github/workflows/spack_ci_bridge_docker.yml
+++ b/.github/workflows/spack_ci_bridge_docker.yml
@@ -28,7 +28,7 @@ jobs:
           context: ./gh-gl-sync
           file: ./gh-gl-sync/Dockerfile
           push: true
-          tags: zackgalbreath/spack-ci-bridge:0.0.17
+          tags: zackgalbreath/spack-ci-bridge:0.0.18
       -
         name: Image digest
         run: echo ${{ steps.docker_build_sync.outputs.digest }}

--- a/gh-gl-sync/SpackCIBridge.py
+++ b/gh-gl-sync/SpackCIBridge.py
@@ -37,7 +37,7 @@ class SpackCIBridge(object):
         self.main_branch = main_branch
         self.currently_running_sha = None
 
-        dt = datetime.now(timezone.utc) + timedelta(minutes=-4)
+        dt = datetime.now(timezone.utc) + timedelta(minutes=-15)
         self.time_threshold_brief = urllib.parse.quote_plus(dt.isoformat(timespec="seconds"))
 
         # We use a longer time threshold to find the currently running main branch pipeline.
@@ -237,12 +237,12 @@ class SpackCIBridge(object):
                 merge_commit_sha, open_pr))
             if not self.currently_running_sha or self.currently_running_sha != base_sha:
                 open_refspecs.append("github/{0}:github/{0}".format(open_pr))
-                print("  pushing {0} -> {1}".format(open_pr, base_sha))
+                print("  pushing {0} (based on {1})".format(open_pr, base_sha))
             else:
                 # By omitting these branches from "open_refspecs", we will defer pushing
                 # them to gitlab for a time when there is not a main branch pipeline running
                 # on one of their parent commits.
-                print("  defer pushing {0} -> {1}".format(open_pr, base_sha))
+                print("  defer pushing {0} (based on {1})".format(open_pr, base_sha))
         return open_refspecs, fetch_refspecs
 
     def update_refspecs_for_protected_branches(self, protected_branches, open_refspecs, fetch_refspecs):

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -14,7 +14,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: zackgalbreath/spack-ci-bridge:0.0.17
+            image: zackgalbreath/spack-ci-bridge:0.0.18
             imagePullPolicy: IfNotPresent
             env:
             - name: GITHUB_TOKEN


### PR DESCRIPTION
We noticed some pipelines slipping through the cracks & not
getting their statuses posted back to GitHub.

Also improve log messages related to a branch's base commit.