### PR TITLE
runners: add level tags to protected x86 runners

### DIFF
--- a/k8s/runners/large-x86-prot/release.yaml
+++ b/k8s/runners/large-x86-prot/release.yaml
@@ -84,7 +84,7 @@ spec:
       protected: true
       runUntagged: false
 
-      tags: "x86_64,avx,avx2,avx512,small,medium,large,huge,protected,aws,spack"
+      tags: "x86_64,x86_64_v2,x86_64_v3,x86_64_v4,avx,avx2,avx512,small,medium,large,huge,protected,aws,spack"
       secret: spack-project-runner-registration-token
 
       serviceAccountName: runner


### PR DESCRIPTION
Need these for the aws stacks coming through soon.