### PR TITLE
Set `install: true` for gitlab postgres in staging

### DIFF
--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -81,9 +81,10 @@ data:
     - op: replace
       path: /spec/values/global/psql/password
       value: {}
-    - op: add
+    - op: replace
       path: /spec/values/postgresql
       value:
+        install: true
         replication:
           enabled: true
           slaveReplicas: 4


### PR DESCRIPTION
I missed this one flag, which is why #281 didn't cause a postgres pod to get deployed in the cluster :sweat_smile: 

I also changed the `op` to `replace`, which is what it should be, since the `spec/values/postgresql` field already exists in the production `release.yaml`.