### PR TITLE
Make flux ignore gitlab/fluent-bit secrets

### DIFF
--- a/k8s/gitlab/secrets.yaml
+++ b/k8s/gitlab/secrets.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: gitlab-secrets
   namespace: gitlab
+  annotations:
+    fluxcd.io/ignore: "true"
 stringData:
   values.yaml: |
     global:

--- a/k8s/logging/fluent-bit.yaml
+++ b/k8s/logging/fluent-bit.yaml
@@ -137,6 +137,8 @@ kind: Secret
 metadata:
   name: fluent-bit-secrets
   namespace: logging
+  annotations:
+    fluxcd.io/ignore: "true"
   labels:
     k8s-app: fluent-bit
 type: Opaque


### PR DESCRIPTION
When #291 was merged, flux overwrote all of the fluent-bit/gitlab secrets with the dummy ones in that file because the flux ignore annotation wasn't present.