### PR TITLE
add temporary large runner (push to production)

### DIFF
--- a/k8s/runners/large-x86-tmp-pub/release.yaml
+++ b/k8s/runners/large-x86-tmp-pub/release.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: runner-large-x86-tmp-pub
+  namespace: gitlab
+spec:
+  releaseName: large-x86-tmp-pub
+  chart:
+    name: gitlab-runner
+    repository: https://charts.gitlab.io
+    version: 0.25.0  # gitlab-runner@13.8.0
+  values:
+    image: gitlab/gitlab-runner:alpine-v13.8.0
+    imagePullPolicy: IfNotPresent
+
+    gitlabUrl: "https://gitlab.spack.io/"
+    unregisterRunners: true
+    terminationGracePeriodSeconds: 21600  # six hours
+    concurrent: 10
+    checkInterval: 30
+    # preEntrypointScript: |
+    #   echo "Hello, from large-pub runner"
+
+    metrics:
+      enabled: true
+
+    rbac:
+      serviceAccountName: runner
+
+    runners:
+      config: |
+        [[runners]]
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+      # default image
+      image: "busybox:1.32.0"
+      imagePullPolicy: "if-not-present"
+      requestConcurrency: 10
+      locked: false
+
+      tags: "x86_64,avx,avx2,avx512,large,public,aws,spack"
+      runUntagged: false
+      privileged: false
+      secret: gitlab-gitlab-runner-secret  # from gitlab release
+
+      namespace: pipeline
+      pollTimeout: 600  # ten minutes
+
+      # build log size limit
+      outputLimit: 4096
+
+      serviceAccountName: runner
+
+      # Distributed runners caching
+      # TODO(opadron): Look into this after setting up stand-alone minio service
+      cache: {}
+        ## General settings
+        # cacheType: s3
+        # cachePath: "gitlab_runner"
+        # cacheShared: true
+
+        ## S3 settings
+        # s3ServerAddress: s3.amazonaws.com
+        # s3BucketName:
+        # s3BucketLocation:
+        # s3CacheInsecure: false
+        # secretName: s3access
+
+        ## GCS settings
+        # gcsBucketName:
+        ## Use this line for access using access-id and private-key
+        # secretName: gcsaccess
+        ## Use this line for access using google-application-credentials file
+        # secretName: google-application-credentials
+
+      builds:
+        cpuRequests: 8000m
+        memoryRequests: 15379114Ki  # 14.666 Gi
+
+      services: {}
+      # cpuRequests: 50m
+      # cpuLimit: 50m
+      # memoryRequests: 144Mi
+      # memoryLimit: 144Mi
+
+      helpers: {}
+      # cpuRequests: 50m
+      # cpuLimit: 50m
+      # memoryRequests: 144Mi
+      # memoryLimit: 144Mi
+
+      nodeSelector:
+        spack.io/node-pool: glr-huge-tmp-pub  # pool for jobs
+        kubernetes.io/arch: amd64
+
+    nodeSelector:
+      spack.io/node-pool: base  # pool for the runner


### PR DESCRIPTION
Temporarily adds a new `large` runner that will run side-by-side with the current runners.  This temporary runner will accept new jobs with the `large` tag and pack them into `c5.12xlarge` instances.  These instances are provisioned using a temporary node pool, `glr-huge-tmp-pub`.  The runner is currently set to run up to 10 jobs at a time.

The plan is to introduce this new runner and monitor jobs for evidence of the "stuck" pods issue we were observing last week.  Assuming the runner runs without issues, we will gradually increase the capacity until we observe the "stuck" pods issue, again.