### PR TITLE
spackbot: Add GITLAB_TOKEN to spackbot in production

### DIFF
--- a/k8s/spack/spackbot-spack-io/deployments.yaml
+++ b/k8s/spack/spackbot-spack-io/deployments.yaml
@@ -33,6 +33,11 @@ spec:
           value: "123749"
         - name: GITHUB_APP_REQUESTER
           value: "spackbot"
+        - name: GITLAB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: spack-bot-credentials
+              key: gitlab_token
         - name: GITHUB_PRIVATE_KEY
           valueFrom:
             secretKeyRef:

--- a/k8s/spack/spackbot-spack-io/secrets-dummy.yaml
+++ b/k8s/spack/spackbot-spack-io/secrets-dummy.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: spack-bot-credentials
+  namespace: spack
+  annotations:
+    fluxcd.io/ignore: "true"
+  labels:
+    app: spackbot-spack-io
+    svc: web
+data:
+  gitlab_token: |
+    # result of:
+    echo -n ${gitlab_token} | base64
+  github_webhook_secret: |
+    # result of:
+    echo -n ${gitlab_webhook_secret} | base64
+  github_private_key: |
+    # result of doing this to github private key download:
+    cat ~/Downloads/spack-bot.2021-07-14.private-key.pem  | perl -pe 's/\n/\\n/;' | perl -pe 's/\\n$/\n/;' | base64
+    # note that you can leave the newlines in the base64 encoded output -- k8s understands them.


### PR DESCRIPTION
This is the prod deploy of #111.