### PR TITLE
Add level tags to the large x86_64 runner

### DIFF
--- a/k8s/runners/large-x86-pub/release.yaml
+++ b/k8s/runners/large-x86-pub/release.yaml
@@ -75,7 +75,7 @@ spec:
       imagePullPolicy: "if-not-present"
       locked: false
 
-      tags: "x86_64,avx,avx2,avx512,small,medium,large,huge,public,aws,spack"
+      tags: "x86_64,x86_64_v2,x86_64_v3,x86_64_v4,avx,avx2,avx512,small,medium,large,huge,public,aws,spack"
       runUntagged: false
       secret: gitlab-gitlab-runner-secret  # from gitlab release
 


### PR DESCRIPTION
I think it's true that if a processor supports `avx512`, then it supports all of these.  Correct me if I'm wrong though. 