### PR TITLE
fix issues with Gitlab data persistence (push to production)

### DIFF
--- a/k8s/gitlab/release.yaml
+++ b/k8s/gitlab/release.yaml
@@ -95,7 +95,7 @@ spec:
       nodeSelector:
         spack.io/node-pool: gitlab
       persistence:
-        size: 500Gi
+        size: 1000Gi
 
     registry:
       ingress:
@@ -175,3 +175,5 @@ spec:
       master:
         nodeSelector:
           spack.io/node-pool: gitlab
+      persistence:
+        size: 100Gi

--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -72,3 +72,5 @@ data:
       value: 3
     - op: remove
       path: /spec/values/gitlab/gitlab-shell/service
+    - op: remove
+      path: /spec/values/postgresql/persistence


### PR DESCRIPTION
 - Set minio volume to 1Ti, which is what it actually is in the cluster.
 - Increase postgresql volume size from 8Gi -> 100Gi.