### PR TITLE
switch staging gitlab back to our custom images

### DIFF
--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -70,10 +70,6 @@ data:
     - op: replace
       path: /spec/values/gitlab/webservice/image/tag
       value: v14.4.1
-    - op: remove
-      path: /spec/values/gitlab/webservice/image/tag
-    - op: remove
-      path: /spec/values/gitlab/webservice/image/repository
     - op: replace
       path: /spec/values/gitlab/webservice/minReplicas
       value: 1
@@ -85,17 +81,9 @@ data:
     - op: replace
       path: /spec/values/gitlab/sidekiq/image/tag
       value: v14.4.1
-    - op: remove
-      path: /spec/values/gitlab/sidekiq/image/tag
-    - op: remove
-      path: /spec/values/gitlab/sidekiq/image/repository
     - op: replace
       path: /spec/values/gitlab/task-runner/image/tag
       value: v14.4.1
-    - op: remove
-      path: /spec/values/gitlab/task-runner/image/tag
-    - op: remove
-      path: /spec/values/gitlab/task-runner/image/repository
     - op: replace
       path: /spec/values/gitlab/task-runner/replicas
       value: 3


### PR DESCRIPTION
Looks like I forgot to remove a temporary change in the staging Gitlab patch file.  This change removed some fields in the helm release related to the images.  The effect of this was to revert those fields back to their default values.  I probably added this before I had the custom images ready, and then forgot to remove it.