### PR TITLE
Fix command line argument to SpackCIBridge.py

### DIFF
--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -43,6 +43,6 @@ spec:
               - "--main-branch"
               - "develop"
               - "--prereq-check"
-              - "ci / prechecks / style"
+              - "prechecks / style"
           nodeSelector:
             spack.io/node-pool: base


### PR DESCRIPTION
It turns out the name of the check we want to gate on is "prechecks / style", not "ci / prechecks / style". If I understand correctly, "ci" is the name of the check suite.