### PR TITLE
Config Grafana for Github Oauth

### DIFF
--- a/k8s/prometheus/ingress.yaml
+++ b/k8s/prometheus/ingress.yaml
@@ -57,9 +57,9 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
-    nginx.ingress.kubernetes.io/auth-tls-secret: "ingress-nginx/client-ca"
+#  annotations:
+#    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+#    nginx.ingress.kubernetes.io/auth-tls-secret: "ingress-nginx/client-ca"
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack

--- a/k8s/prometheus/release.yaml
+++ b/k8s/prometheus/release.yaml
@@ -35,6 +35,46 @@ spec:
     grafana:
       ingress:
         enabled: false
+      admin:
+        existingSecret: "kube-prometheus-stack-grafana" # See: secrets.yaml
+        userKey: admin-user
+        passwordKey: admin-password
+      grafana.ini:
+        paths:
+          data: /var/lib/grafana/
+          logs: /var/log/grafana
+          plugins: /var/lib/grafana/plugins
+          provisioning: /etc/grafana/provisioning
+        analytics:
+          check_for_updates: true
+        log:
+          mode: console
+        grafana_net:
+          url: https://grafana.net
+        server:
+          root_url: https://grafana.spack.io
+        auth.github:
+          enabled: true
+          allow_sign_up: true
+          scopes: user:email,read:org
+          auth_url: https://github.com/login/oauth/authorize
+          token_url: https://github.com/login/oauth/access_token
+          api_url: https://api.github.com/user
+#          team_ids:
+          allowed_organizations: spack
+          client_id: DEADBEEF # Will be overriden by environment vars
+          client_secret: DEADBEEF # Will be overriden by environment vars
+
+      envValueFrom:
+        GF_AUTH_GITHUB_CLIENT_ID:
+          secretKeyRef:
+            name: grafana-github-oauth-client
+            key: client-id
+        GF_AUTH_GITHUB_CLIENT_SECRET:
+          secretKeyRef:
+            name: grafana-github-oauth-client
+            key: client-secret
+
 
     prometheus:
       ingress:

--- a/k8s/prometheus/secrets.yaml
+++ b/k8s/prometheus/secrets.yaml
@@ -8,3 +8,28 @@ metadata:
       fluxcd.io/ignore: "true"
 data:
   webhook: DEADBEEF  # fake-secret
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    fluxcd.io/ignore: "true"
+  name: kube-prometheus-stack-grafana
+  namespace: monitoring
+data:
+  admin-password: DEADBEEF # fake-secret
+  admin-user: DEADBEEF # fake-secret
+  ldap-toml: ""
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    fluxcd.io/ignore: "true"
+  name: grafana-github-oauth-client
+  namespace: monitoring
+data:
+  client-id: DEADBEEF # fake-secret
+  client-secret: DEADBEEF # fake-secret


### PR DESCRIPTION
This allows authentication with https://grafana.spack.io/  via GitHub OAuth provided you're a member of the `spack` organization. 