### PR TITLE
Increase brief threshold again

### DIFF
--- a/.github/workflows/spack_ci_bridge_docker.yml
+++ b/.github/workflows/spack_ci_bridge_docker.yml
@@ -28,7 +28,7 @@ jobs:
           context: ./gh-gl-sync
           file: ./gh-gl-sync/Dockerfile
           push: true
-          tags: zackgalbreath/spack-ci-bridge:0.0.19
+          tags: zackgalbreath/spack-ci-bridge:0.0.20
       -
         name: Image digest
         run: echo ${{ steps.docker_build_sync.outputs.digest }}

--- a/gh-gl-sync/SpackCIBridge.py
+++ b/gh-gl-sync/SpackCIBridge.py
@@ -37,7 +37,7 @@ class SpackCIBridge(object):
         self.main_branch = main_branch
         self.currently_running_sha = None
 
-        dt = datetime.now(timezone.utc) + timedelta(minutes=-30)
+        dt = datetime.now(timezone.utc) + timedelta(minutes=-60)
         self.time_threshold_brief = urllib.parse.quote_plus(dt.isoformat(timespec="seconds"))
 
         # We use a longer time threshold to find the currently running main branch pipeline.

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -14,7 +14,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: zackgalbreath/spack-ci-bridge:0.0.19
+            image: zackgalbreath/spack-ci-bridge:0.0.20
             imagePullPolicy: IfNotPresent
             env:
             - name: GITHUB_TOKEN


### PR DESCRIPTION
It's still a mystery why this is happening, but we continue to see the
occasional GitHub PR not get its status updated after the corresponding
GitLab CI pipeline has finished running.