### PR TITLE
Reduce spackbot-workers memory request

### DIFF
--- a/k8s/spack/spackbot-spack-io/deployments.yaml
+++ b/k8s/spack/spackbot-spack-io/deployments.yaml
@@ -91,7 +91,7 @@ spec:
         resources:
           requests:
             cpu: 1500m
-            memory: 1.3G
+            memory: 1G
         # Mount secrets to non-existing location
         volumeMounts:
           - mountPath: "/git_rsa"


### PR DESCRIPTION
Autoscaler is having trouble scheduling this pod because of memory
issues.  The t3.small have 2G ram, so you would think we could safely
request 1.3G.  And in fact, it did get scheduled and run for a little
while with the request set to 1.3G, but was still found pending an
hour later.