### PR TITLE
add efs csi driver

### DIFF
--- a/k8s/efs-csi-driver/release.yaml
+++ b/k8s/efs-csi-driver/release.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: aws-efs-csi-driver
+  namespace: kube-system
+spec:
+  releaseName: aws-efs-csi-driver
+  chart:
+    name: aws-efs-csi-driver
+    repository: https://kubernetes-sigs.github.io/aws-efs-csi-driver
+    version: 2.2.0  # aws-efs-csi-driver@1.3.4
+  values:
+    image:
+      repository: 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/aws-efs-csi-driver
+    controller:
+      nodeSelector:
+        spack.io/node-pool: base
+      serviceAccount:
+        create: false
+        name: efs-csi-controller-sa


### PR DESCRIPTION
Allows us to provision storage that is shared across multiple pods.  The storage is provisioned using Amazon EFS.

cc @vsoch 