### PR TITLE
Stop blocking PRs due to a currently running "main branch" pipeline

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -27,7 +27,7 @@ jobs:
           - python-aws-bash
         include:
           - docker-image: gh-gl-sync
-            image-tags: ghcr.io/spack/ci-bridge:0.0.29
+            image-tags: ghcr.io/spack/ci-bridge:0.0.30
           - docker-image: gitlab-api-scrape
             image-tags: ghcr.io/spack/gitlab-api-scrape:0.0.2
           - docker-image: ci-key-rotate

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.29
+            image: ghcr.io/spack/ci-bridge:0.0.30
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
Remove the 'waiting for base develop commit pipeline to succeed' functionality from our sync script. It doesn't jive well with '@spackbot run pipeline' and it will soon be unnecessary once we roll out PR binary graduation.