### PR TITLE
Also publish custom docker images on push to `production`

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -2,7 +2,9 @@ name: Publish Docker Images
 
 on:
   push:
-    branches: main
+    branches:
+      - main
+      - production
 
 jobs:
   publish:


### PR DESCRIPTION
@zackgalbreath do you see any downsides to doing this? Merging straight to production is a common pattern, but currently any changes to docker images won't be reflected until the changes are backported to main.