### PR TITLE
Attempt to add spack monitor with new setup

### DIFF
--- a/k8s/spack/builds-spack-io/certificates.yaml
+++ b/k8s/spack/builds-spack-io/certificates.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: tls-spackbuilds
+  namespace: spack
+spec:
+  secretName: tls-spackbuilds
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer
+  commonName: builds.spack.io
+  dnsNames:
+    - builds.spack.io

--- a/k8s/spack/builds-spack-io/deployments.yaml
+++ b/k8s/spack/builds-spack-io/deployments.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: builds-spack-io
+  namespace: spack
+  labels:
+    app: builds-spack-io
+    svc: web
+spec:
+  selector:
+    matchLabels:
+      app: builds-spack-io
+      svc: web
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: builds-spack-io
+        svc: web
+    spec:
+      containers:
+
+      - name: web
+
+        # https://github.com/spack/spack-monitor/pkgs/container/spack-monitor
+        image: "ghcr.io/spack/spack-monitor:e13ad73b"
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 3031
+        env:
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: SPACKMON_ENABLE_GITHUB_AUTH
+          value: "true"
+        - name: SPACKMON_DOMAIN_NAME
+          value: https://builds.spack.io
+        - name: SPACKMON_PORT
+          value: null
+
+        # Database
+        - name: DATABASE_ENGINE
+          value: django.db.backends.postgresql_psycopg2
+
+        - name: DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: spack-build-credentials
+              key: database_password
+        - name: DATABASE_NAME
+          valueFrom:
+            secretKeyRef:
+              name: spack-build-credentials
+              key: database_name
+        - name: DATABASE_USER
+          valueFrom:
+            secretKeyRef:
+              name: spack-build-credentials
+              key: database_user
+        - name: DATABASE_HOST
+          valueFrom:
+            secretKeyRef:
+              name: spack-build-credentials
+              key: database_host
+
+        # GitHub Social Auth
+        - name: SOCIAL_AUTH_GITHUB_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: spack-build-credentials
+              key: social_auth_github_secret
+        - name: SOCIAL_AUTH_GITHUB_KEY
+          valueFrom:
+            secretKeyRef:
+              name: spack-build-credentials
+              key: social_auth_github_key
+      nodeSelector:
+        spack.io/node-pool: base

--- a/k8s/spack/builds-spack-io/ingress.yaml
+++ b/k8s/spack/builds-spack-io/ingress.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: builds-spack-io
+  namespace: spack
+spec:
+  tls:
+  - secretName: tls-spackbuilds
+  rules:
+  - host: builds.spack.io
+    http:
+      paths:
+      - backend:
+          serviceName: builds-spack-io
+          servicePort: 80

--- a/k8s/spack/builds-spack-io/secrets-dummy.yaml
+++ b/k8s/spack/builds-spack-io/secrets-dummy.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: spack-build-credentials
+  namespace: spack
+  annotations:
+    fluxcd.io/ignore: "true"
+  labels:
+    app: builds-spack-io
+    svc: web
+data:
+  social_auth_github_key: |
+    # result of:
+    echo -n ${social_auth_github_key} | base64
+  social_auth_github_secret: |
+    # result of:
+    echo -n ${social_auth_github_secret} | base64
+  database_host: |
+    # result of:
+    echo -n database_host | base64    
+  database_name: |
+    # result of:
+    echo -n database_name | base64    
+  database_password: |
+    # result of:
+    echo -n database_password | base64    
+  database_user: |
+    # result of:
+    echo -n database_user | base64

--- a/k8s/spack/builds-spack-io/services.yaml
+++ b/k8s/spack/builds-spack-io/services.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: builds-spack-io
+  namespace: spack
+  labels:
+    app: builds-spack-io
+    svc: web
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 3031
+    targetPort: 80
+  selector:
+    app: builds-spack-io
+    svc: web


### PR DESCRIPTION
We want to give another shot at deploying spack monitor (a Django application) on K8s!

This is the service at monitor.spack.io, but I am calling it builds.spack.io since that name is taken (and for the time being we need both to coexist). This one is different / updated because it has user authentication (OAuth2 via GitHub) to get a token.

I think probably a good approach would be to review here, and then when something looks relatively okay allow me to test? @opadron let me know what works for you, and c.c @tgamblin.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>