### PR TITLE
Gitlab runner resource limits tweak (push to production)

### DIFF
--- a/k8s/runners/huge-arm-pub/release.yaml
+++ b/k8s/runners/huge-arm-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 46000m
-        memoryRequests: 86Gi
+        memoryRequests: 88Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/huge-arm-pub/release.yaml
+++ b/k8s/runners/huge-arm-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 46000m
-        memoryRequests: 94Gi
+        memoryRequests: 86Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/huge-x86-pub/release.yaml
+++ b/k8s/runners/huge-x86-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 46000m
-        memoryRequests: 86Gi
+        memoryRequests: 88Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/huge-x86-pub/release.yaml
+++ b/k8s/runners/huge-x86-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 46000m
-        memoryRequests: 88Gi
+        memoryRequests: 86Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/large-arm-pub/release.yaml
+++ b/k8s/runners/large-arm-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 8000m
-        memoryRequests: 16Gi
+        memoryRequests: 15029589Ki  # 14.333 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/large-arm-pub/release.yaml
+++ b/k8s/runners/large-arm-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 8000m
-        memoryRequests: 15029589Ki  # 14.333 Gi
+        memoryRequests: 15379114Ki  # 14.666 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/large-x86-pub/release.yaml
+++ b/k8s/runners/large-x86-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 8000m
-        memoryRequests: 16Gi
+        memoryRequests: 15029589Ki  # 14.333 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/large-x86-pub/release.yaml
+++ b/k8s/runners/large-x86-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 8000m
-        memoryRequests: 15029589Ki  # 14.333 Gi
+        memoryRequests: 15379114Ki  # 14.666 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/medium-arm-pub/release.yaml
+++ b/k8s/runners/medium-arm-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 4000m
-        memoryRequests: 8Gi
+        memoryRequests: 7514794Ki  # 7.166 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/medium-arm-pub/release.yaml
+++ b/k8s/runners/medium-arm-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 4000m
-        memoryRequests: 7514794Ki  # 7.166 Gi
+        memoryRequests: 7689557Ki  # 7.333 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/medium-x86-pub/release.yaml
+++ b/k8s/runners/medium-x86-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 4000m
-        memoryRequests: 8Gi
+        memoryRequests: 7514794Ki  # 7.166 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/medium-x86-pub/release.yaml
+++ b/k8s/runners/medium-x86-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 4000m
-        memoryRequests: 7514794Ki  # 7.166 Gi
+        memoryRequests: 7689557Ki  # 7.333 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/xlarge-arm-pub/release.yaml
+++ b/k8s/runners/xlarge-arm-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 16000m
-        memoryRequests: 30059178Ki  # 28.666 Gi
+        memoryRequests: 30758229Ki  # 29.333 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/xlarge-arm-pub/release.yaml
+++ b/k8s/runners/xlarge-arm-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 16000m
-        memoryRequests: 32Gi
+        memoryRequests: 30059178Ki  # 28.666 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/xlarge-x86-pub/release.yaml
+++ b/k8s/runners/xlarge-x86-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 16000m
-        memoryRequests: 30059178Ki  # 28.666 Gi
+        memoryRequests: 30758229Ki  # 29.333 Gi
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/runners/xlarge-x86-pub/release.yaml
+++ b/k8s/runners/xlarge-x86-pub/release.yaml
@@ -76,7 +76,7 @@ spec:
 
       builds:
         cpuRequests: 16000m
-        memoryRequests: 32Gi
+        memoryRequests: 30059178Ki  # 28.666 Gi
 
       services: {}
       # cpuRequests: 50m


### PR DESCRIPTION
Readjusts all the worker memory requests based on 88 Gi of allocatable memory on the `c5.12xlarge` nodes.