### PR TITLE
Prometheus alertmanager hack

### DIFF
--- a/k8s/prometheus/alertmanagerconfig.yaml
+++ b/k8s/prometheus/alertmanagerconfig.yaml
@@ -20,9 +20,12 @@ spec:
           name: slack-webhook-alertmanager
           key: webhook
         iconEmoji: ':warning:'
-        title: '[{{ .CommonLabels.severity }}] {{ .GroupLabels.alertname }} ({{ .Alerts.Firing | len }}) -  {{ .CommonAnnotations.summary }}'
-        text: >-
+        title: |-
+          [{{ .CommonLabels.severity }}] {{ .GroupLabels.alertname }} ({{ .Alerts.Firing | len }}) - {{ .CommonAnnotations.summary }}
+        text: |-
           {{ .CommonAnnotations.description }}
           {{ range .Alerts }}
-              *{{.Labels.alertname}}* ({{ .Fingerprint }}): <{{ .GeneratorURL }}|:chart_with_upwards_trend:> <{{ .Annotations.runbook }}|:spiral_note_pad:> - {{.Annotations.description}}
+          *{{.Labels.alertname}}* ({{ .Fingerprint }}): <{{ .GeneratorURL }}|:chart_with_upwards_trend:>
+          {{.Annotations.description}}
+
           {{ end }}

--- a/k8s/prometheus/alertmanagerconfig.yaml
+++ b/k8s/prometheus/alertmanagerconfig.yaml
@@ -16,7 +16,6 @@ spec:
   - name: 'slack'
     slackConfigs:
       - channel: '#monitoring-alerts'
-        sendResolved: true
         apiURL:
           name: slack-webhook-alertmanager
           key: webhook

--- a/k8s/prometheus/alertmanagerconfig.yaml
+++ b/k8s/prometheus/alertmanagerconfig.yaml
@@ -7,7 +7,7 @@ metadata:
     alertmanagerConfig: spack
 spec:
   route:
-    groupBy: ['job']
+    groupBy: ['alertname']
     groupWait: 30s
     groupInterval: 5m
     repeatInterval: 12h
@@ -19,13 +19,10 @@ spec:
         apiURL:
           name: slack-webhook-alertmanager
           key: webhook
-        title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Monitoring Event Notification'
+        iconEmoji: ':warning:'
+        title: '[{{ .CommonLabels.severity }}] {{ .GroupLabels.alertname }} ({{ .Alerts.Firing | len }}) -  {{ .CommonAnnotations.summary }}'
         text: >-
+          {{ .CommonAnnotations.description }}
           {{ range .Alerts }}
-              *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
-              *Description:* {{ .Annotations.description }}
-              *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:> *Runbook:* <{{ .Annotations.runbook }}|:spiral_note_pad:>
-              *Details:*
-                  {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
-                  {{ end }}
+              *{{.Labels.alertname}}* ({{ .Fingerprint }}): <{{ .GeneratorURL }}|:chart_with_upwards_trend:> <{{ .Annotations.runbook }}|:spiral_note_pad:> - {{.Annotations.description}}
           {{ end }}

--- a/k8s/prometheus/customalerts.yaml
+++ b/k8s/prometheus/customalerts.yaml
@@ -1,0 +1,25 @@
+---
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-prometheus-stack-spack-custom-alerts
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    release: kube-prometheus-stack
+spec:
+  groups:
+   - name: spack-custom-alerts
+     rules:
+       - alert: GitlabPipelinePodStuck
+         annotations:
+           description: '{{ $labels.pod }} has had no activity for more than 5 minutes.'
+           runbook_url: 'TODO'
+           summary: 'The pod appears to be stuck.  No CPU, RAM, or Network activity for the last 5 minutes.'
+         expr: node_namespace_pod_name:pipeline_stuck_pods_info == 1
+         for: 5m
+         labels:
+           severity: critical
+           namespace: monitoring
+           source_namespace: "{{ $labels.namespace }}"

--- a/k8s/prometheus/customrules.yaml
+++ b/k8s/prometheus/customrules.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kube-prometheus-stack-spack-custom.rules
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    release: kube-prometheus-stack
+spec:
+  groups:
+   - name: spack-custom.rules
+     rules:
+       - expr: |-
+           count by(name, pod, node, namespace) (
+             irate(container_cpu_usage_seconds_total{namespace="pipeline", container="build"}[3m]) == 0 and on(pod, container)
+             delta(container_memory_usage_bytes{namespace="pipeline", container="build"}[3m]) == 0 and on (pod)
+             irate(container_network_receive_bytes_total{namespace="pipeline"}[3m]) == 0 and on (pod)
+             irate(container_network_transmit_bytes_total{namespace="pipeline"}[3m]) == 0
+           )
+         record: node_namespace_pod_name:pipeline_stuck_pods_info

--- a/k8s/prometheus/release.yaml
+++ b/k8s/prometheus/release.yaml
@@ -12,6 +12,10 @@ spec:
     version: 19.2.2
   values:
     defaultRules:
+      disabled:
+        # Both of these services are handled by EKS
+        KubeSchedulerDown: true
+        KubeControllerManagerDown: true
       additionalRuleLabels:
         namespace: monitoring
         source_namespace: '{{ $labels.namespace }}'
@@ -21,6 +25,7 @@ spec:
       ingress:
         enabled: false
       alertmanagerSpec:
+        externalUrl: "https://alertmanager.spack.io"
         alertmanagerConfigSelector:
           matchLabels:
             alertmanagerConfig: spack
@@ -33,6 +38,7 @@ spec:
       ingress:
         enabled: false
       prometheusSpec:
+        externalUrl: "https://prometheus.spack.io"
         storageSpec:
           volumeClaimTemplate:
             spec:

--- a/k8s/prometheus/release.yaml
+++ b/k8s/prometheus/release.yaml
@@ -11,6 +11,11 @@ spec:
     repository: https://prometheus-community.github.io/helm-charts
     version: 19.2.2
   values:
+    defaultRules:
+      additionalRuleLabels:
+        namespace: monitoring
+        source_namespace: '{{ $labels.namespace }}'
+
     namespaceOverride: monitoring
     alertmanager:
       ingress:

--- a/scripts/dummyalert.sh
+++ b/scripts/dummyalert.sh
@@ -21,18 +21,19 @@ generate_post_data() {
 [{
   "status": "$1",
   "labels": {
-    "job": "DummyAlert",
-    "alertname": "${name}",
+    "alertname": "DummyAlert",
+    "name": "${name}",
     "service": "my-service",
     "severity":"warning",
     "instance": "${name}.example.net",
     "namespace": "monitoring",
-    "label_costcentre": "FOO"
+    "source_namespace": "custom"
   },
   "annotations": {
-    "summary": "This is a dummy alert used for debugging. Please Ignore."
+    "summary": "Dummy Alert",
+    "description": "This is a dummy alert for ${name}.  Please Ignore."
   },
-  "generatorURL": "http://local-example-alert/$name"
+  "generatorURL": "http://nota.realdomain.com/$name"
   $2
   $3
 }]

--- a/scripts/dummyalert.sh
+++ b/scripts/dummyalert.sh
@@ -30,8 +30,8 @@ generate_post_data() {
     "source_namespace": "custom"
   },
   "annotations": {
-    "summary": "Dummy Alert",
-    "description": "This is a dummy alert for ${name}.  Please Ignore."
+    "summary": "A test alert",
+    "description": "This is a dummy alert for ${name}.  Please Ignore. Here is some additional text because sometimes descriptions are longer."
   },
   "generatorURL": "http://nota.realdomain.com/$name"
   $2


### PR DESCRIPTION
This makes sure all alert messages are picked up by the `AlertmanagerConfig` custom resource in the `monitoring` namespace.  Note that alerts originated in `source_namespace`

Note that It may be possible to do some post-alert label processing to rewrite source_namespace back to namespace. If so i would do that as a follow on PR. 