### PR TITLE
Remove instance type restriction in karpenter

### DIFF
--- a/k8s/karpenter/provisioners.yaml
+++ b/k8s/karpenter/provisioners.yaml
@@ -31,13 +31,6 @@ spec:
         - "us-east-1c"
         - "us-east-1d"
 
-    # Allowed instance types
-    - key: node.kubernetes.io/instance-type
-      operator: In
-      values:
-        - "m6g.4xlarge" # ARM64 instances
-        - "m5zn.3xlarge" # AMD64 instances
-
     # Try spot, fall over to on-demand
     - key: "karpenter.sh/capacity-type"
       operator: In


### PR DESCRIPTION
This should help with our ARM instance capacity issues. @zackgalbreath I chose to simply remove the the restriction, without adding any additional restrictions, for the following reasons:

* GPU instances will not be provisioned if a GPU is not requested
* Based on some [old documentation](https://karpenter.sh/v0.13.1/provisioner/#instance-types) (not sure why it's no longer mentioned anywhere), karpenter will not provision metal instances unless specified in the provisioner.

From the docs:
> The default value includes all instance types with the exclusion of metal (non-virtualized), [non-HVM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html), and GPU instances.

I think it might be easiest to just remove our restrictions, watch what instance types are being provisioned, and adjust if needed.