### PR TITLE
fix gitops initialization logic/add gitlab namespace to patches

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -201,7 +201,7 @@ jobs:
           context: ./images/gitops
           file: ./images/gitops/Dockerfile
           push: true
-          tags: ghcr.io/spack/gitops:0.0.3
+          tags: ghcr.io/spack/gitops:0.0.4
       -
         name: Image digest
         run: echo ${{ steps.docker_build_gitops.outputs.digest }}

--- a/images/gitops/entrypoint.py
+++ b/images/gitops/entrypoint.py
@@ -251,6 +251,7 @@ last_production_hash = read_scalar_from_path(last_production_file)
 last_target_hash = read_scalar_from_path(last_target_file)
 
 waited_last_iter = False
+first_iteration = True
 
 while True:
     start_time = time.time()
@@ -263,14 +264,15 @@ while True:
     current_production_hash = repo.rev_list(args.production_branch)
     current_target_hash = repo.rev_list(args.target_branch)
 
-    staging_needs_update = (last_staging_hash is None or
+    staging_needs_update = (first_iteration or last_staging_hash is None or
                             last_staging_hash != current_staging_hash)
 
-    production_needs_update = (last_production_hash is None or
-                            last_production_hash != current_production_hash)
+    production_needs_update = (first_iteration or last_production_hash is None
+                               or last_production_hash !=
+                                   current_production_hash)
 
-    target_needs_update = (last_target_hash is None or
-                            last_target_hash != current_target_hash)
+    target_needs_update = (first_iteration or last_target_hash is None or
+                           last_target_hash != current_target_hash)
 
     update_staging_hash = False
     update_production_hash = False
@@ -455,3 +457,5 @@ while True:
     sleep_time = args.interval - elapsed_time
     if sleep_time > 0:
         time.sleep(sleep_time)
+
+    first_iteration = False

--- a/k8s/gitlab/staging/certificates.yaml
+++ b/k8s/gitlab/staging/certificates.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gitlab-staging-webservice-patch
+  namespace: gitlab
   annotations:
     cd.spack.io/staged-resource: "1"
 data:
@@ -25,6 +26,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gitlab-staging-registry-patch
+  namespace: gitlab
   annotations:
     cd.spack.io/staged-resource: "1"
 data:
@@ -47,12 +49,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gitlab-staging-minio-patch
+  namespace: gitlab
   annotations:
     cd.spack.io/staged-resource: "1"
 data:
   apiVersion: cert-manager.io/v1
   kind: Certificate
   name: gitlab-minio
+  namespace: gitlab
   patch: |
     - op: replace
       path: /metadata/name

--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gitlab-staging-patch
+  namespace: gitlab
   annotations:
     cd.spack.io/staged-resource: "1"
 data:

--- a/k8s/gitops/deployments.yaml
+++ b/k8s/gitops/deployments.yaml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: controller
-          image: ghcr.io/spack/gitops:0.0.3
+          image: ghcr.io/spack/gitops:0.0.4
           args:
             - --repo
             - ssh://git@github.com/spack/spack-infrastructure

--- a/k8s/runners/staging/release.yaml
+++ b/k8s/runners/staging/release.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: runner-staging-patch
+  namespace: gitlab
   annotations:
     cd.spack.io/staged-resource: "1"
 data:


### PR DESCRIPTION
Fixes two other issues identified during maintenance:

1. Fixes an issue where the gitops controller wasn't initializing properly on its first iteration.
2. Adds the new patch config maps to their correct namespaces.