### PR TITLE
transition away from gitlab-task-runner to gitlab-toolbox

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -155,7 +155,7 @@ jobs:
       -
         name: Image digest
         run: echo ${{ steps.docker_build_gitlab_sideqkiq.outputs.digest }}
-  gitlab-task-runner:
+  gitlab-toolbox:
     runs-on: ubuntu-latest
     steps:
       -
@@ -169,17 +169,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        name: Build and push gitlab-task-runner
-        id: docker_build_gitlab_task_runner
+        name: Build and push gitlab-toolbox
+        id: docker_build_gitlab_toolbox
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
-          context: ./images/gitlab-task-runner
-          file: ./images/gitlab-task-runner/Dockerfile
+          context: ./images/gitlab-toolbox
+          file: ./images/gitlab-toolbox/Dockerfile
           push: true
-          tags: ghcr.io/spack/gitlab-task-runner:v14.6.3
+          tags: ghcr.io/spack/gitlab-toolbox:v14.6.3
       -
         name: Image digest
-        run: echo ${{ steps.docker_build_gitlab_task_runner.outputs.digest }}
+        run: echo ${{ steps.docker_build_gitlab_toolbox.outputs.digest }}
   gitops:
     runs-on: ubuntu-latest
     steps:

--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -81,9 +81,20 @@ data:
     - op: replace
       path: /spec/values/gitlab/sidekiq/image/tag
       value: v14.6.3
-    - op: replace
-      path: /spec/values/gitlab/task-runner/image/tag
-      value: v14.6.3
-    - op: replace
-      path: /spec/values/gitlab/task-runner/replicas
-      value: 3
+    - op: remove
+      path: /spec/values/gitlab/task-runner
+    - op: add
+      path: /spec/values/gitlab
+      value:
+        toolbox:
+          image:
+            pullPolicy: IfNotPresent
+            repository: ghcr.io/spack/gitlab-toolbox
+            tag: v14.6.3
+          nodeSelector:
+            spack.io/node-pool: gitlab
+
+          replicas: 3
+          antiAffinityLabels:
+            matchLabels:
+              app: 'gitaly'


### PR DESCRIPTION
Background: Our `gitlab` and `gitlab-staging` helm releases are currently stuck in `failed` states.  This can happen for a variety of reasons.  The releases need to be returned to a healthy state in order for flux to continue managing them automatically.  This operation requires manual intervention.

This PR tries to address one of the reasons for the failure (there may be others): Gitlab had switched their component naming around so that what they used to call "gitlab-task-runner" is now "gitlab-toolbox".  This change is reflected in the `values.yaml` of their helm charts, so we need to manually update our helm releases.

This PR also updates the custom image that we use for running `gitlab-task-runner`.