### PR TITLE
Specify RDS DB hostname directly

### DIFF
--- a/k8s/gitlab/release.yaml
+++ b/k8s/gitlab/release.yaml
@@ -11,13 +11,6 @@ spec:
     repository: https://charts.gitlab.io
     version: 5.6.3 # gitlab@14.6.3
 
-  valuesFrom:
-    - secretKeyRef:
-        name: gitlab-secrets
-        namespace: gitlab
-        key: postgres-hostname
-        optional: false
-
   values:
     nodeSelector:
       spack.io/node-pool: gitlab
@@ -67,6 +60,7 @@ spec:
 
       psql:
         connectTimeout:
+        host: production-db.example.com # TODO: set up the prod DB and specify its hostname here
         password:
           secret: gitlab-secrets
           key: postgres-password

--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -71,8 +71,8 @@ data:
     - op: remove
       path: /spec/values/gitlab/gitlab-shell/service
     - op: replace
-      path: /spec/valuesFrom/0/secretKeyRef/name
-      value: gitlab-{ENV}-secrets
+      path: /spec/values/global/psql/host
+      value: spack-gitlab.cgnbnwwuxkgt.us-east-1.rds.amazonaws.com
     - op: replace
       path: /spec/values/global/psql/password/secret
       value: gitlab-{ENV}-secrets


### PR DESCRIPTION
The database instance isn't publicly accessible, so this should be safe to do.