### PR TITLE
add count-nodes script

### DIFF
--- a/scripts/count-nodes.sh
+++ b/scripts/count-nodes.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+template="{{ range .items }}{{ with .metadata.labels }}\
+{{ index . \"topology.kubernetes.io/zone\" }} \
+{{ index . \"spack.io/node-pool\" }}
+{{ end }}{{ end }}"
+
+exec kubectl get nodes -o go-template="$template" | sort | uniq -c


### PR DESCRIPTION
Adds a small utility script that we can run to get a breakdown of how many nodes of each availability zone - node pool combination are registered.

#### Example: 

```
./count-nodes.sh
      2 us-east-1a base
      1 us-east-1a beefy
      1 us-east-1a gitlab
      3 us-east-1b base
      2 us-east-1b gitlab
      3 us-east-1c base
      1 us-east-1c gitlab
      3 us-east-1d base
      2 us-east-1d gitlab
      1 us-east-1d glr-glr-testing
```