### PR TITLE
Hotfix: fix runner tags

### DIFF
--- a/k8s/runners/large-x86-pub/release.yaml
+++ b/k8s/runners/large-x86-pub/release.yaml
@@ -75,7 +75,7 @@ spec:
       imagePullPolicy: "if-not-present"
       locked: false
 
-      tags: "x86_64,avx,avx2,avx512,large,public,aws,spack"
+      tags: "x86_64,avx,avx2,avx512,small,medium,large,huge,public,aws,spack"
       runUntagged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
 

--- a/k8s/runners/large-x86-testing-pub/release.yaml
+++ b/k8s/runners/large-x86-testing-pub/release.yaml
@@ -74,7 +74,7 @@ spec:
       imagePullPolicy: "if-not-present"
       locked: false
 
-      tags: "x86_64,avx,avx2,avx512,large,public,aws,spack,testing"
+      tags: "testing"
       runUntagged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
 

--- a/k8s/runners/staging/release.yaml
+++ b/k8s/runners/staging/release.yaml
@@ -21,6 +21,9 @@ data:
       path: /spec/releaseName
       value: runner-{ENV}
     - op: replace
+      path: /spec/values/replicas
+      value: 1
+    - op: replace
       path: /spec/values/gitlabUrl
       value: "https://gitlab.{ENV}.spack.io/"
     - op: replace
@@ -34,7 +37,7 @@ data:
       value: 1
     - op: replace
       path: /spec/values/runners/tags
-      value: "x86_64,avx,avx2,avx512,{ENV},public,aws,spack"
+      value: "x86_64,avx,avx2,avx512,small,medium,large,huge,{ENV},public,aws,spack"
     - op: replace
       path: /spec/values/runners/secret
       value: gitlab-{ENV}-gitlab-runner-secret


### PR DESCRIPTION
Also fixes a minor oversight returning our staging runner to one replica.