### PR TITLE
update ingress and prometheus releases so that they talk to each other

### DIFF
--- a/k8s/ingress-nginx/release.yaml
+++ b/k8s/ingress-nginx/release.yaml
@@ -77,6 +77,7 @@ spec:
 
         serviceMonitor:
           enabled: true
+          namespace: monitoring
           additionalLabels:
             # must match the name of the prometheus release
             release: kube-prometheus-stack

--- a/k8s/ingress-nginx/release.yaml
+++ b/k8s/ingress-nginx/release.yaml
@@ -77,6 +77,9 @@ spec:
 
         serviceMonitor:
           enabled: true
+          additionalLabels:
+            # must match the name of the prometheus release
+            release: kube-prometheus-stack
 
     ## Default 404 backend
     defaultBackend:

--- a/k8s/prometheus/release.yaml
+++ b/k8s/prometheus/release.yaml
@@ -89,6 +89,8 @@ spec:
               resources:
                 requests:
                   storage: 200Gi
+        podMonitorSelectorNilUsesHelmValues: false
+        serviceMonitorSelectorNilUsesHelmValues: false
         nodeSelector:
           spack.io/node-pool: beefy
 


### PR DESCRIPTION
Follows the instructions at

https://kubernetes.github.io/ingress-nginx/user-guide/monitoring/#prometheus-and-grafana-installation-using-service-monitors

 1. Merge this PR
 2. Confirm that the changes worked
 3. Import Grafana dashboard as detailed near the bottom of the instructions linked above