### PR TITLE
Only strip the first occurrence of 'gitlab/' in get_synced_prs()

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -25,7 +25,7 @@ jobs:
           - python-aws-bash
         include:
           - docker-image: gh-gl-sync
-            image-tags: ghcr.io/spack/ci-bridge:0.0.28
+            image-tags: ghcr.io/spack/ci-bridge:0.0.29
           - docker-image: gitlab-api-scrape
             image-tags: ghcr.io/spack/gitlab-api-scrape:0.0.2
           - docker-image: ci-key-rotate

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -260,7 +260,7 @@ class SpackCIBridge(object):
         for line in self.gitlab_pr_output.split(b"\n"):
             if line.find(b"gitlab/") == -1:
                 continue
-            synced_pr = line.strip().replace(b"gitlab/", b"").decode("utf-8")
+            synced_pr = line.strip().replace(b"gitlab/", b"", 1).decode("utf-8")
             synced_prs.append(synced_pr)
         print("Synced PRs:")
         for pr in synced_prs:

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.28
+            image: ghcr.io/spack/ci-bridge:0.0.29
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
This fixes a bug where GitHub branches named 'gitlab/...' break the sync script.