### PR TITLE
Add AWS node termination handler

### DIFF
--- a/k8s/aws-node-termination-handler/release.yaml
+++ b/k8s/aws-node-termination-handler/release.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: aws-node-termination-handler
+  namespace: kube-system
+spec:
+  releaseName: aws-node-termination-handler
+  chart:
+    name: aws-node-termination-handler
+    repository: https://aws.github.io/eks-charts
+    version: 0.18.0  # aws-node-termination-handler@1.16.0
+  values:
+    # emitKubernetesEvents If true, Kubernetes events will be emitted
+    # when interruption events are received and when actions are taken on
+    # Kubernetes nodes. In IMDS Processor mode a default set of
+    # annotations with all the node metadata gathered from IMDS will be
+    # attached to each event
+    emitKubernetesEvents: true

--- a/k8s/helm-operator/release.yaml
+++ b/k8s/helm-operator/release.yaml
@@ -40,3 +40,5 @@ spec:
           url: https://prometheus-community.github.io/helm-charts
         - name: aws-efs-csi-driver
           url: https://kubernetes-sigs.github.io/aws-efs-csi-driver
+        - name: aws-eks
+          url: https://aws.github.io/eks-charts


### PR DESCRIPTION
Daemonset that will monitor for termination events (such as in the case of Spot interruption) and gracefully drain a node before the instance is terminated.