### PR TITLE
Bump kube-prometheus-stack from 19.2.2 to 32.0.2

### DIFF
--- a/k8s/prometheus/release.yaml
+++ b/k8s/prometheus/release.yaml
@@ -9,13 +9,15 @@ spec:
   chart:
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 19.2.2
+    version: 32.0.2
   values:
     defaultRules:
-      disabled:
-        # Both of these services are handled by EKS
-        KubeSchedulerDown: true
-        KubeControllerManagerDown: true
+#  Appears to be broken in production -  Does not validate.
+#  See: https://github.com/prometheus-community/helm-charts/issues/1718
+#      disabled:
+#        # Both of these services are handled by EKS
+#        KubeSchedulerDown: true
+#        KubeControllerManagerDown: true
       additionalRuleLabels:
         namespace: monitoring
         source_namespace: '{{ $labels.namespace }}'


### PR DESCRIPTION
Note this required significant manual intervention on cluster related to
Custom Resource Definitions