### PR TITLE
Fix status posted for PRs backlogged by a running develop pipeline

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -26,7 +26,7 @@ jobs:
           context: ./images/gh-gl-sync
           file: ./images/gh-gl-sync/Dockerfile
           push: true
-          tags: ghcr.io/spack/ci-bridge:0.0.22
+          tags: ghcr.io/spack/ci-bridge:0.0.23
       -
         name: Image digest
         run: echo ${{ steps.docker_build_sync.outputs.digest }}

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -494,7 +494,7 @@ class SpackCIBridge(object):
         for branch, head_sha, reason in backlog_branches:
             try:
                 print('  {0} -> {1}'.format(branch, head_sha))
-                if backlog == "base":
+                if reason == "base":
                     desc = base_backlog_desc
                     url = self.currently_running_url,
                 else:

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -14,7 +14,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.22
+            image: ghcr.io/spack/ci-bridge:0.0.23
             imagePullPolicy: IfNotPresent
             env:
             - name: GITHUB_TOKEN


### PR DESCRIPTION
We were inadvertently posting a status message of:
"Pending -- base"

...when we really meant to be saying:
"Pending -- waiting for base develop commit pipeline to succeed"

This bug fix will also cause us to link to the currently running develop pipeline from the pending status that gets posted to GitHub.