### PR TITLE
Ignore `INFO` logs from GitLab web server

### DIFF
--- a/k8s/logging/configmaps.yaml
+++ b/k8s/logging/configmaps.yaml
@@ -50,6 +50,12 @@ data:
         K8S-Logging.Exclude On
         Buffer_Size         512KB
 
+    [FILTER]
+        # Filter out 'INFO' level logs
+        Name    grep
+        Match   *
+        Exclude $log_processed['severity'] INFO
+
   parsers.conf: |
     [PARSER]
         Name   apache


### PR DESCRIPTION
Since #320 took effect, the next largest source of logs are the GitLab `webservice` pods. The vast majority of these pods are `INFO` logs that are emitted whenever the GitLab webserver receives an HTTP request. This PR adds a [fluent-bit grep filter](https://docs.fluentbit.io/manual/pipeline/filters/grep) that excludes these types of logs; using a filter instead of setting a `"fluentbit.io/exclude" = "true"` annotation on the gitlab webservice pods ensures other log levels from the webservice will continue to be sent to opensearch (in particular, we'll still want to record `ERROR` logs).