### PR TITLE
increase nginx max replicas

### DIFF
--- a/k8s/ingress-nginx/release.yaml
+++ b/k8s/ingress-nginx/release.yaml
@@ -38,7 +38,7 @@ spec:
       autoscaling:
         enabled: true
         minReplicas: 1
-        maxReplicas: 4
+        maxReplicas: 20
         targetCPUUtilizationPercentage: 50
         targetMemoryUtilizationPercentage: 50
 


### PR DESCRIPTION
Increases max replicas by 4x, since the HPA has been oversubscribed by more than 3x.  This should leave a comfortable-enough margin for the replica count.