### PR TITLE
Reconfigure metabase to connect to gitlab RDS postgres instance

### DIFF
--- a/k8s/metabase/gitlab_ro_user_job.yaml
+++ b/k8s/metabase/gitlab_ro_user_job.yaml
@@ -35,14 +35,17 @@ spec:
           - name: PGUSER
             value: postgres
           - name: PGHOST
-            value: gitlab-postgresql
+            valueFrom:
+              secretKeyRef:
+                name: gitlab-postgresql-secrets
+                key: gitlab-postgresql-host
           - name: PGDATABASE
             value: gitlabhq_production
           - name: PGPASSWORD
             valueFrom:
               secretKeyRef:
-                name: gitlab-postgresql-password
-                key: postgresql-postgres-password
+                name: gitlab-postgresql-secrets
+                key: gitlab-postgresql-password
           - name: RO_PGPASSWORD
             valueFrom:
               secretKeyRef:

--- a/k8s/metabase/secrets.yaml
+++ b/k8s/metabase/secrets.yaml
@@ -21,3 +21,15 @@ metadata:
     fluxcd.io/ignore: "true"
 data:
   postgresql-password: DEADBEEF # fake-secret
+---
+# Secret used to log into the GitLab postgres instance
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitlab-postgresql-secrets
+  namespace: monitoring
+  annotations:
+    fluxcd.io/ignore: "true"
+stringData:
+  gitlab-postgresql-host: DEADBEEF # fake-secret
+  gitlab-postgresql-password: DEADBEEF # fake-secret


### PR DESCRIPTION
Metabase was still pointing at the old gitlab postgres DB. This PR will point it at the RDS instance. I've already add the new secrets to the cluster.