### PR TITLE
(SpackCIBridge) Stop posting duplicate statuses to commits

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -26,7 +26,7 @@ jobs:
           context: ./images/gh-gl-sync
           file: ./images/gh-gl-sync/Dockerfile
           push: true
-          tags: ghcr.io/spack/ci-bridge:0.0.24
+          tags: ghcr.io/spack/ci-bridge:0.0.25
       -
         name: Image digest
         run: echo ${{ steps.docker_build_sync.outputs.digest }}

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -114,6 +114,9 @@ class SpackCIBridge(object):
         pulls = self.py_gh_repo.get_pulls(state="open")
         print("Rate limit after get_pulls(): {}".format(self.py_github.rate_limiting[0]))
         for pull in pulls:
+            if pull.draft:
+                print("Skipping draft PR {0} ({1})".format(pull.number, pull.head.ref))
+                continue
             if not pull.merge_commit_sha:
                 print("PR {0} ({1}) has no 'merge_commit_sha', skipping".format(pull.number, pull.head.ref))
                 self.unmergeable_shas.append(pull.head.sha)

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -126,7 +126,8 @@ class SpackCIBridge(object):
             push = True
             log_args = ["git", "log", "--pretty=%s", "gitlab/github/{0}".format(pr_string)]
             try:
-                merge_commit_msg = subprocess.run(log_args, check=True, stdout=subprocess.PIPE).stdout
+                merge_commit_msg = subprocess.run(
+                    log_args, check=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout
                 match = self.merge_msg_regex.match(merge_commit_msg.decode("utf-8"))
                 if match and match.group(1) == pull.head.sha:
                     print("Skip pushing {0} because GitLab already has HEAD {1}".format(pr_string, pull.head.sha))

--- a/images/gh-gl-sync/test_SpackCIBridge.py
+++ b/images/gh-gl-sync/test_SpackCIBridge.py
@@ -22,6 +22,7 @@ def test_list_github_prs(capfd):
     github_pr_response = [
         AttrDict({
             "number": 1,
+            "draft": False,
             "merge_commit_sha": "aaaaaaaa",
             "head": {
                 "ref": "improve_docs",
@@ -33,6 +34,7 @@ def test_list_github_prs(capfd):
         }),
         AttrDict({
             "number": 2,
+            "draft": False,
             "merge_commit_sha": "bbbbbbbb",
             "head": {
                 "ref": "fix_test",
@@ -40,6 +42,18 @@ def test_list_github_prs(capfd):
             },
             "base": {
                 "sha": "shafaz"
+            }
+        }),
+        AttrDict({
+            "number": 3,
+            "draft": True,
+            "merge_commit_sha": "cccccccc",
+            "head": {
+                "ref": "wip",
+                "sha": "shafff"
+            },
+            "base": {
+                "sha": "shaggg"
             }
         }),
     ]
@@ -64,6 +78,7 @@ def test_list_github_prs(capfd):
     out, err = capfd.readouterr()
     expected = """Rate limit after get_pulls(): 5000
 Skip pushing pr2_fix_test because GitLab already has HEAD shagah
+Skipping draft PR 3 (wip)
 All Open PRs:
     pr1_improve_docs
     pr2_fix_test
@@ -458,6 +473,7 @@ def test_pipeline_status_backlogged_by_checks(capfd):
         github_pr_response = [
             AttrDict({
                 "number": 1,
+                "draft": False,
                 "merge_commit_sha": "aaaaaaaa",
                 "head": {
                     "ref": "improve_docs",

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gh-gl-sync
   namespace: custom
 spec:
-  schedule: "*/3 * * * *"
+  schedule: "*/4 * * * *"
   jobTemplate:
     spec:
       backoffLimit: 0

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.24
+            image: ghcr.io/spack/ci-bridge:0.0.25
             imagePullPolicy: IfNotPresent
             env:
             - name: GITHUB_TOKEN


### PR DESCRIPTION
Up until now, we've been unconditionally posting status to commits on GitHub. If we post too many statuses to a single commit then GitHub will not allow us to update it later. This causes a PR to be blocked until we manually intervene.

Other things this PR does:

* Print messages about our rate limit usage
* Cache calls to the ["get a commit" GitHub API endpoint](https://docs.github.com/en/rest/reference/commits#get-a-commit) in an effort to preserve our rate limit
* Suppress irrelevant errors emanating from `git log`
* Don't use GitLab CI to test draft PRs
* Reduce our cron job frequency from 3 minutes to 4 minutes in another attempt to preserve our rate limit