### PR TITLE
Gitlab PostgreSQL RDS migration

### DIFF
--- a/k8s/gitlab/release.yaml
+++ b/k8s/gitlab/release.yaml
@@ -60,7 +60,15 @@ spec:
 
       psql:
         connectTimeout:
-        password: {}
+        host:
+          secret: gitlab-secrets
+          key: postgres-hostname
+        password:
+          secret: gitlab-secrets
+          key: postgres-password
+        port: 5432
+        database: gitlabhq_production
+        username: gitlab
 
       redis:
         password:
@@ -172,56 +180,4 @@ spec:
           spack.io/node-pool: gitlab
 
     postgresql:
-      replication:
-        enabled: true
-        slaveReplicas: 4
-        synchronousCommit: "on"
-      shmVolume:
-        enabled: true
-      master:
-        podLabels:
-          spack.io/environment: production
-          spack.io/release: gitlab
-          spack.io/app: postgresql
-        affinity:
-          podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              - topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchExpressions:
-                    - key: spack.io/environment
-                      operator: In
-                      values: [production]
-                    - key: spack.io/release
-                      operator: In
-                      values: [gitlab]
-                    - key: spack.io/app
-                      operator: In
-                      values: [postgresql]
-        nodeSelector:
-          spack.io/node-pool: gitlab
-      slave:
-        podLabels:
-          spack.io/environment: production
-          spack.io/release: gitlab
-          spack.io/app: postgresql
-        affinity:
-          podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              - topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchExpressions:
-                    - key: spack.io/environment
-                      operator: In
-                      values: [production]
-                    - key: spack.io/release
-                      operator: In
-                      values: [gitlab]
-                    - key: spack.io/app
-                      operator: In
-                      values: [postgresql]
-        nodeSelector:
-          spack.io/node-pool: gitlab
-      persistence:
-        storageClass: gp3
-        size: 100Gi
+      install: false

--- a/k8s/gitlab/secrets.yaml
+++ b/k8s/gitlab/secrets.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitlab-secrets
+  namespace: gitlab
+stringData:
+  postgres-hostname: rds.example.com # fake hostname
+  postgres-password: password # fake password

--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -38,8 +38,6 @@ data:
       path: /spec/values/global/email/reply_to
       value: noreply@gitlab.{ENV}.spack.io
     - op: remove
-      path: /spec/values/global/psql
-    - op: remove
       path: /spec/values/global/redis
     - op: remove
       path: /spec/values/global/minio
@@ -73,26 +71,8 @@ data:
     - op: remove
       path: /spec/values/gitlab/gitlab-shell/service
     - op: replace
-      path: /spec/values/postgresql/persistence/size
-      value: 8Gi
+      path: /spec/values/global/psql/host/secret
+      value: gitlab-{ENV}-secrets
     - op: replace
-      path: /spec/values/postgresql/persistence/storageClass
-      value: gp3-small
-    - op: replace
-      path: /spec/values/postgresql/master/podLabels/spack.io~1environment
-      value: "{ENV}"
-    - op: replace
-      path: "\
-         /spec/values/postgresql/master/affinity/podAntiAffinity\
-         /requiredDuringSchedulingIgnoredDuringExecution/0/labelSelector\
-         /matchExpressions/0/values/0"
-      value: "{ENV}"
-    - op: replace
-      path: /spec/values/postgresql/slave/podLabels/spack.io~1environment
-      value: "{ENV}"
-    - op: replace
-      path: "\
-         /spec/values/postgresql/slave/affinity/podAntiAffinity\
-         /requiredDuringSchedulingIgnoredDuringExecution/0/labelSelector\
-         /matchExpressions/0/values/0"
-      value: "{ENV}"
+      path: /spec/values/global/psql/password/secret
+      value: gitlab-{ENV}-secrets


### PR DESCRIPTION
Gitlab's guide to using an external DB: https://docs.gitlab.com/charts/advanced/external-db/

First, we'll test out the RDS migration in staging. Note, because we likely do not want to maintain/pay for an additional postgres RDS instance for staging, an additional PR will be merged after this one that re-enables the in-cluster postgres DB for staging.

Steps:

- [x] Backup the gitlab staging database with the following command:
```sh
kubectl exec -it gitlab-staging-postgresql-master-0 -n gitlab -- bash -c "PGPASSWORD=<db_password> pg_dump -U gitlab -d gitlabhq_production" > dump.sql
```
- [x] Create an RDS database through the AWS console with the following settings:
  - Standard create
  - PostgreSQL (select latest version)
  - Master username: "gitlab"
  - Additional configuration: 
    - Initial database name: `gitlabhq_production`

- [x] Ensure the RDS DB has two users - `gitlab` and `postgres` by running the following SQL queries:
`CREATE ROLE postgres;`
`CREATE ROLE gitlab;`

- [x] Restore the backup to the RDS DB with the following command:
```sh
psql --host=<db url> --port=5432 --username=gitlab --password --dbname=gitlabhq_production -f dump.sql
```

- [ ] Merge this PR into `main`
	- Hopefully, this will trigger flux to make the changes in this PR and connect the gitlab staging deployment to the new database.

If all goes well in staging, proceed to the following nearly identical steps to apply the changes to production as well.

- [ ] Take down gitlab

- [ ] Backup the gitlab production database with the following command:
```sh
kubectl exec -it gitlab-postgresql-master-0 -n gitlab -- bash -c "PGPASSWORD=<db_password> pg_dump -U gitlab -d gitlabhq_production" > dump.sql
```
- [ ] Create an RDS database through the AWS console with the following settings:
  - Standard create
  - PostgreSQL (select latest version)
  - Master username: "gitlab"
  - Additional configuration: 
    - Initial database name: `gitlabhq_production`

- [ ] Ensure the RDS DB has two users - `gitlab` and `postgres` by running the following SQL queries:
`CREATE ROLE postgres;`
`CREATE ROLE gitlab;`

- [ ] Restore the backup to the RDS DB with the following command:
```sh
psql --host=<db url> --port=5432 --username=gitlab --password --dbname=gitlabhq_production -f dump.sql
```

- [ ] Create a PR merging `main` into `production` and merge it.

- [ ] Merge #281 into `main` and delete the staging RDS database through the AWS console.