### PR TITLE
Runners: Switch from bleedingedge to 14.7.0

### DIFF
--- a/k8s/runners/huge-arm-pub/release.yaml
+++ b/k8s/runners/huge-arm-pub/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     name: gitlab-runner
     repository: https://charts.gitlab.io
-    version: 0.37.1  # gitlab-runner@bleeding-edge
+    version: 0.37.2  # gitlab-runner@14.7.0
   values:
     image: gitlab/gitlab-runner:alpine-v14.7.0
     imagePullPolicy: IfNotPresent

--- a/k8s/runners/huge-x86-pub/release.yaml
+++ b/k8s/runners/huge-x86-pub/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     name: gitlab-runner
     repository: https://charts.gitlab.io
-    version: 0.37.1  # gitlab-runner@bleeding-edge
+    version: 0.37.2  # gitlab-runner@14.7.0
   values:
     image: gitlab/gitlab-runner:alpine-v14.7.0
     imagePullPolicy: IfNotPresent

--- a/k8s/runners/large-arm-pub/release.yaml
+++ b/k8s/runners/large-arm-pub/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     name: gitlab-runner
     repository: https://charts.gitlab.io
-    version: 0.37.1  # gitlab-runner@bleeding-edge
+    version: 0.37.2  # gitlab-runner@14.7.0
   values:
     image: gitlab/gitlab-runner:alpine-v14.7.0
     imagePullPolicy: IfNotPresent

--- a/k8s/runners/large-x86-pub/release.yaml
+++ b/k8s/runners/large-x86-pub/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     name: gitlab-runner
     repository: https://charts.gitlab.io
-    version: 0.37.1  # gitlab-runner@bleeding-edge
+    version: 0.37.2  # gitlab-runner@14.7.0
   values:
     image: gitlab/gitlab-runner:alpine-v14.7.0
     imagePullPolicy: IfNotPresent

--- a/k8s/runners/large-x86-tmp-pub/release.yaml
+++ b/k8s/runners/large-x86-tmp-pub/release.yaml
@@ -11,7 +11,7 @@ spec:
   chart:
     name: gitlab-runner
     repository: https://charts.gitlab.io
-    version: 0.37.1  # gitlab-runner@bleeding-edge
+    version: 0.37.2  # gitlab-runner@14.7.0
   values:
     image: gitlab/gitlab-runner:alpine-v14.7.0
     imagePullPolicy: IfNotPresent

--- a/k8s/runners/medium-arm-pub/release.yaml
+++ b/k8s/runners/medium-arm-pub/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     name: gitlab-runner
     repository: https://charts.gitlab.io
-    version: 0.37.1  # gitlab-runner@bleeding-edge
+    version: 0.37.2  # gitlab-runner@14.7.0
   values:
     image: gitlab/gitlab-runner:alpine-v14.7.0
     imagePullPolicy: IfNotPresent

--- a/k8s/runners/medium-x86-pub/release.yaml
+++ b/k8s/runners/medium-x86-pub/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     name: gitlab-runner
     repository: https://charts.gitlab.io
-    version: 0.37.1  # gitlab-runner@bleeding-edge
+    version: 0.37.2  # gitlab-runner@14.7.0
   values:
     image: gitlab/gitlab-runner:alpine-v14.7.0
     imagePullPolicy: IfNotPresent

--- a/k8s/runners/staging/release.yaml
+++ b/k8s/runners/staging/release.yaml
@@ -16,7 +16,7 @@ data:
       value: runner-{ENV}
     - op: replace
       path: /spec/chart/version
-      value: "0.37.1"  # bleeding edge
+      value: "0.37.2"  # bleeding edge
     - op: replace
       path: /spec/releaseName
       value: runner-{ENV}

--- a/k8s/runners/xlarge-arm-pub/release.yaml
+++ b/k8s/runners/xlarge-arm-pub/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     name: gitlab-runner
     repository: https://charts.gitlab.io
-    version: 0.37.1  # gitlab-runner@bleeding-edge
+    version: 0.37.2  # gitlab-runner@14.7.0
   values:
     image: gitlab/gitlab-runner:alpine-v14.7.0
     imagePullPolicy: IfNotPresent

--- a/k8s/runners/xlarge-x86-pub/release.yaml
+++ b/k8s/runners/xlarge-x86-pub/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     name: gitlab-runner
     repository: https://charts.gitlab.io
-    version: 0.37.1  # gitlab-runner@bleeding-edge
+    version: 0.37.2  # gitlab-runner@14.7.0
   values:
     image: gitlab/gitlab-runner:alpine-v14.7.0
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Pick a new Helm chart version (0.37.2) which, according to

https://artifacthub.io/packages/helm/gitlab/gitlab-runner/,

is the most recent version of the chart which provides 14.7.0.