### PR TITLE
Start specifying resource requests

### DIFF
--- a/k8s/aws-node-termination-handler/release.yaml
+++ b/k8s/aws-node-termination-handler/release.yaml
@@ -19,3 +19,8 @@ spec:
     emitKubernetesEvents: true
     enablePrometheusServer: true
     prometheusServerPort: 9092
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 200M

--- a/k8s/cdash/deployments.yaml
+++ b/k8s/cdash/deployments.yaml
@@ -30,6 +30,10 @@ spec:
             exec /bin/bash /docker-entrypoint.sh
         image: kitware/cdash:spack_deploy_v4
         imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 1600m
+            memory: 1G
         ports:
         - containerPort: 80
           name: web

--- a/k8s/cert-manager/release.yaml
+++ b/k8s/cert-manager/release.yaml
@@ -8,13 +8,18 @@ spec:
   releaseName: cert-manager
   chart:
     name: cert-manager
-    repository: https://charts.jetstack.io                        
+    repository: https://charts.jetstack.io
     version: v1.0.2  # cert-manager@1.0.2
   values:
     installCRDs: false
     replicaCount: 3
     nodeSelector:
       spack.io/node-pool: base
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 300M
 
     extraArgs:
       - --enable-certificate-owner-ref=true
@@ -25,11 +30,18 @@ spec:
 
     webhook:
       replicaCount: 3
+      resources:
+        requests:
+          cpu: 300m
+          memory: 50M
       nodeSelector:
         spack.io/node-pool: base
 
     cainjector:
       enabled: true
       replicaCount: 3
+      requests:
+          cpu: 30m
+          memory: 200M
       nodeSelector:
         spack.io/node-pool: base

--- a/k8s/cluster-autoscaler/release.yaml
+++ b/k8s/cluster-autoscaler/release.yaml
@@ -28,6 +28,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base
 
+    resources:
+      requests:
+        cpu: 100m
+        memory: 800M
+
     replicaCount: 3
 
     serviceMonitor:

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -17,6 +17,10 @@ spec:
           - name: sync
             image: ghcr.io/spack/ci-bridge:0.0.28
             imagePullPolicy: IfNotPresent
+            resources:
+              requests:
+                cpu: 500m
+                memory: 500M
             env:
             - name: GITHUB_TOKEN
               valueFrom:

--- a/k8s/custom/gitlab-stuckpods/deployment.yaml
+++ b/k8s/custom/gitlab-stuckpods/deployment.yaml
@@ -21,5 +21,9 @@ spec:
         - name: deletor
           image: ghcr.io/spack/stuckpods:0.0.1
           imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 25m
+              memory: 50M
       nodeSelector:
         spack.io/node-pool: base

--- a/k8s/custom/node-share-controller/deployment.yaml
+++ b/k8s/custom/node-share-controller/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         - name: main
           image: alpine:3.12
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 150m
+              memory: 100M
           command: ["sh", "/script"]
           volumeMounts:
             - name: script

--- a/k8s/gitlab/release.yaml
+++ b/k8s/gitlab/release.yaml
@@ -108,6 +108,10 @@ spec:
         spack.io/node-pool: gitlab
       persistence:
         size: 1000Gi
+      resources:
+        requests:
+          cpu: 200m
+          memory: 12G
 
     registry:
       ingress:
@@ -138,10 +142,10 @@ spec:
         resources:
           limits:
             cpu: 1500m
-            memory: 2.5G
+            memory: 3.5G
           requests:
             cpu: 300m
-            memory: 1.5G
+            memory: 2.5G
         nodeSelector:
           spack.io/node-pool: gitlab
       gitlab-exporter:

--- a/k8s/gitlab/staging/release.yaml
+++ b/k8s/gitlab/staging/release.yaml
@@ -68,6 +68,12 @@ data:
     - op: replace
       path: /spec/values/gitlab/webservice/maxReplicas
       value: 3
+    - op: replace
+      path: /spec/values/gitlab/webservice/resources/requests/cpu
+      value: 550m
+    - op: replace
+      path: /spec/values/gitlab/webservice/resources/requests/memory
+      value: 2G
     - op: remove
       path: /spec/values/gitlab/gitlab-shell/service
     - op: remove

--- a/k8s/gitops/deployments.yaml
+++ b/k8s/gitops/deployments.yaml
@@ -25,6 +25,10 @@ spec:
       containers:
         - name: controller
           image: ghcr.io/spack/gitops:0.0.4
+          resources:
+            requests:
+              cpu: 250m
+              memory: 50M
           args:
             - --repo
             - ssh://git@github.com/spack/spack-infrastructure

--- a/k8s/logging/fluent-bit.yaml
+++ b/k8s/logging/fluent-bit.yaml
@@ -186,6 +186,10 @@ spec:
       - name: fluent-bit
         image: amazon/aws-for-fluent-bit:2.27.0
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 150m
+            memory: 500M
         ports:
           - containerPort: 2020
         resources:

--- a/k8s/metabase/metabase-deployment.yaml
+++ b/k8s/metabase/metabase-deployment.yaml
@@ -18,6 +18,10 @@ spec:
         - name: metabase
           image: metabase/metabase:v0.41.2
           imagePullPolicy: "IfNotPresent"
+          resources:
+            requests:
+              cpu: 350m
+              memory: 2G
           ports:
             - containerPort: 3000
           envFrom:

--- a/k8s/prometheus/release.yaml
+++ b/k8s/prometheus/release.yaml
@@ -89,8 +89,18 @@ spec:
               resources:
                 requests:
                   storage: 200Gi
+        resources:
+          requests:
+            cpu: 2000m
+            memory: 50G
         nodeSelector:
           spack.io/node-pool: beefy
+
+    prometheusOperator:
+      resources:
+        requests:
+          cpu: 750m
+          memory: 300M
 
     kube-state-metrics:
       metricLabelsAllowlist:

--- a/k8s/spack/slack-spack-io/deployments.yaml
+++ b/k8s/spack/slack-spack-io/deployments.yaml
@@ -23,6 +23,10 @@ spec:
       - name: web
         image: "spack/slackin-extended:latest"
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 20m
+            memory: 65M
         ports:
         - name: http
           containerPort: 80

--- a/k8s/spack/spackbot-spack-io/deployments.yaml
+++ b/k8s/spack/spackbot-spack-io/deployments.yaml
@@ -23,6 +23,10 @@ spec:
       - name: web
         image: "ghcr.io/spack/spack-bot:latest"
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 110m
+            memory: 200M
         ports:
         - name: http
           containerPort: 8080
@@ -84,6 +88,10 @@ spec:
       - name: worker
         image: "ghcr.io/spack/spackbot-workers:latest"
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1500m
+            memory: 1.3G
         # Mount secrets to non-existing location
         volumeMounts:
           - mountPath: "/git_rsa"

--- a/k8s/spack/spackbotdev-spack-io/deployments.yaml
+++ b/k8s/spack/spackbotdev-spack-io/deployments.yaml
@@ -23,6 +23,10 @@ spec:
       - name: web
         image: "ghcr.io/spack/spack-bot:latest"
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 110m
+            memory: 200M
         ports:
         - name: http
           containerPort: 8080
@@ -86,6 +90,10 @@ spec:
       - name: worker
         image: "ghcr.io/spack/spackbot-workers:latest"
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 900m
+            memory: 1G
         # Mount secrets to non-existing location
         volumeMounts:
           - mountPath: "/git_rsa"


### PR DESCRIPTION
Most of the things we deployed in the cluster do not specify the
amount of memory or cpu they request, although this information is
critical to allow kubernetes to make good pod scheduling decisions.  

This PR applies cpu and memory requests to some of the largest 
resource consumers that did not previously specify resource requests.

Using prometheus queries crafted by @kotfic, we were able to get
some measurements of what kind of resources are getting consumed
by the cluster services/apps now, and use that information to provide
these initial resource requests.  

We will need to follow up a few more PRs doing the same until we
have set requests for everything running in the cluster.

I'm not sure about the `k8s-bootstrap` changes, as to whether they'll
get picked up by flux automatically.  So we will have to keep an eye
on pods in the `flux` namespace to see if these requests show up in
the live objects, and figure out some action to take if not.

Links (also thanks to @kotfic):

https://sysdig.com/blog/kubernetes-resource-limits
https://itnext.io/k8s-monitor-pod-cpu-and-memory-usage-with-prometheus-28eec6d84729
