### PR TITLE
turn on async parsing for CDash

### DIFF
--- a/k8s/cdash/deployments.yaml
+++ b/k8s/cdash/deployments.yaml
@@ -84,5 +84,6 @@ spec:
             \$CDASH_AUTOREMOVE_BUILDS = '\'1\'';
             \$CDASH_DEFAULT_PROJECT = '\'Spack\'';
             \$CDASH_ACTIVE_PROJECT_DAYS = '\'0\'';
+            \$CDASH_ASYNCHRONOUS_SUBMISSION = '\'1\'';
       nodeSelector:
         spack.io/node-pool: base

--- a/k8s/cdash/deployments.yaml
+++ b/k8s/cdash/deployments.yaml
@@ -82,7 +82,6 @@ spec:
             \$CDASH_USE_HTTPS = '\'1\'';
             \$CDASH_PRODUCTION_MODE = '\'1\'';
             \$CDASH_AUTOREMOVE_BUILDS = '\'1\'';
-            \$CDASH_DEFAULT_PROJECT = '\'Spack\'';
             \$CDASH_ACTIVE_PROJECT_DAYS = '\'0\'';
             \$CDASH_ASYNCHRONOUS_SUBMISSION = '\'1\'';
       nodeSelector:


### PR DESCRIPTION
This should allow us to more easily cope with 'bursty' workflows.