### PR TITLE
Fix fluent-bit parsing

### DIFF
--- a/k8s/logging/fluent-bit.yaml
+++ b/k8s/logging/fluent-bit.yaml
@@ -149,6 +149,8 @@ stringData:
         AWS_Auth        On
         AWS_Region      us-east-1
         Retry_Limit     6
+        Replace_Dots    On
+        Trace_Error     On
 
 ---
 apiVersion: apps/v1

--- a/k8s/logging/fluent-bit.yaml
+++ b/k8s/logging/fluent-bit.yaml
@@ -180,7 +180,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: amazon/aws-for-fluent-bit:2.5.0
+        image: amazon/aws-for-fluent-bit:2.27.0
         imagePullPolicy: Always
         ports:
           - containerPort: 2020

--- a/k8s/logging/fluent-bit.yaml
+++ b/k8s/logging/fluent-bit.yaml
@@ -69,6 +69,7 @@ data:
         Skip_Long_Lines   On
         Refresh_Interval  10
         multiline.parser  cri, docker, python
+        Mem_Buf_Limit     10MB
 
   filter-kubernetes.conf: |
     [FILTER]
@@ -185,6 +186,9 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 2020
+        resources:
+          requests:
+            memory: "36Mi"
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/k8s/logging/fluent-bit.yaml
+++ b/k8s/logging/fluent-bit.yaml
@@ -68,6 +68,7 @@ data:
         Mem_Buf_Limit     50MB
         Skip_Long_Lines   On
         Refresh_Interval  10
+        multiline.parser  cri, docker, python
 
   filter-kubernetes.conf: |
     [FILTER]


### PR DESCRIPTION
Enabling the `Replace_Dots` setting in fluent-bit as suggested here https://github.com/fluent/fluent-bit/issues/4386 is apparently needed to avoid some log parsing issues. After deploying that change to the cluster and deleting the existing OpenSearch index, everything appears to be working now.
The `Trace_Error` setting enables more verbose logging for the fluent-bit pods themselves, and is what helped me debug this particular issue, so I think it's worth keeping that on as well.