### PR TITLE
Correctly specify hostname secret for RDS DB

### DIFF
--- a/k8s/gitlab/release.yaml
+++ b/k8s/gitlab/release.yaml
@@ -11,6 +11,13 @@ spec:
     repository: https://charts.gitlab.io
     version: 5.6.3 # gitlab@14.6.3
 
+  valuesFrom:
+    - kind: Secret
+      name: gitlab-secrets
+      valuesKey: postgres-hostname
+      targetPath: global.psql.host
+      optional: false
+
   values:
     nodeSelector:
       spack.io/node-pool: gitlab
@@ -60,9 +67,6 @@ spec:
 
       psql:
         connectTimeout:
-        host:
-          secret: gitlab-secrets
-          key: postgres-hostname
         password:
           secret: gitlab-secrets
           key: postgres-password

--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -71,7 +71,7 @@ data:
     - op: remove
       path: /spec/values/gitlab/gitlab-shell/service
     - op: replace
-      path: /spec/values/global/psql/host/secret
+      path: /spec/valuesFrom/name
       value: gitlab-{ENV}-secrets
     - op: replace
       path: /spec/values/global/psql/password/secret


### PR DESCRIPTION
The gitlab `HelmRelease` doesn't support specifying the `host` of the postgres database as a secret (ref: https://docs.gitlab.com/charts/charts/globals.html#configure-postgresql-settings), so [`valuesFrom`](https://fluxcd.io/docs/components/helm/helmreleases/#values-overrides) must be used to do this. I believe this is why staging doesn't work after #280 was merged.