### PR TITLE
Revert "Distributed MinIO for GitLab"

### DIFF
--- a/k8s/gitlab/release.yaml
+++ b/k8s/gitlab/release.yaml
@@ -96,8 +96,6 @@ spec:
         spack.io/node-pool: gitlab
       persistence:
         size: 1000Gi
-      mode: distributed
-      replicas: 4
 
     registry:
       ingress:


### PR DESCRIPTION
Reverting @zackgalbreath's PR setting minio to distributed mode since the changes are not actually supported by the helm charts.

This reverts commit c6183ddb412a64f084cb8fd884e595b0d6e3da4c.