### PR TITLE
Look for stuck pipelines and run a new pipeline on the branch

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -231,3 +231,29 @@ jobs:
       -
         name: Image digest
         run: echo ${{ steps.docker_build_gitops.outputs.digest }}
+
+  unstick-pipelines:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Login to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push gitlab-clear-pipelines
+        id: docker_build_gitlab_clear_pipelines
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./images/gitlab-clear-pipelines
+          file: ./images/gitlab-clear-pipelines/Dockerfile
+          push: true
+          tags: ghcr.io/spack/gitlab-clear-pipelines:0.0.1
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build_gitlab_clear_pipelines.outputs.digest }}

--- a/images/gitlab-clear-pipelines/Dockerfile
+++ b/images/gitlab-clear-pipelines/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+WORKDIR /scripts/
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY cancel_and_restart_stuck_pipelines.py ./
+
+ENTRYPOINT [ "python", "./cancel_and_restart_stuck_pipelines.py"]

--- a/images/gitlab-clear-pipelines/README.md
+++ b/images/gitlab-clear-pipelines/README.md
@@ -1,0 +1,15 @@
+# Purpose
+
+The purpose of this cronjob is to find and cancel gitlab pipelines that have become mystyeriously "stuck" as well as to run a new pipeline on the affected branch.
+
+## Background
+
+This [issue](https://github.com/spack/spack-infrastructure/issues/239) describes the problem.
+
+## Cause
+
+At the moment we are investigating whether an overloaded ingress controller has correlation with this behavior, but so far have found no concrete evidence of any cause.
+
+## Mitigation
+
+Run a cronjob that periodically looks for pipelines older than some threshold, and cancel them (dynamic child pipelines must be found and canceled specifically as well).  Also, blindly attempt to run a new pipeline on the affected branch (i.e. do not first check whether the branch still exists in gitlab or has been deleted by the gh-gl-sync cronjob).

--- a/images/gitlab-clear-pipelines/cancel_and_restart_stuck_pipelines.py
+++ b/images/gitlab-clear-pipelines/cancel_and_restart_stuck_pipelines.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import os
+import urllib.parse
+from datetime import datetime
+
+import requests
+
+
+GITLAB_API_URL = "https://gitlab.spack.io/api/v4/projects/2"
+TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+AUTH_HEADER = {
+    "PRIVATE-TOKEN": os.environ.get("GITLAB_TOKEN", None)
+}
+
+
+def paginate(query_url):
+    """Helper method to get all pages of paginated query results"""
+    results = []
+
+    while query_url:
+        resp = requests.get(query_url, headers=AUTH_HEADER)
+
+        if resp.status_code == 401:
+            print(" !!! Unauthorized to make request, check GITLAB_TOKEN !!!")
+            return []
+
+        next_batch = json.loads(resp.content)
+
+        for result in next_batch:
+            results.append(result)
+
+        if "next" in resp.links:
+            query_url = resp.links["next"]["url"]
+        else:
+            query_url = None
+
+    return results
+
+
+def print_response(resp, padding=''):
+    """Helper method to print response status code and content"""
+    print(f"{padding}response code: {resp.status_code}")
+    print(f"{padding}response value: {resp.text}")
+
+
+def run_new_pipeline(pipeline_ref):
+    """Given a ref (branch name), run a new pipeline for that ref.  If
+    the branch has already been deleted from gitlab, this will generate
+    an error and a 400 response, but we probably don't care."""
+    enc_ref = urllib.parse.quote_plus(pipeline_ref)
+    run_url = f"{GITLAB_API_URL}/pipeline?ref={enc_ref}"
+    print(f"    running new pipeline for {pipeline_ref}")
+    print_response(requests.post(run_url, headers=AUTH_HEADER), "      ")
+
+
+def cancel_downstream_pipelines(pipeline_id):
+    """Given a pipeline id, query gitlab for its downstream pipelines
+    and cancel them one at a time.  Once all the child pipelines are
+    canceled, also cancel the parent pipeline."""
+    bridges_url = f"{GITLAB_API_URL}/pipelines/{pipeline_id}/bridges"
+    bridge_jobs = paginate(bridges_url)
+
+    for bridge in bridge_jobs:
+        if "downstream_pipeline" in bridge and bridge["downstream_pipeline"]:
+            child_pipeline = bridge["downstream_pipeline"]
+            child_pid = child_pipeline["id"]
+            print(f"    canceling child pipeline {child_pid}")
+            cancel_url = f"{GITLAB_API_URL}/pipelines/{child_pid}/cancel"
+            print_response(requests.post(cancel_url, headers=AUTH_HEADER), "      ")
+
+    print(f"    canceling parent pipeline {pipeline_id}")
+    cancel_url = f"{GITLAB_API_URL}/pipelines/{pipeline_id}/cancel"
+    print_response(requests.post(cancel_url, headers=AUTH_HEADER), "      ")
+
+
+def cancel_and_restart_stuck_pipelines(num_days=0):
+    """Query gitlab for all running pipelines.  For any pipeline that is
+    more than 1 day old, run a new pipeline on the assocatied ref/branch,
+    and then  cancel the pipeline as well as its downstream child
+    pipelines.  Any pipeolines created fewer than num_days ago will
+    be ignored."""
+    print(f"Attempting to cancel and retry pipelines older than {num_days} days")
+
+    time_now = datetime.utcnow()
+
+    pipelines_url = f"{GITLAB_API_URL}/pipelines?status=running"
+    running_pipelines = paginate(pipelines_url)
+
+    print(f"Retrieved {len(running_pipelines)} pipelines:")
+    for pipeline in running_pipelines:
+        p_id = pipeline["id"]
+        p_ref = pipeline["ref"]
+        p_created = pipeline["created_at"]
+
+        time_pipeline = datetime.strptime(p_created, TIME_FORMAT)
+        elapsed_days = (time_now - time_pipeline).days
+
+        if elapsed_days > num_days:
+            print(f"  Cleaning up stuck pipeline {p_id} created at {p_created}")
+            run_new_pipeline(p_ref)
+            cancel_downstream_pipelines(p_id)
+        else:
+            print(f"  Ignoring pipeline {p_id} created at {p_created}")
+
+
+if __name__ == "__main__":
+    if "GITLAB_TOKEN" not in os.environ:
+        raise Exception("GITLAB_TOKEN environment is not set")
+
+    parser = argparse.ArgumentParser(description="Find stuck pipelines to cancel and restart")
+    parser.add_argument("--num-days", default=0, type=int,
+                        help="Ignore pipelines created fewer than this many days ago")
+    args = parser.parse_args()
+
+    try:
+        cancel_and_restart_stuck_pipelines(args.num_days)
+    except Exception as inst:
+        print("Caught unhandled exception:")
+        print(inst)

--- a/images/gitlab-clear-pipelines/requirements.txt
+++ b/images/gitlab-clear-pipelines/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/k8s/custom/unstick-pipelines/cron-jobs.yaml
+++ b/k8s/custom/unstick-pipelines/cron-jobs.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cancel-and-restart-stuck-pipelines
+  namespace: custom
+spec:
+  schedule: "0 */3 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: cancel-and-restart-stuck-pipelines
+            image: ghcr.io/spack/gitlab-clear-pipelines:0.0.1
+            imagePullPolicy: IfNotPresent
+            env:
+            - name: GITLAB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: gitlab-clear-pipelines
+                  key: gitlab-token
+            args:
+              - "--num-days"
+              - "0"
+          nodeSelector:
+            spack.io/node-pool: base

--- a/k8s/custom/unstick-pipelines/secrets-dummy.yml
+++ b/k8s/custom/unstick-pipelines/secrets-dummy.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  gitlab-token: |
+    # result of:
+    echo -n ${gitlab_token} | base64
+kind: Secret
+metadata:
+  name: gitlab-clear-pipelines
+  namespace: custom
+  annotations:
+    fluxcd.io/ignore: "true"
+type: Opaque


### PR DESCRIPTION
Query gitlab for running pipelines that were created more than
a day ago and try to run a new pipeline on the ref associated
with each stuck pipeline.  Also query for the pipelines child
pipelines, and try to cancel each one before finally canceling
the parent.