### PR TITLE
Gitops migration

### DIFF
--- a/k8s-bootstrap/flux-chart.yaml
+++ b/k8s-bootstrap/flux-chart.yaml
@@ -22,8 +22,8 @@ nodeSelector:
 
 git:
   url: "ssh://git@github.com/spack/spack-infrastructure"
-  branch: "production"
-  path: "k8s"
+  branch: "flux"
+  path: "flux"
   user: "Spack Bot"
   email: "maintainers@spack.io"
   verifySignatures: false

--- a/k8s/gitops/deployments.yaml
+++ b/k8s/gitops/deployments.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitops-controller
+  namespace: gitops
+  labels:
+    app: gitops-controller
+    svc: controller
+spec:
+  selector:
+    matchLabels:
+      app: gitops-controller
+      svc: controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: gitops-controller
+        svc: controller
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: controller
+          image: ghcr.io/opadron/gitops:latest
+          imagePullPolicy: Always
+          args:
+            - --repo
+            - ssh://git@github.com/spack/spack-infrastructure
+            - --staging-branch
+            - main
+            - --production-branch
+            - production
+            - --source-dir
+            - k8s
+            - --target-branch
+            - flux
+            - --target-dir
+            - flux
+            - --interval
+            - "10"
+            - --deploy-key
+            - /key
+            - --user-email
+            - maintainers@spack.io
+            - --user-name
+            - Spack Bot
+            - --storage-dir
+            - /storage
+          volumeMounts:
+            - name: storage
+              mountPath: /storage
+            - name: key
+              subPath: key
+              mountPath: /key
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: gitops
+        - name: key
+          secret:
+            secretName: gitops-secrets
+            defaultMode: 0600

--- a/k8s/gitops/namespace.yaml
+++ b/k8s/gitops/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitops

--- a/k8s/gitops/pvc.yaml
+++ b/k8s/gitops/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gitops
+  namespace: gitops
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/gitops/secrets.yaml
+++ b/k8s/gitops/secrets.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitops-secrets
+  namespace: gitops
+  annotations:
+    fluxcd.io/ignore: "true"
+data:
+  key: ZmFrZS1zZWNyZXQK  # fake-secret


### PR DESCRIPTION
Adds my custom gitops controller.

Container image taken from my Github registry.  See https://github.com/opadron/images/tree/main/gitops for code and details.

TODO:

- [ ] Review/Merge this PR
- [ ] Update `production` branch
- [ ] Apply changes in `flux-chart.yaml`
  - This should get flux to switch from observing the `production` branch to the `flux` branch
- [ ] Follow up with a Gitlab staging environment