### PR TITLE
Only backlog PRs we would otherwise have pushed

### DIFF
--- a/.github/workflows/spack_ci_bridge_docker.yml
+++ b/.github/workflows/spack_ci_bridge_docker.yml
@@ -28,7 +28,7 @@ jobs:
           context: ./gh-gl-sync
           file: ./gh-gl-sync/Dockerfile
           push: true
-          tags: zackgalbreath/spack-ci-bridge:0.0.20
+          tags: zackgalbreath/spack-ci-bridge:0.0.21
       -
         name: Image digest
         run: echo ${{ steps.docker_build_sync.outputs.digest }}

--- a/gh-gl-sync/test_SpackCIBridge.py
+++ b/gh-gl-sync/test_SpackCIBridge.py
@@ -139,7 +139,8 @@ def test_get_open_refspecs():
         "pr_strings": ["pr1_this", "pr2_that"],
         "merge_commit_shas": ["aaaaaaaa", "bbbbbbbb"],
         "base_shas": ["shafoo", "shabar"],
-        "head_shas": ["shabaz", "shagah"]
+        "head_shas": ["shabaz", "shagah"],
+        "backlogged": [False, False]
     }
     bridge = SpackCIBridge.SpackCIBridge()
     open_refspecs, fetch_refspecs = bridge.get_open_refspecs(open_prs)
@@ -363,7 +364,8 @@ def test_post_pipeline_status(capfd):
         "pr_strings": ["pr1_readme"],
         "merge_commit_shas": ["aaaaaaaa"],
         "base_shas": ["shafoo"],
-        "head_shas": ["shabaz"]
+        "head_shas": ["shabaz"],
+        "backlogged": [False]
     }
 
     gh_commit = Mock()

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -14,7 +14,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: zackgalbreath/spack-ci-bridge:0.0.20
+            image: zackgalbreath/spack-ci-bridge:0.0.21
             imagePullPolicy: IfNotPresent
             env:
             - name: GITHUB_TOKEN


### PR DESCRIPTION
Instead of marking a PR backlogged anytime the github merge  commit includes a running develop, only backlog PRs if we would otherwise have needed to push its branch too.