### PR TITLE
Enable logstash format for OpenSearch indices

### DIFF
--- a/k8s/logging/secrets.yaml
+++ b/k8s/logging/secrets.yaml
@@ -12,13 +12,15 @@ type: Opaque
 stringData:
   output-elasticsearch.conf: |
     [OUTPUT]
-        Name            es
-        Match           *
-        Host            DEADBEEF  # fake value
-        Port            443
-        TLS             On
-        AWS_Auth        On
-        AWS_Region      us-east-1
-        Retry_Limit     6
-        Replace_Dots    On
-        Trace_Error     On
+        Name             es
+        Match            *
+        Host             DEADBEEF  # fake value
+        Port             443
+        TLS              On
+        AWS_Auth         On
+        AWS_Region       us-east-1
+        Retry_Limit      6
+        Logstash_Format  On
+        Logstash_Prefix  fluent-bit
+        Replace_Dots     On
+        Trace_Error      On


### PR DESCRIPTION
Currently, our log rotation policy is "delete every OpenSearch index older than 14 days". This approach is flawed because we currently send all log records to the same index. So right now, we are essentially deleting every log in the system every 14 days.

This PR adds `Logstash_Format` and `Logstash_Prefix` settings to fluent-bit config file. These options make it so fluent-bit sends its logs to an OpenSearch index called "fluent-bit-YYYY-MM-DD"; this guarantees that a new index is created everyday, thus allowing our log rotation policy to actually work as intended.

I've applied this to the cluster already, this is just a PR to encode this into the "fake secret" in the repo.