### PR TITLE
Allow huge jobs to run on the glr-huge-pub pool (merge to production)

### DIFF
--- a/k8s/runners/huge-x86-pub/release.yaml
+++ b/k8s/runners/huge-x86-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 46000m
-        memoryRequests: 94Gi
+        memoryRequests: 88Gi
 
       services: {}
       # cpuRequests: 50m


### PR DESCRIPTION
I don't completely understand why, but the amount of memory we were
requesting (94Gi) was too much for cluster-autoscaler to spin up a new instance
for huge jobs:

Pod <snip> can't be scheduled on <huge-ASG>, predicate checking error:
Insufficient memory; predicateName=NodeResourcesFit;
reasons: Insufficient memory; debugInfo=

I also tried 90 GiB, but this resulted in the same error. Thus, the current
value of 88 GiB was more-or-less discovered by trial & error.