### PR TITLE
Create an image for the merging of per-stack mirrors

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -283,3 +283,29 @@ jobs:
       -
         name: Image digest
         run: echo ${{ steps.docker_build_gitops.outputs.digest }}
+
+  python-aws-bash:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Login to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push gitops
+        id: docker_build_gitops
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./images/python-aws-bash
+          file: ./images/python-aws-bash/Dockerfile
+          push: true
+          tags: ghcr.io/spack/python-aws-bash:0.0.1
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build_gitops.outputs.digest }}

--- a/images/python-aws-bash/Dockerfile
+++ b/images/python-aws-bash/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+# bug in spack s3 handling requires older botocore:
+#     https://github.com/spack/spack/issues/28830
+RUN pip install --upgrade \
+    awscli==1.22.46 \
+    boto3==1.20.35 \
+    botocore==1.23.46
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
This image can be used at the end of each pipeline to copy the
binary packages up to the mirror root (or wherever), and at the
end of all pipelines to rebuild the spack binary index.