### PR TITLE
Increase fluent-bit k8s buffer size

### DIFF
--- a/k8s/logging/configmaps.yaml
+++ b/k8s/logging/configmaps.yaml
@@ -48,6 +48,7 @@ data:
         Merge_Log_Key       log_processed
         K8S-Logging.Parser  On
         K8S-Logging.Exclude Off
+        Buffer_Size         512KB
 
   parsers.conf: |
     [PARSER]


### PR DESCRIPTION
I'm seeing errors like this showing up in the ELK dashboard for several fluent-bit pods:
`[2022/08/17 18:01:02] [ warn] [http_client] cannot increase buffer: current=32000 requested=64768 max=32000`

According to [this fluent-bit issue](https://github.com/fluent/fluent-bit/issues/3918#issuecomment-1118528986), if you have a large kubernetes cluster, the cluster metadata that fluent-bit needs to read can take up more than the default buffer size of 32KB. I've applied the suggested fix from that issue here and bumped the buffer size to 512KB. 