### PR TITLE
Gitlab runner revamp revert (push to production)

### DIFF
--- a/k8s/runners/huge-arm-pub/release.yaml
+++ b/k8s/runners/huge-arm-pub/release.yaml
@@ -36,7 +36,7 @@ spec:
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 1
+      requestConcurrency: 20
       locked: false
 
       tags: "arm,aarch64,graviton,graviton2,huge,public,aws,spack"

--- a/k8s/runners/huge-x86-pub/release.yaml
+++ b/k8s/runners/huge-x86-pub/release.yaml
@@ -36,7 +36,7 @@ spec:
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 1
+      requestConcurrency: 20
       locked: false
 
       tags: "x86_64,avx,avx2,avx512,huge,public,aws,spack"

--- a/k8s/runners/large-arm-pub/release.yaml
+++ b/k8s/runners/large-arm-pub/release.yaml
@@ -36,7 +36,7 @@ spec:
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 100
+      requestConcurrency: 20
       locked: false
 
       tags: "arm,aarch64,graviton,graviton2,large,public,aws,spack"
@@ -75,8 +75,7 @@ spec:
         # secretName: google-application-credentials
 
       builds:
-        cpuRequests: 8000m
-        memoryRequests: 15379114Ki  # 14.666 Gi
+        cpuRequests: 1500m
 
       services: {}
       # cpuRequests: 50m
@@ -97,7 +96,7 @@ spec:
       # memoryLimit: 144Mi
 
       nodeSelector:
-        spack.io/node-pool: glr-huge-pub  # pool for jobs
+        spack.io/node-pool: glr-large-pub  # pool for jobs
         kubernetes.io/arch: arm64
 
     nodeSelector:

--- a/k8s/runners/large-x86-pub/release.yaml
+++ b/k8s/runners/large-x86-pub/release.yaml
@@ -36,7 +36,7 @@ spec:
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 100
+      requestConcurrency: 20
       locked: false
 
       tags: "x86_64,avx,avx2,avx512,large,public,aws,spack"
@@ -75,8 +75,7 @@ spec:
         # secretName: google-application-credentials
 
       builds:
-        cpuRequests: 8000m
-        memoryRequests: 15379114Ki  # 14.666 Gi
+        cpuRequests: 1500m
 
       services: {}
       # cpuRequests: 50m
@@ -91,7 +90,7 @@ spec:
       # memoryLimit: 144Mi
 
       nodeSelector:
-        spack.io/node-pool: glr-huge-pub  # pool for jobs
+        spack.io/node-pool: glr-large-pub  # pool for jobs
         kubernetes.io/arch: amd64
 
     nodeSelector:

--- a/k8s/runners/medium-arm-pub/release.yaml
+++ b/k8s/runners/medium-arm-pub/release.yaml
@@ -36,7 +36,7 @@ spec:
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 50
+      requestConcurrency: 20
       locked: false
 
       tags: "arm,aarch64,graviton,graviton2,medium,public,aws,spack"
@@ -75,8 +75,7 @@ spec:
         # secretName: google-application-credentials
 
       builds:
-        cpuRequests: 4000m
-        memoryRequests: 7689557Ki  # 7.333 Gi
+        cpuRequests: 1050m
 
       services: {}
       # cpuRequests: 50m
@@ -97,7 +96,7 @@ spec:
       # memoryLimit: 144Mi
 
       nodeSelector:
-        spack.io/node-pool: glr-huge-pub  # pool for jobs
+        spack.io/node-pool: glr-medium-pub  # pool for jobs
         kubernetes.io/arch: arm64
 
     nodeSelector:

--- a/k8s/runners/medium-x86-pub/release.yaml
+++ b/k8s/runners/medium-x86-pub/release.yaml
@@ -39,7 +39,7 @@ spec:
       requestConcurrency: 20
       locked: false
 
-      tags: "x86_64,avx,avx2,avx512,medium,public,aws,spack"
+      tags: "x86_64,avx,medium,public,aws,spack"
       runUntagged: false
       privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release

--- a/k8s/runners/medium-x86-pub/release.yaml
+++ b/k8s/runners/medium-x86-pub/release.yaml
@@ -36,7 +36,7 @@ spec:
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 50
+      requestConcurrency: 20
       locked: false
 
       tags: "x86_64,avx,avx2,avx512,medium,public,aws,spack"
@@ -75,8 +75,7 @@ spec:
         # secretName: google-application-credentials
 
       builds:
-        cpuRequests: 4000m
-        memoryRequests: 7689557Ki  # 7.333 Gi
+        cpuRequests: 1050m
 
       services: {}
       # cpuRequests: 50m
@@ -91,7 +90,7 @@ spec:
       # memoryLimit: 144Mi
 
       nodeSelector:
-        spack.io/node-pool: glr-huge-pub  # pool for jobs
+        spack.io/node-pool: glr-medium-pub  # pool for jobs
         kubernetes.io/arch: amd64
 
     nodeSelector:

--- a/k8s/runners/xlarge-arm-pub/release.yaml
+++ b/k8s/runners/xlarge-arm-pub/release.yaml
@@ -36,7 +36,7 @@ spec:
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 5
+      requestConcurrency: 20
       locked: false
 
       tags: "arm,aarch64,graviton,graviton2,xlarge,public,aws,spack"
@@ -75,8 +75,7 @@ spec:
         # secretName: google-application-credentials
 
       builds:
-        cpuRequests: 16000m
-        memoryRequests: 30758229Ki  # 29.333 Gi
+        cpuRequests: 9000m
 
       services: {}
       # cpuRequests: 50m
@@ -97,7 +96,7 @@ spec:
       # memoryLimit: 144Mi
 
       nodeSelector:
-        spack.io/node-pool: glr-huge-pub  # pool for jobs
+        spack.io/node-pool: glr-xlarge-pub  # pool for jobs
         kubernetes.io/arch: arm64
 
     nodeSelector:

--- a/k8s/runners/xlarge-x86-pub/release.yaml
+++ b/k8s/runners/xlarge-x86-pub/release.yaml
@@ -36,7 +36,7 @@ spec:
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 5
+      requestConcurrency: 20
       locked: false
 
       tags: "x86_64,avx,avx2,avx512,xlarge,public,aws,spack"
@@ -75,8 +75,7 @@ spec:
         # secretName: google-application-credentials
 
       builds:
-        cpuRequests: 16000m
-        memoryRequests: 30758229Ki  # 29.333 Gi
+        cpuRequests: 9000m
 
       services: {}
       # cpuRequests: 50m
@@ -91,7 +90,7 @@ spec:
       # memoryLimit: 144Mi
 
       nodeSelector:
-        spack.io/node-pool: glr-huge-pub  # pool for jobs
+        spack.io/node-pool: glr-xlarge-pub  # pool for jobs
         kubernetes.io/arch: amd64
 
     nodeSelector:


### PR DESCRIPTION
After #163, we're getting hit by a nasty Gitlab Runner bug where stale pods are being left around after they have finished building their packages.  As far as we can tell, these pods are left running indefinitely, occupying resources and preventing new work from running.  We don't know why this issue is affecting us, nor why it only started after we changed the way our runners were deployed.  This is a critical issue affecting the pipelines, and our immediate response is to revert the changes in the hopes that it goes away.

After this is merged, I'll update the underlying `huge` pools to only run up to 20 instances.