### PR TITLE
Gitlab canary

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -201,7 +201,7 @@ jobs:
           context: ./images/gitops
           file: ./images/gitops/Dockerfile
           push: true
-          tags: ghcr.io/spack/gitops:0.0.1
+          tags: ghcr.io/spack/gitops:0.0.2
       -
         name: Image digest
         run: echo ${{ steps.docker_build_gitops.outputs.digest }}

--- a/images/gitops/entrypoint.py
+++ b/images/gitops/entrypoint.py
@@ -118,6 +118,14 @@ def warn(*args):
     sys.stdout.write('\x1b[0m\n')
 
 
+RE_TILDE = re.compile('~0')
+RE_SLASH = re.compile('~1')
+
+
+def process_path_token(tok):
+    return RE_TILDE.sub('~', RE_SLASH.sub('/', tok))
+
+
 def apply_patch(obj, patch):
     for p in patch:
         op = p.get('op', None)
@@ -133,7 +141,8 @@ def apply_patch(obj, patch):
             if path == '/':
                 key = ''
             else:
-                tokens = path.split('/')[1:]
+                tokens = [process_path_token(tok)
+                          for tok in path.split('/')[1:]]
                 tokens, key = tokens[:-1], tokens[-1]
                 for t in tokens:
                     if isinstance(ptr, list):

--- a/k8s/gitlab/staging/certificates.yaml
+++ b/k8s/gitlab/staging/certificates.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gitlab-staging-webservice-patch
+  annotations:
+    cd.spack.io/staged-resource: "1"
+data:
+  apiVersion: cert-manager.io/v1
+  kind: Certificate
+  name: gitlab-webservice
+  patch: |
+    - op: replace
+      path: /metadata/name
+      value: gitlab-{ENV}-webservice
+    - op: replace
+      path: /spec/secretName
+      value: tls-gitlab-{ENV}-webservice
+    - op: replace
+      path: /spec/dnsNames/0
+      value: gitlab.{ENV}.spack.io
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gitlab-staging-registry-patch
+  annotations:
+    cd.spack.io/staged-resource: "1"
+data:
+  apiVersion: cert-manager.io/v1
+  kind: Certificate
+  name: gitlab-registry
+  patch: |
+    - op: replace
+      path: /metadata/name
+      value: gitlab-{ENV}-registry
+    - op: replace
+      path: /spec/secretName
+      value: tls-gitlab-{ENV}-registry
+    - op: replace
+      path: /spec/dnsNames/0
+      value: registry.gitlab.{ENV}.spack.io
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gitlab-staging-minio-patch
+  annotations:
+    cd.spack.io/staged-resource: "1"
+data:
+  apiVersion: cert-manager.io/v1
+  kind: Certificate
+  name: gitlab-minio
+  patch: |
+    - op: replace
+      path: /metadata/name
+      value: gitlab-{ENV}-minio
+    - op: replace
+      path: /spec/secretName
+      value: tls-gitlab-{ENV}-minio
+    - op: replace
+      path: /spec/dnsNames/0
+      value: minio.gitlab.{ENV}.spack.io

--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -66,16 +66,13 @@ data:
     - op: replace
       path: /spec/values/gitlab/webservice/ingress/tls/secretName
       value: tls-gitlab-{ENV}-webservice
-
-      # - op: replace
-      #   path: /spec/values/gitlab/webservice/image/tag
-      #   value: v14.4.1
-
+    - op: replace
+      path: /spec/values/gitlab/webservice/image/tag
+      value: v14.4.1
     - op: remove
       path: /spec/values/gitlab/webservice/image/tag
     - op: remove
       path: /spec/values/gitlab/webservice/image/repository
-
     - op: replace
       path: /spec/values/gitlab/webservice/minReplicas
       value: 1
@@ -84,25 +81,20 @@ data:
       value: 3
     - op: remove
       path: /spec/values/gitlab/gitlab-shell/service
-
-      # - op: replace
-      #   path: /spec/values/gitlab/sidekiq/image/tag
-      #   value: v14.4.1
-
+    - op: replace
+      path: /spec/values/gitlab/sidekiq/image/tag
+      value: v14.4.1
     - op: remove
       path: /spec/values/gitlab/sidekiq/image/tag
     - op: remove
       path: /spec/values/gitlab/sidekiq/image/repository
-
-      # - op: replace
-      #   path: /spec/values/gitlab/task-runner/image/tag
-      #   value: v14.4.1
-
+    - op: replace
+      path: /spec/values/gitlab/task-runner/image/tag
+      value: v14.4.1
     - op: remove
       path: /spec/values/gitlab/task-runner/image/tag
     - op: remove
       path: /spec/values/gitlab/task-runner/image/repository
-
     - op: replace
       path: /spec/values/gitlab/task-runner/replicas
       value: 3

--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gitlab-staging-patch
+  annotations:
+    cd.spack.io/staged-resource: "1"
+data:
+  apiVersion: helm.fluxcd.io/v1
+  kind: HelmRelease
+  name: gitlab
+  patch: |
+    - op: replace
+      path: /metadata/name
+      value: gitlab-{ENV}
+    - op: replace
+      path: /spec/releaseName
+      value: gitlab-{ENV}
+    - op: replace
+      path: /spec/chart/version
+      value: 5.4.1  # gitlab@14.4.1
+    - op: replace
+      path: /spec/values/global/hosts/domain
+      value: "{ENV}.spack.io"
+    - op: replace
+      path: /spec/values/global/hosts/gitlab/name
+      value: gitlab.{ENV}.spack.io
+    - op: replace
+      path: /spec/values/global/hosts/minio/name
+      value: minio.gitlab.{ENV}.spack.io
+    - op: replace
+      path: /spec/values/global/hosts/registry/name
+      value: registry.gitlab.{ENV}.spack.io
+    - op: remove
+      path: /spec/values/global/hosts/ssh
+    - op: replace
+      path: /spec/values/global/email/from
+      value: admin@gitlab.{ENV}.spack.io
+    - op: replace
+      path: /spec/values/global/email/reply_to
+      value: noreply@gitlab.{ENV}.spack.io
+    - op: remove
+      path: /spec/values/global/psql
+    - op: remove
+      path: /spec/values/global/redis
+    - op: remove
+      path: /spec/values/global/minio
+    - op: remove
+      path: /spec/values/global/grafana
+    - op: remove
+      path: /spec/values/global/appConfig
+    - op: replace
+      path: /spec/values/minio/ingress/tls/secretName
+      value: tls-gitlab-{ENV}-minio
+    - op: replace
+      path: /spec/values/minio/persistence/size
+      value: 10Gi
+    - op: replace
+      path: /spec/values/registry/ingress/tls/secretName
+      value: tls-gitlab-{ENV}-registry
+    - op: add
+      path: /spec/values
+      value:
+        grafana:
+          enabled: false
+    - op: replace
+      path: /spec/values/gitlab/webservice/ingress/tls/secretName
+      value: tls-gitlab-{ENV}-webservice
+
+      # - op: replace
+      #   path: /spec/values/gitlab/webservice/image/tag
+      #   value: v14.4.1
+
+    - op: remove
+      path: /spec/values/gitlab/webservice/image/tag
+    - op: remove
+      path: /spec/values/gitlab/webservice/image/repository
+
+    - op: replace
+      path: /spec/values/gitlab/webservice/minReplicas
+      value: 1
+    - op: replace
+      path: /spec/values/gitlab/webservice/maxReplicas
+      value: 3
+    - op: remove
+      path: /spec/values/gitlab/gitlab-shell/service
+
+      # - op: replace
+      #   path: /spec/values/gitlab/sidekiq/image/tag
+      #   value: v14.4.1
+
+    - op: remove
+      path: /spec/values/gitlab/sidekiq/image/tag
+    - op: remove
+      path: /spec/values/gitlab/sidekiq/image/repository
+
+      # - op: replace
+      #   path: /spec/values/gitlab/task-runner/image/tag
+      #   value: v14.4.1
+
+    - op: remove
+      path: /spec/values/gitlab/task-runner/image/tag
+    - op: remove
+      path: /spec/values/gitlab/task-runner/image/repository
+
+    - op: replace
+      path: /spec/values/gitlab/task-runner/replicas
+      value: 3

--- a/k8s/gitops/deployments.yaml
+++ b/k8s/gitops/deployments.yaml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: controller
-          image: ghcr.io/spack/gitops:0.0.1
+          image: ghcr.io/spack/gitops:0.0.2
           args:
             - --repo
             - ssh://git@github.com/spack/spack-infrastructure

--- a/k8s/runners/staging/release.yaml
+++ b/k8s/runners/staging/release.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: runner-staging-patch
+  annotations:
+    cd.spack.io/staged-resource: "1"
+data:
+  apiVersion: helm.fluxcd.io/v1
+  kind: HelmRelease
+  name: runner-small-x86-pub
+  patch: |
+    - op: replace
+      path: /metadata/name
+      value: runner-{ENV}
+    - op: replace
+      path: /spec/releaseName
+      value: runner-{ENV}
+    - op: replace
+      path: /spec/values/gitlabUrl
+      value: "https://gitlab.{ENV}.spack.io/"
+    - op: replace
+      path: /spec/values/terminationGracePeriodSeconds
+      value: 300  # five minutes
+    - op: replace
+      path: /spec/values/concurrent
+      value: 3
+    - op: replace
+      path: /spec/values/checkInterval
+      value: 1
+    - op: replace
+      path: /spec/values/runners/requestConcurrency
+      value: 3
+    - op: replace
+      path: /spec/values/runners/tags
+      value: "x86_64,avx,{ENV},public,aws,spack"
+    - op: replace
+      path: /spec/values/runners/secret
+      value: gitlab-{ENV}-gitlab-runner-secret
+    - op: replace
+      path: /spec/values/runners/namespace
+      value: gitlab
+    - op: replace
+      path: /spec/values/runners/pollTimeout
+      value: 30
+    - op: replace
+      path: /spec/values/runners/nodeSelector/spack.io~1node-pool
+      value: base
+    - op: remove
+      path: /spec/values/runners/builds/cpuRequests
+    - op: remove
+      path: /spec/values/runners/nodeSelector/kubernetes.io~1arch

--- a/scripts/gitops-patch.py
+++ b/scripts/gitops-patch.py
@@ -1,8 +1,12 @@
 #! /usr/bin/env python
 
 import argparse
+import re
 import sys
 import yaml
+
+RE_TILDE = re.compile('~0')
+RE_SLASH = re.compile('~1')
 
 parser = argparse.ArgumentParser()
 
@@ -28,6 +32,11 @@ parser.add_argument('-e',
                           ' the given value (default: staging)'),
                     default='staging')
 
+
+def process_path_token(tok):
+    return RE_TILDE.sub('~', RE_SLASH.sub('/', tok))
+
+
 def apply_patch(obj, patch):
     for p in patch:
         op = p.get('op', None)
@@ -43,7 +52,8 @@ def apply_patch(obj, patch):
             if path == '/':
                 key = ''
             else:
-                tokens = path.split('/')[1:]
+                tokens = [process_path_token(tok)
+                          for tok in path.split('/')[1:]]
                 tokens, key = tokens[:-1], tokens[-1]
                 for t in tokens:
                     if isinstance(ptr, list):

--- a/scripts/gitops-patch.py
+++ b/scripts/gitops-patch.py
@@ -1,0 +1,177 @@
+#! /usr/bin/env python
+
+import argparse
+import sys
+import yaml
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('orig_file', help='file to apply patch to')
+parser.add_argument('patch_file', help='patch to apply')
+
+parser.add_argument('-i',
+                    '--index',
+                    help='which root-level object to patch (default: 0)',
+                    type=int,
+                    default=0)
+
+parser.add_argument('-p',
+                    '--patch-index',
+                    help=('which root-level object to use as'
+                          ' the patch (default: 0)'),
+                    type=int,
+                    default=0)
+
+parser.add_argument('-e',
+                    '--environment',
+                    help=('replcae {ENV} in the patch with'
+                          ' the given value (default: staging)'),
+                    default='staging')
+
+def apply_patch(obj, patch):
+    for p in patch:
+        op = p.get('op', None)
+        path = p.get('path', None)
+        val = p.get('value', None)
+
+        if not op: continue
+        if not path: continue
+
+        ptr = obj
+        key = None
+        if path:
+            if path == '/':
+                key = ''
+            else:
+                tokens = path.split('/')[1:]
+                tokens, key = tokens[:-1], tokens[-1]
+                for t in tokens:
+                    if isinstance(ptr, list):
+                        t = int(t)
+                    ptr = ptr[t]
+
+        if op == 'add':
+            if isinstance(ptr, list):
+                if key == '-':
+                    ptr.append(val)
+                else:
+                    key = int(key)
+                    ptr.insert(key, val)
+            else:
+                ptr[key].update(val)
+        elif op == 'remove':
+            if isinstance(ptr, list):
+                if key == '-':
+                    ptr.pop()
+                else:
+                    key = int(key)
+                    ptr.remove(key)
+            else:
+                ptr.pop(key)
+        elif op == 'replace':
+            if isinstance(ptr, list):
+                if key == '-':
+                    ptr[-1] = val
+                else:
+                    key = int(key)
+                    ptr[key] = val
+            else:
+                ptr[key] = val
+        else:
+            continue  # TODO(opadron): finish this if we ever start caring
+                      #                about copy, move, or test
+
+
+def process_patch(patch, env):
+    if isinstance(patch, list):
+        return [process_patch(p, env) for p in patch]
+
+    if isinstance(patch, dict):
+        return {process_patch(k, env): process_patch(v, env)
+                for k, v in patch.items()}
+
+    if isinstance(patch, str):
+        return patch.format(ENV=env)
+
+    return patch
+
+
+def warn(*args):
+    sys.stdout.write('\n')
+    sys.stdout.write('\x1b[1;33m')
+    sys.stdout.write(*args)
+    sys.stdout.write('\x1b[0m\n')
+
+
+# MAIN ENTRY POINT
+args = parser.parse_args()
+f = sys.stdin
+f_name = '<stdin>'
+if args.patch_file:
+    f = open(args.patch_file)
+    f_name = args.patch_file
+
+patch = None
+with f:
+    try:
+        roots = list(yaml.full_load_all(f))
+        patch = roots[args.patch_index]
+    except yaml.scanner.ScannerError as e:
+        warn('patch file failed to parse')
+        sys.stdout.write('\x1b[1;31m')
+        e.problem_mark.name = f_name
+        print(e)
+        sys.stdout.write('\x1b[0m')
+
+# some sanity checks
+if patch['apiVersion'] != 'v1':
+    raise ValueError('patch["apiVersion"] != "v1"')
+
+if patch['kind'] != 'ConfigMap':
+    raise ValueError('patch["kind"] != "ConfigMap"')
+
+annotation_missing = (
+    (
+        (
+            (patch.get('metadata') or {})
+            .get('annotations') or {}
+        )
+        .get('cd.spack.io/staged-resource', '0')
+    ) in
+    (None, 'false', '0', 'off', 'no', 'disabled'))
+
+if annotation_missing:
+    raise ValueError('patch annotation missing or disabled:'
+                     ' cd.spack.io/staged-resource')
+
+patch = patch.get('data', {}).get('patch', None)
+if patch is None:
+    raise ValueError('patch.data.patch missing or empty')
+
+
+try:
+    patch = yaml.full_load(patch)
+except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
+    warn('patch data failed to parse')
+    sys.stdout.write('\x1b[1;31m')
+    print(e)
+    sys.stdout.write('\x1b[0m')
+
+orig_file = open(args.orig_file)
+orig_file_name = args.orig_file
+
+target = None
+with orig_file:
+    try:
+        roots = list(yaml.full_load_all(orig_file))
+        target = roots[args.index]
+    except yaml.scanner.ScannerError as e:
+        warn('file failed to parse')
+        sys.stdout.write('\x1b[1;31m')
+        e.problem_mark.name = orig_file_name
+        print(e)
+        sys.stdout.write('\x1b[0m')
+
+patch = process_patch(patch, env=args.environment)
+apply_patch(target, patch)
+yaml.dump(target, sys.stdout)


### PR DESCRIPTION
Adds canary deployments for Gitlab and one gitlab runner.  The runner is configured to run up to 3 jobs at a time on the `base` node pool.  The jobs can share instance resources with each other as well as any other pods running on the pool.  This should be fine for testing, and has the added benefit that jobs should start up and run quickly since it is unlikely that they would need to wait for cluster autoscaler to bring up a new instance.

While producing these patches, the value of having a tool to preview the results of applying a patch to some resources became clear, and so I also added the `gitops-patch.py` script.  This script can apply a patch and show you the result.  It uses the same logic that my `gitops` controller uses when applying patches.

As a final detail, I had to manually implement the processing and application of these patches since the only python library available doesn't work.  I've only implemented a subset of the standard, but realized that there was a part of the standard that was missing from the implementation: handling `~0` and `~1` escape sequences in paths.  This PR also adds code that handles these sequences in both the above script as well as the controller, so I needed to bump the version number on the image.