### PR TITLE
Drop the maximum values to match runner's specs

### DIFF
--- a/k8s/runners/large-x86-pub/release.yaml
+++ b/k8s/runners/large-x86-pub/release.yaml
@@ -38,14 +38,14 @@ spec:
             privileged = false
 
             cpu_request = "750m"
-            cpu_request_overwrite_max_allowed = "16"
-            cpu_limit = "16"
-            cpu_limit_overwrite_max_allowed = "16"
+            cpu_request_overwrite_max_allowed = "12"
+            cpu_limit = "12"
+            cpu_limit_overwrite_max_allowed = "12"
 
             memory_request = "2G"
-            memory_request_overwrite_max_allowed = "64G"
-            memory_limit = "64G"
-            memory_limit_overwrite_max_allowed = "64G"
+            memory_request_overwrite_max_allowed = "48G"
+            memory_limit = "48G"
+            memory_limit_overwrite_max_allowed = "48G"
 
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes

--- a/k8s/runners/large-x86-testing-pub/release.yaml
+++ b/k8s/runners/large-x86-testing-pub/release.yaml
@@ -37,14 +37,14 @@ spec:
             privileged = false
 
             cpu_request = "750m"
-            cpu_request_overwrite_max_allowed = "16"
-            cpu_limit = "16"
-            cpu_limit_overwrite_max_allowed = "16"
+            cpu_request_overwrite_max_allowed = "12"
+            cpu_limit = "12"
+            cpu_limit_overwrite_max_allowed = "12"
 
             memory_request = "2G"
-            memory_request_overwrite_max_allowed = "64G"
-            memory_limit = "64G"
-            memory_limit_overwrite_max_allowed = "64G"
+            memory_request_overwrite_max_allowed = "48G"
+            memory_limit = "48G"
+            memory_limit_overwrite_max_allowed = "48G"
 
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes


### PR DESCRIPTION
The x86 runners run on `m5zn.3xlarge` instances which have a memory
limit of 48GB, match the runners maximum to that.

The same change needs to occur for CPU, as the instance has 12 CPU
available, not 16.