### PR TITLE
Send deprecated entries via config.

### DIFF
--- a/k8s/runners/huge-arm-pub/release.yaml
+++ b/k8s/runners/huge-arm-pub/release.yaml
@@ -31,26 +31,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          requestConcurrency =  20
+          output_limit = 4096
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            helper_image = "gitlab/gitlab-runner-helper:arm-latest"
+            privileged = false
+            cpu_request = "46000m"
+            memory_request = "88Gi"
+            namespace = "pipeline"
+            pollTimeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.node_selector]
+              "kubernetes.io/arch" = "arm64"
+              "spack.io/node-pool" = "glr-huge-pub"
 
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 20
       locked: false
 
       tags: "arm,aarch64,graviton,graviton2,huge,public,aws,spack"
       runUntagged: false
-      privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
-
-      namespace: pipeline
-      pollTimeout: 600  # ten minutes
-
-      # build log size limit
-      outputLimit: 4096
-
-      serviceAccountName: runner
 
       # Distributed runners caching
       # TODO(opadron): Look into this after setting up stand-alone minio service
@@ -74,31 +77,11 @@ spec:
         ## Use this line for access using google-application-credentials file
         # secretName: google-application-credentials
 
-      builds:
-        cpuRequests: 46000m
-        memoryRequests: 88Gi
-
       services: {}
       # cpuRequests: 50m
       # cpuLimit: 50m
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
-
-      helpers:
-        # Without specifying image here, we got the following error when the
-        # job was run:
-        #
-        # ERROR: Job failed (system failure): prepare environment: unable to upgrade connection: container not found ("helper").
-        #
-        image: gitlab/gitlab-runner-helper:arm-latest
-      # cpuRequests: 50m
-      # cpuLimit: 50m
-      # memoryRequests: 144Mi
-      # memoryLimit: 144Mi
-
-      nodeSelector:
-        spack.io/node-pool: glr-huge-pub  # pool for jobs
-        kubernetes.io/arch: arm64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/huge-x86-pub/release.yaml
+++ b/k8s/runners/huge-x86-pub/release.yaml
@@ -31,24 +31,28 @@ spec:
     runners:
       config: |
         [[runners]]
+          requestConcurrency =  20
+          output_limit = 4096
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            privileged = false
+            cpu_request = "46000m"
+            memory_request = "88Gi"
+            namespace = "pipeline"
+            pollTimeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.node_selector]
+              "kubernetes.io/arch" = "amd64"
+              "spack.io/node-pool" = "glr-huge-pub"
 
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 20
       locked: false
 
       tags: "x86_64,avx,avx2,avx512,huge,public,aws,spack"
       runUntagged: false
-      privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
-
-      namespace: pipeline
-      pollTimeout: 600  # ten minutes
-
-      # build log size limit
-      outputLimit: 4096
 
       serviceAccountName: runner
 
@@ -74,10 +78,6 @@ spec:
         ## Use this line for access using google-application-credentials file
         # secretName: google-application-credentials
 
-      builds:
-        cpuRequests: 46000m
-        memoryRequests: 88Gi
-
       services: {}
       # cpuRequests: 50m
       # cpuLimit: 50m
@@ -89,10 +89,6 @@ spec:
       # cpuLimit: 50m
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
-
-      nodeSelector:
-        spack.io/node-pool: glr-huge-pub  # pool for jobs
-        kubernetes.io/arch: amd64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/large-arm-pub/release.yaml
+++ b/k8s/runners/large-arm-pub/release.yaml
@@ -17,7 +17,7 @@ spec:
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600  # six hours
-    concurrent: 100
+    concurrent: 20
     checkInterval: 30
     # preEntrypointScript: |
     #   echo "Hello, from large-pub runner"
@@ -31,24 +31,28 @@ spec:
     runners:
       config: |
         [[runners]]
+          requestConcurrency =  20
+          output_limit = 4096
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            helper_image = "gitlab/gitlab-runner-helper:arm-latest"
+            privileged = false
+            cpu_request = "1500m"
+            namespace = "pipeline"
+            pollTimeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.node_selector]
+              "kubernetes.io/arch" = "arm64"
+              "spack.io/node-pool" = "glr-large-pub"
 
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 20
       locked: false
 
       tags: "arm,aarch64,graviton,graviton2,large,public,aws,spack"
       runUntagged: false
-      privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
-
-      namespace: pipeline
-      pollTimeout: 600  # ten minutes
-
-      # build log size limit
-      outputLimit: 4096
 
       serviceAccountName: runner
 
@@ -74,30 +78,11 @@ spec:
         ## Use this line for access using google-application-credentials file
         # secretName: google-application-credentials
 
-      builds:
-        cpuRequests: 1500m
-
       services: {}
       # cpuRequests: 50m
       # cpuLimit: 50m
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
-
-      helpers:
-        # Without specifying image here, we got the following error when the
-        # job was run:
-        #
-        # ERROR: Job failed (system failure): prepare environment: unable to upgrade connection: container not found ("helper").
-        #
-        image: gitlab/gitlab-runner-helper:arm-latest
-      # cpuRequests: 50m
-      # cpuLimit: 50m
-      # memoryRequests: 144Mi
-      # memoryLimit: 144Mi
-
-      nodeSelector:
-        spack.io/node-pool: glr-large-pub  # pool for jobs
-        kubernetes.io/arch: arm64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/large-x86-pub/release.yaml
+++ b/k8s/runners/large-x86-pub/release.yaml
@@ -17,7 +17,7 @@ spec:
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600  # six hours
-    concurrent: 100
+    concurrent: 20
     checkInterval: 30
     # preEntrypointScript: |
     #   echo "Hello, from large-pub runner"
@@ -31,26 +31,27 @@ spec:
     runners:
       config: |
         [[runners]]
+          requestConcurrency =  20
+          output_limit = 4096
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            privileged = false
+            cpu_request = "1500m"
+            namespace = "pipeline"
+            pollTimeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.node_selector]
+              "kubernetes.io/arch" = "amd64"
+              "spack.io/node-pool" = "glr-large-pub"
 
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 20
       locked: false
 
       tags: "x86_64,avx,avx2,avx512,large,public,aws,spack"
       runUntagged: false
-      privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
-
-      namespace: pipeline
-      pollTimeout: 600  # ten minutes
-
-      # build log size limit
-      outputLimit: 4096
-
-      serviceAccountName: runner
 
       # Distributed runners caching
       # TODO(opadron): Look into this after setting up stand-alone minio service
@@ -74,9 +75,6 @@ spec:
         ## Use this line for access using google-application-credentials file
         # secretName: google-application-credentials
 
-      builds:
-        cpuRequests: 1500m
-
       services: {}
       # cpuRequests: 50m
       # cpuLimit: 50m
@@ -88,10 +86,6 @@ spec:
       # cpuLimit: 50m
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
-
-      nodeSelector:
-        spack.io/node-pool: glr-large-pub  # pool for jobs
-        kubernetes.io/arch: amd64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/large-x86-tmp-pub/release.yaml
+++ b/k8s/runners/large-x86-tmp-pub/release.yaml
@@ -33,26 +33,28 @@ spec:
     runners:
       config: |
         [[runners]]
+          requestConcurrency =  10
+          output_limit = 4096
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            privileged = false
+            cpu_request = "8000m"
+            memory_request = "15379114Ki" # 14.666 Gi
+            namespace = "pipeline"
+            pollTimeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.node_selector]
+              "kubernetes.io/arch" = "amd64"
+              "spack.io/node-pool" = "glr-huge-tmp-pubb"
 
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 10
       locked: false
 
       tags: "x86_64,avx,avx2,avx512,large,public,aws,spack"
       runUntagged: false
-      privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
-
-      namespace: pipeline
-      pollTimeout: 600  # ten minutes
-
-      # build log size limit
-      outputLimit: 4096
-
-      serviceAccountName: runner
 
       # Distributed runners caching
       # TODO(opadron): Look into this after setting up stand-alone minio service
@@ -76,10 +78,6 @@ spec:
         ## Use this line for access using google-application-credentials file
         # secretName: google-application-credentials
 
-      builds:
-        cpuRequests: 8000m
-        memoryRequests: 15379114Ki  # 14.666 Gi
-
       services: {}
       # cpuRequests: 50m
       # cpuLimit: 50m
@@ -91,10 +89,6 @@ spec:
       # cpuLimit: 50m
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
-
-      nodeSelector:
-        spack.io/node-pool: glr-huge-tmp-pub  # pool for jobs
-        kubernetes.io/arch: amd64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/medium-arm-pub/release.yaml
+++ b/k8s/runners/medium-arm-pub/release.yaml
@@ -17,7 +17,7 @@ spec:
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600  # six hours
-    concurrent: 50
+    concurrent: 20
     checkInterval: 30
     # preEntrypointScript: |
     #   echo "Hello, from medium-pub runner"
@@ -31,26 +31,28 @@ spec:
     runners:
       config: |
         [[runners]]
+          requestConcurrency =  20
+          output_limit = 4096
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            helper_image = "gitlab/gitlab-runner-helper:arm-latest"
+            privileged = false
+            cpu_request = "1050m"
+            namespace = "pipeline"
+            pollTimeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.node_selector]
+              "kubernetes.io/arch" = "arm64"
+              "spack.io/node-pool" = "glr-medium-pub"
 
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 20
       locked: false
 
       tags: "arm,aarch64,graviton,graviton2,medium,public,aws,spack"
       runUntagged: false
-      privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
-
-      namespace: pipeline
-      pollTimeout: 600  # ten minutes
-
-      # build log size limit
-      outputLimit: 4096
-
-      serviceAccountName: runner
 
       # Distributed runners caching
       # TODO(opadron): Look into this after setting up stand-alone minio service
@@ -74,30 +76,11 @@ spec:
         ## Use this line for access using google-application-credentials file
         # secretName: google-application-credentials
 
-      builds:
-        cpuRequests: 1050m
-
       services: {}
       # cpuRequests: 50m
       # cpuLimit: 50m
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
-
-      helpers:
-        # Without specifying image here, we got the following error when the
-        # job was run:
-        #
-        # ERROR: Job failed (system failure): prepare environment: unable to upgrade connection: container not found ("helper").
-        #
-        image: gitlab/gitlab-runner-helper:arm-latest
-      # cpuRequests: 50m
-      # cpuLimit: 50m
-      # memoryRequests: 144Mi
-      # memoryLimit: 144Mi
-
-      nodeSelector:
-        spack.io/node-pool: glr-medium-pub  # pool for jobs
-        kubernetes.io/arch: arm64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/medium-x86-pub/release.yaml
+++ b/k8s/runners/medium-x86-pub/release.yaml
@@ -31,26 +31,27 @@ spec:
     runners:
       config: |
         [[runners]]
+          requestConcurrency =  20
+          output_limit = 4096
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            privileged = false
+            cpu_request = "1050m"
+            namespace = "pipeline"
+            pollTimeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.node_selector]
+              "kubernetes.io/arch" = "amd64"
+              "spack.io/node-pool" = "glr-medium-pub"
 
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 20
       locked: false
 
       tags: "x86_64,avx,medium,public,aws,spack"
       runUntagged: false
-      privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
-
-      namespace: pipeline
-      pollTimeout: 600  # ten minutes
-
-      # build log size limit
-      outputLimit: 4096
-
-      serviceAccountName: runner
 
       # Distributed runners caching
       # TODO(opadron): Look into this after setting up stand-alone minio service
@@ -74,9 +75,6 @@ spec:
         ## Use this line for access using google-application-credentials file
         # secretName: google-application-credentials
 
-      builds:
-        cpuRequests: 1050m
-
       services: {}
       # cpuRequests: 50m
       # cpuLimit: 50m
@@ -88,10 +86,6 @@ spec:
       # cpuLimit: 50m
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
-
-      nodeSelector:
-        spack.io/node-pool: glr-medium-pub  # pool for jobs
-        kubernetes.io/arch: amd64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/staging/release.yaml
+++ b/k8s/runners/staging/release.yaml
@@ -33,14 +33,24 @@ data:
       path: /spec/values/checkInterval
       value: 1
     - op: replace
-      path: /spec/values/runners/requestConcurrency
-      value: 3
-    - op: replace
       path: /spec/values/runners/tags
       value: "x86_64,avx,avx2,avx512,{ENV},public,aws,spack"
     - op: replace
       path: /spec/values/runners/secret
       value: gitlab-{ENV}-gitlab-runner-secret
     - op: replace
-      path: /spec/values/runners/namespace
-      value: gitlab
+      path: /spec/values/runners/config
+      value: |
+          [[runners]]
+          requestConcurrency =  3
+          output_limit = 4096
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            privileged = false
+            cpu_request = "9000m"
+            namespace = "gitlab"
+            pollTimeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.node_selector]
+              "kubernetes.io/arch" = "amd64"
+              "spack.io/node-pool" = "glr-xlarge-pub"

--- a/k8s/runners/xlarge-arm-pub/release.yaml
+++ b/k8s/runners/xlarge-arm-pub/release.yaml
@@ -31,26 +31,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          requestConcurrency =  20
+          output_limit = 4096
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            helper_image = "gitlab/gitlab-runner-helper:arm-latest"
+            privileged = false
+            cpu_request = "9000m"
+            namespace = "pipeline"
+            pollTimeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.node_selector]
+              "kubernetes.io/arch" = "arm64"
+              "spack.io/node-pool" = "glr-xlarge-pub"
 
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 20
       locked: false
 
       tags: "arm,aarch64,graviton,graviton2,xlarge,public,aws,spack"
       runUntagged: false
       privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
-
-      namespace: pipeline
-      pollTimeout: 600  # ten minutes
-
-      # build log size limit
-      outputLimit: 4096
-
-      serviceAccountName: runner
 
       # Distributed runners caching
       # TODO(opadron): Look into this after setting up stand-alone minio service
@@ -74,9 +77,6 @@ spec:
         ## Use this line for access using google-application-credentials file
         # secretName: google-application-credentials
 
-      builds:
-        cpuRequests: 9000m
-
       services: {}
       # cpuRequests: 50m
       # cpuLimit: 50m
@@ -94,10 +94,6 @@ spec:
       # cpuLimit: 50m
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
-
-      nodeSelector:
-        spack.io/node-pool: glr-xlarge-pub  # pool for jobs
-        kubernetes.io/arch: arm64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/xlarge-x86-pub/release.yaml
+++ b/k8s/runners/xlarge-x86-pub/release.yaml
@@ -31,26 +31,27 @@ spec:
     runners:
       config: |
         [[runners]]
+          requestConcurrency =  5
+          output_limit = 4096
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            privileged = false
+            cpu_request = "9000m"
+            namespace = "pipeline"
+            pollTimeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.node_selector]
+              "kubernetes.io/arch" = "amd64"
+              "spack.io/node-pool" = "glr-xlarge-pub"
 
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
-      requestConcurrency: 20
       locked: false
 
       tags: "x86_64,avx,avx2,avx512,xlarge,public,aws,spack"
       runUntagged: false
-      privileged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
-
-      namespace: pipeline
-      pollTimeout: 600  # ten minutes
-
-      # build log size limit
-      outputLimit: 4096
-
-      serviceAccountName: runner
 
       # Distributed runners caching
       # TODO(opadron): Look into this after setting up stand-alone minio service
@@ -74,9 +75,6 @@ spec:
         ## Use this line for access using google-application-credentials file
         # secretName: google-application-credentials
 
-      builds:
-        cpuRequests: 9000m
-
       services: {}
       # cpuRequests: 50m
       # cpuLimit: 50m
@@ -88,10 +86,6 @@ spec:
       # cpuLimit: 50m
       # memoryRequests: 144Mi
       # memoryLimit: 144Mi
-
-      nodeSelector:
-        spack.io/node-pool: glr-xlarge-pub  # pool for jobs
-        kubernetes.io/arch: amd64
 
     nodeSelector:
       spack.io/node-pool: base  # pool for the runner


### PR DESCRIPTION
Eliminate the usage of several deprecated Helm variables in the
release.yaml file by setting the config.toml to contain those values
directly.

Deprecated options are marked here:
https://gitlab.com/gitlab-org/charts/gitlab-runner/-/blob/main/values.yaml
Commit SHA: 477f145bedcb68690d723826831d9c8c4f5b2d09