### PR TITLE
Add PVC to prometheus stateful Set

### DIFF
--- a/k8s/prometheus/release.yaml
+++ b/k8s/prometheus/release.yaml
@@ -24,5 +24,13 @@ spec:
       ingress:
         enabled: false
       prometheusSpec:
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: gp2
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: 200Gi
         nodeSelector:
           spack.io/node-pool: beefy


### PR DESCRIPTION
By default we lose prometheus info on pod crash. This should prevent that from happening.