### PR TITLE
Updates and fixes to our CronJobs

### DIFF
--- a/k8s/cdash/cron-jobs.yaml
+++ b/k8s/cdash/cron-jobs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cdash-updater

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -8,6 +8,7 @@ spec:
   schedule: "*/3 * * * *"
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         spec:
           serviceAccountName: gh-gl-sync

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: gh-gl-sync

--- a/k8s/custom/gitlab-api-scrape/cron-jobs.yaml
+++ b/k8s/custom/gitlab-api-scrape/cron-jobs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: gitlab-api-scrape

--- a/k8s/custom/rotate-keys/cron-jobs.yaml
+++ b/k8s/custom/rotate-keys/cron-jobs.yaml
@@ -39,7 +39,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: clear-admin-keys
-            image: spack/ci-key-clear:0.0.1
+            image: ghcr.io/spack/ci-key-clear:0.0.1
             imagePullPolicy: IfNotPresent
           nodeSelector:
             spack.io/node-pool: base

--- a/k8s/custom/rotate-keys/cron-jobs.yaml
+++ b/k8s/custom/rotate-keys/cron-jobs.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: rotate-gitlab-aws-access-keys
@@ -24,7 +24,7 @@ spec:
           nodeSelector:
             spack.io/node-pool: base
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: clear-admin-keys

--- a/k8s/spack/packages-spack-io/cron-jobs.yaml
+++ b/k8s/spack/packages-spack-io/cron-jobs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: spack-packages-updater

--- a/k8s/spack/www-spack-io/cron-jobs.yaml
+++ b/k8s/spack/www-spack-io/cron-jobs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: spack-io-updater


### PR DESCRIPTION
1. Pull the `ci-key-clear` image from ghcr.io (not Docker Hub)
2. Update gh-gl-sync to not recreate failed pods
3. Move out of the beta apiVersion for batch