### PR TITLE
Adding first shot at drift server

### DIFF
--- a/k8s/spack/drift-server/certificates.yaml
+++ b/k8s/spack/drift-server/certificates.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: tls-drift-server
+  namespace: spack
+spec:
+  secretName: tls-drift-server
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer
+  commonName: drift-server.spack.io
+  dnsNames:
+    - drift-server.spack.io

--- a/k8s/spack/drift-server/deployments.yaml
+++ b/k8s/spack/drift-server/deployments.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: drift-server-spack-io
+  namespace: spack
+  labels:
+    app: drift-server-spack-io
+    svc: web
+spec:
+  selector:
+    matchLabels:
+      app: drift-server-spack-io
+      svc: web
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: drift-server-spack-io
+        svc: web
+    spec:
+      containers:
+      - name: web
+        image: "ghcr.io/autamus/drif-server:latest"
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 8080
+        env:
+        - name: DRIFTSERVER_PORT
+          value: "8080"
+        - name: DRIFTSERVER_DATABASE_TYPE
+          value: "mysql"
+        - name: DRIFTSERVER_DATABASE_DSN
+          valueFrom:
+            secretKeyRef:
+              name: drift-server-secrets
+              key: driftserver_database_dsn
+        - name: DRIFTSERVER_USER
+          valueFrom:
+            secretKeyRef:
+              name: drift-server-secrets
+              key: driftserver_user
+        - name: DRIFTSERVER_PASS
+          valueFrom:
+            secretKeyRef:
+              name: drift-server-secrets
+              key: driftserver_pass
+      nodeSelector:
+        spack.io/node-pool: base

--- a/k8s/spack/drift-server/ingress.yaml
+++ b/k8s/spack/drift-server/ingress.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: drift-server-spack-io
+  namespace: spack
+spec:
+  tls:
+  - secretName: tls-drift-server
+  rules:
+  - host: drift-server.spack.io
+    http:
+      paths:
+      - backend:
+          serviceName: drift-server-spack-io
+          servicePort: 80

--- a/k8s/spack/drift-server/secrets.yaml
+++ b/k8s/spack/drift-server/secrets.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: drift-server-secrets
+  namespace: spack
+  annotations:
+      fluxcd.io/ignore: "true"
+data:
+  drift_server_dsn: ZmFrZS1zZWNyZXQK  # fake-secret
+  drift_server_user: ZmFrZS1zZWNyZXQK  # fake-secret
+  drift_server_pass: ZmFrZS1zZWNyZXQK  # fake-secret

--- a/k8s/spack/drift-server/services.yaml
+++ b/k8s/spack/drift-server/services.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: drift-server-spack-io
+  namespace: spack
+  labels:
+    app: drift-server-spack-io
+    svc: web
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app: drift-server-spack-io
+    svc: web


### PR DESCRIPTION
@alecbcs is working on a drift analysis for spack (or BUILD SI) and part of that requires deploying this drift server:

https://github.com/buildsi/drift-server

We have a PR underway that is going to do an automated build for the container base:

https://github.com/buildsi/drift-server/pull/7

and our plan is to create an AWS database to connect to (via the `DRIFTSERVER_DATABASE_DSN` that is a secret). We will also define some username and password (also secrets) that have permission to write to it.

In terms of the kubernetes yaml recipes, I took my best effort first shot here! The container basically runs the app when you run it on port 8080, so it shouldn't need to look very different than the other spack webby things. I'm thinking before this gets added here so it's automated, we probably want to get the container deployed, create the database, and then test our deploying the files from our local machines. If that works, then would adding the recipes here automate it (but we would still need to deploy our secrets from our local machines?)
 
@opadron if you have maybe 30 minutes next week (and think it would be fun) I think this could be a fun way for @alecbcs and I to  meet up with you and walk through the steps of interacting with kubernetes to test this out. Hey, maybe we might even be useful someday! :laughing: 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>