### PR TITLE
Karpenter: Use consolidation instead of ttlSecondsAfterEmpty

### DIFF
--- a/k8s/karpenter/provisioners.yaml
+++ b/k8s/karpenter/provisioners.yaml
@@ -5,10 +5,12 @@ kind: Provisioner
 metadata:
   name: default
 spec:
-  # Terminate nodes after 10 minutes of idle time
-  ttlSecondsAfterEmpty: 600
   providerRef:
     name: default
+
+  # Consolidation will de-provision larger than necessary nodes
+  consolidation:
+    enabled: true
 
   # Resource limits for this provisioner only
   limits:
@@ -47,10 +49,13 @@ kind: Provisioner
 metadata:
   name: testing
 spec:
-  # Terminate nodes after 10 minutes of idle time
-  ttlSecondsAfterEmpty: 600
   providerRef:
     name: default
+
+  # Consolidation will de-provision larger than necessary nodes
+  consolidation:
+    enabled: true
+
   requirements:
     # Only spin up arm64 nodes
     - key: "kubernetes.io/arch"


### PR DESCRIPTION
Since we are now allowing almost all instance types to be provisioned with Karpenter, it's possible that a large node is provisioned for some temporary workload, and then is left running at a very low utilization, since pods are being scheduled onto it within the 10 minute TTL.

This PR changes our de-provisioning method to [Consolidation](https://karpenter.sh/v0.18.1/tasks/deprovisioning/#consolidation), which will optimize for cost by deprovisioning larger than necessary nodes.