### PR TITLE
Remove alerting rules

### DIFF
--- a/k8s/prometheus/alertmanagerconfig.yaml
+++ b/k8s/prometheus/alertmanagerconfig.yaml
@@ -29,3 +29,12 @@ spec:
           {{.Annotations.description}}
 
           {{ end }}
+  inhibitRules:
+    - targetMatch:
+        - name: severity
+          value: warning
+      sourceMatch:
+        - name: severity
+          value: critical
+      equal:
+        - group

--- a/k8s/prometheus/custom/alerts.yaml
+++ b/k8s/prometheus/custom/alerts.yaml
@@ -19,6 +19,34 @@ spec:
          expr: node_namespace_pod_name:pipeline_stuck_pods_info == 1
          for: 5m
          labels:
+           group: gitlab_webservice_error_rate
+           severity: warning
+           namespace: monitoring
+           source_namespace: "{{ $labels.namespace }}"
+
+       - alert: GitLabWebServiceErrorRate5Percent
+         annotations:
+           description: 'GitLab Web Service has been seeing a 5% error rate for the last 5 minutes'
+           runbook_url: 'TODO'
+           summary: 'The GitLab web service has seen 4XX/5XX responses for at least 5% of requests over the last 5 minutes.'
+         expr: ingress_error_rate:gitlab_webservice_default <= 95.0
+         for: 5m
+         labels:
+           group: gitlab_webservice_error_rate
+           severity: warning
+           namespace: monitoring
+           source_namespace: "{{ $labels.namespace }}"
+
+
+       - alert: GitLabWebServiceErrorRate10Percent
+         annotations:
+           description: 'GitLab Web Service has been seeing a 10% error rate for the last 2 minutes'
+           runbook_url: 'TODO'
+           summary: 'The GitLab web service has seen 4XX/5XX responses for at least 10% of requests over the last 2 minutes.'
+         expr: ingress_error_rate:gitlab_webservice_default <= 90.0
+         for: 2m
+         labels:
+           group: gitlab_webservice_error_rate
            severity: critical
            namespace: monitoring
            source_namespace: "{{ $labels.namespace }}"

--- a/k8s/prometheus/custom/rules.yaml
+++ b/k8s/prometheus/custom/rules.yaml
@@ -19,3 +19,8 @@ spec:
              irate(container_network_transmit_bytes_total{namespace="pipeline"}[3m]) == 0
            )
          record: node_namespace_pod_name:pipeline_stuck_pods_info
+
+       - expr: |-
+           sum(irate(nginx_ingress_controller_requests{exported_service="gitlab-webservice-default", status!~"[4-5].*"}[2m])) by (ingress) /
+           sum(irate(nginx_ingress_controller_requests{exported_service="gitlab-webservice-default"}[2m])) by (ingress) * 100
+         record: ingress_error_rate:gitlab_webservice_default

--- a/k8s/prometheus/release.yaml
+++ b/k8s/prometheus/release.yaml
@@ -12,12 +12,7 @@ spec:
     version: 32.0.2
   values:
     defaultRules:
-#  Appears to be broken in production -  Does not validate.
-#  See: https://github.com/prometheus-community/helm-charts/issues/1718
-#      disabled:
-#        # Both of these services are handled by EKS
-#        KubeSchedulerDown: true
-#        KubeControllerManagerDown: true
+      create: false
       additionalRuleLabels:
         namespace: monitoring
         source_namespace: '{{ $labels.namespace }}'


### PR DESCRIPTION
This PR removes the default rules associated with kube-prometheus-stack.  While some of these rules are undoubtedly useful, many are unactionable causing the #monitoring-alerts  channel to become spammed in a way that has lead to alerting fatigue. Currently there are 3 alerting rules defined:

1. GitlabPipelineStuckPods - pods that have seen no CPU/RAM/Network activity for more than 5 minutes.
2. GitlabWebServiceErrorRate5Percent - a warning that the gitlab web services has been experiencing 5% error rates for at least 5 minutes.
3. GitlabWebServiceErrorRate10Percent - a critical warning that the gitlab web service has been experiencing 10% error rates for at least 2 minutes. 

More may be defined as actionable problems arise. 