### PR TITLE
Add Labels and Annotations to Job Pods

### DIFF
--- a/k8s/runners/huge-arm-pub/release.yaml
+++ b/k8s/runners/huge-arm-pub/release.yaml
@@ -42,6 +42,21 @@ spec:
             namespace = "pipeline"
             pollTimeout = 600  # ten minutes
             service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "gitlab-ci/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab-ci/ci_job_url" = "$CI_JOB_URL"
+              "gitlab-ci/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab-ci/ci_job_id" = "$CI_JOB_ID"
+              "gitlab-ci/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+            [runners.kubernetes.pod_labels]
+              "gitlab-ci/ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "gitlab-ci/ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "gitlab-ci/ci_project_name" = "$CI_PROJECT_NAME"
+              "gitlab-ci/ci_job_stage" = "$CI_JOB_STAGE"
+              "gitlab-ci/ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "gitlab-ci/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "gitlab-ci/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "gitlab-ci/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "arm64"
               "spack.io/node-pool" = "glr-huge-pub"

--- a/k8s/runners/huge-x86-pub/release.yaml
+++ b/k8s/runners/huge-x86-pub/release.yaml
@@ -41,6 +41,21 @@ spec:
             namespace = "pipeline"
             pollTimeout = 600  # ten minutes
             service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "gitlab-ci/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab-ci/ci_job_url" = "$CI_JOB_URL"
+              "gitlab-ci/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab-ci/ci_job_id" = "$CI_JOB_ID"
+              "gitlab-ci/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+            [runners.kubernetes.pod_labels]
+              "gitlab-ci/ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "gitlab-ci/ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "gitlab-ci/ci_project_name" = "$CI_PROJECT_NAME"
+              "gitlab-ci/ci_job_stage" = "$CI_JOB_STAGE"
+              "gitlab-ci/ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "gitlab-ci/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "gitlab-ci/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "gitlab-ci/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "amd64"
               "spack.io/node-pool" = "glr-huge-pub"

--- a/k8s/runners/large-arm-pub/release.yaml
+++ b/k8s/runners/large-arm-pub/release.yaml
@@ -41,6 +41,21 @@ spec:
             namespace = "pipeline"
             pollTimeout = 600  # ten minutes
             service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "gitlab-ci/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab-ci/ci_job_url" = "$CI_JOB_URL"
+              "gitlab-ci/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab-ci/ci_job_id" = "$CI_JOB_ID"
+              "gitlab-ci/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+            [runners.kubernetes.pod_labels]
+              "gitlab-ci/ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "gitlab-ci/ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "gitlab-ci/ci_project_name" = "$CI_PROJECT_NAME"
+              "gitlab-ci/ci_job_stage" = "$CI_JOB_STAGE"
+              "gitlab-ci/ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "gitlab-ci/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "gitlab-ci/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "gitlab-ci/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "arm64"
               "spack.io/node-pool" = "glr-large-pub"

--- a/k8s/runners/large-x86-pub/release.yaml
+++ b/k8s/runners/large-x86-pub/release.yaml
@@ -40,6 +40,21 @@ spec:
             namespace = "pipeline"
             pollTimeout = 600  # ten minutes
             service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "gitlab-ci/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab-ci/ci_job_url" = "$CI_JOB_URL"
+              "gitlab-ci/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab-ci/ci_job_id" = "$CI_JOB_ID"
+              "gitlab-ci/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+            [runners.kubernetes.pod_labels]
+              "gitlab-ci/ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "gitlab-ci/ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "gitlab-ci/ci_project_name" = "$CI_PROJECT_NAME"
+              "gitlab-ci/ci_job_stage" = "$CI_JOB_STAGE"
+              "gitlab-ci/ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "gitlab-ci/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "gitlab-ci/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "gitlab-ci/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "amd64"
               "spack.io/node-pool" = "glr-large-pub"

--- a/k8s/runners/large-x86-tmp-pub/release.yaml
+++ b/k8s/runners/large-x86-tmp-pub/release.yaml
@@ -43,6 +43,21 @@ spec:
             namespace = "pipeline"
             pollTimeout = 600  # ten minutes
             service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "gitlab-ci/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab-ci/ci_job_url" = "$CI_JOB_URL"
+              "gitlab-ci/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab-ci/ci_job_id" = "$CI_JOB_ID"
+              "gitlab-ci/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+            [runners.kubernetes.pod_labels]
+              "gitlab-ci/ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "gitlab-ci/ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "gitlab-ci/ci_project_name" = "$CI_PROJECT_NAME"
+              "gitlab-ci/ci_job_stage" = "$CI_JOB_STAGE"
+              "gitlab-ci/ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "gitlab-ci/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "gitlab-ci/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "gitlab-ci/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "amd64"
               "spack.io/node-pool" = "glr-huge-tmp-pubb"

--- a/k8s/runners/medium-arm-pub/release.yaml
+++ b/k8s/runners/medium-arm-pub/release.yaml
@@ -41,6 +41,21 @@ spec:
             namespace = "pipeline"
             pollTimeout = 600  # ten minutes
             service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "gitlab-ci/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab-ci/ci_job_url" = "$CI_JOB_URL"
+              "gitlab-ci/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab-ci/ci_job_id" = "$CI_JOB_ID"
+              "gitlab-ci/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+            [runners.kubernetes.pod_labels]
+              "gitlab-ci/ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "gitlab-ci/ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "gitlab-ci/ci_project_name" = "$CI_PROJECT_NAME"
+              "gitlab-ci/ci_job_stage" = "$CI_JOB_STAGE"
+              "gitlab-ci/ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "gitlab-ci/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "gitlab-ci/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "gitlab-ci/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "arm64"
               "spack.io/node-pool" = "glr-medium-pub"

--- a/k8s/runners/medium-x86-pub/release.yaml
+++ b/k8s/runners/medium-x86-pub/release.yaml
@@ -40,6 +40,21 @@ spec:
             namespace = "pipeline"
             pollTimeout = 600  # ten minutes
             service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "gitlab-ci/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab-ci/ci_job_url" = "$CI_JOB_URL"
+              "gitlab-ci/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab-ci/ci_job_id" = "$CI_JOB_ID"
+              "gitlab-ci/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+            [runners.kubernetes.pod_labels]
+              "gitlab-ci/ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "gitlab-ci/ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "gitlab-ci/ci_project_name" = "$CI_PROJECT_NAME"
+              "gitlab-ci/ci_job_stage" = "$CI_JOB_STAGE"
+              "gitlab-ci/ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "gitlab-ci/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "gitlab-ci/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "gitlab-ci/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "amd64"
               "spack.io/node-pool" = "glr-medium-pub"

--- a/k8s/runners/staging/release.yaml
+++ b/k8s/runners/staging/release.yaml
@@ -51,6 +51,21 @@ data:
             namespace = "gitlab"
             pollTimeout = 600  # ten minutes
             service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "gitlab-ci/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab-ci/ci_job_url" = "$CI_JOB_URL"
+              "gitlab-ci/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab-ci/ci_job_id" = "$CI_JOB_ID"
+              "gitlab-ci/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+            [runners.kubernetes.pod_labels]
+              "gitlab-ci/ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "gitlab-ci/ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "gitlab-ci/ci_project_name" = "$CI_PROJECT_NAME"
+              "gitlab-ci/ci_job_stage" = "$CI_JOB_STAGE"
+              "gitlab-ci/ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "gitlab-ci/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "gitlab-ci/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "gitlab-ci/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "amd64"
               "spack.io/node-pool" = "glr-xlarge-pub"

--- a/k8s/runners/xlarge-arm-pub/release.yaml
+++ b/k8s/runners/xlarge-arm-pub/release.yaml
@@ -41,6 +41,21 @@ spec:
             namespace = "pipeline"
             pollTimeout = 600  # ten minutes
             service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "gitlab-ci/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab-ci/ci_job_url" = "$CI_JOB_URL"
+              "gitlab-ci/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab-ci/ci_job_id" = "$CI_JOB_ID"
+              "gitlab-ci/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+            [runners.kubernetes.pod_labels]
+              "gitlab-ci/ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "gitlab-ci/ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "gitlab-ci/ci_project_name" = "$CI_PROJECT_NAME"
+              "gitlab-ci/ci_job_stage" = "$CI_JOB_STAGE"
+              "gitlab-ci/ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "gitlab-ci/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "gitlab-ci/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "gitlab-ci/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "arm64"
               "spack.io/node-pool" = "glr-xlarge-pub"

--- a/k8s/runners/xlarge-x86-pub/release.yaml
+++ b/k8s/runners/xlarge-x86-pub/release.yaml
@@ -40,6 +40,21 @@ spec:
             namespace = "pipeline"
             pollTimeout = 600  # ten minutes
             service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "gitlab-ci/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab-ci/ci_job_url" = "$CI_JOB_URL"
+              "gitlab-ci/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab-ci/ci_job_id" = "$CI_JOB_ID"
+              "gitlab-ci/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+            [runners.kubernetes.pod_labels]
+              "gitlab-ci/ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "gitlab-ci/ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "gitlab-ci/ci_project_name" = "$CI_PROJECT_NAME"
+              "gitlab-ci/ci_job_stage" = "$CI_JOB_STAGE"
+              "gitlab-ci/ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "gitlab-ci/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "gitlab-ci/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "gitlab-ci/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "amd64"
               "spack.io/node-pool" = "glr-xlarge-pub"


### PR DESCRIPTION
Adds annotations and labels to pods running the pipeline namespace. These are mostly pulled from the Job variables,  but include a few `SPACK_*` specific variables for propagation down into the metrics labels which will be a follow on PR