### PR TITLE
update staging gitlab release / fix migrate-pvc.py script (Push to Production)

### DIFF
--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -72,8 +72,12 @@ data:
       value: 3
     - op: remove
       path: /spec/values/gitlab/gitlab-shell/service
-    - op: remove
-      path: /spec/values/postgresql/persistence
+    - op: replace
+      path: /spec/values/postgresql/persistence/size
+      value: 8Gi
+    - op: replace
+      path: /spec/values/postgresql/persistence/storageClass
+      value: gp3-small
     - op: replace
       path: /spec/values/postgresql/master/podLabels/spack.io~1environment
       value: "{ENV}"

--- a/scripts/migrate-pvc.py
+++ b/scripts/migrate-pvc.py
@@ -375,8 +375,8 @@ def main(inputf):
 
     # query new PVC metadata
     proc = kubectl(
-            ['get', 'persistentvolumeclaim', orig_pvc_name,
-              '-o', 'jsonpath={.metadata}'],
+            ['get', 'persistentvolumeclaim', '--namespace', namespace,
+                orig_pvc_name, '-o', 'jsonpath={.metadata}'],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     outs, errs = proc.communicate()
 
@@ -426,7 +426,6 @@ def main(inputf):
             break
 
         time.sleep(5)
-
 
     if old_pv_reclaim_policy != 'Retain':
         # restore original PV retention policy
@@ -499,8 +498,8 @@ def main(inputf):
 
         # query new PVC metadata
         proc = kubectl(
-                ['get', 'persistentvolumeclaim', answer,
-                  '-o', 'jsonpath={.metadata}'],
+                ['get', 'persistentvolumeclaim', '--namespace', namespace,
+                    answer, '-o', 'jsonpath={.metadata}'],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         outs, errs = proc.communicate()
 


### PR DESCRIPTION
Updates the staging gitlab release to explicitly reference the new `gp3-small` storage class (suitable for PVCs with size >= 1Gi and size <= 32Gi).

Also, fixes an issue with the `migrate-pvc.py` script where some of its query operations did not pass the right kubernetes namespace to `kubectl`.