### PR TITLE
remove poll timeout override

### DIFF
--- a/k8s/runners/staging/release.yaml
+++ b/k8s/runners/staging/release.yaml
@@ -42,9 +42,6 @@ data:
       path: /spec/values/runners/namespace
       value: gitlab
     - op: replace
-      path: /spec/values/runners/pollTimeout
-      value: 30
-    - op: replace
       path: /spec/values/runners/nodeSelector/spack.io~1node-pool
       value: glr-xlarge-pub
     - op: remove


### PR DESCRIPTION
There's a setting in the gitlab runner helm chart called `pollTimeout`.  This value controls how long a job will idle waiting for its pod to come up before giving up and failing the job.  I had overridden this value in the staging runner because I thought it was for something else.

This was a mistake that causes the runner's jobs to fail when spinning up a new instance through cluster autoscaler.  I set the value to 30 seconds, which is not enough time.

Here, I undo that mistake, leaving the setting to its original value of ten minutes.