### PR TITLE
Separate provisioners per CPU architecture

### DIFF
--- a/k8s/karpenter/provisioners/runners/graviton/2/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/graviton/2/provisioners.yaml
@@ -1,0 +1,56 @@
+---
+# Provisioner for graviton2 gitlab runners
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: glr-graviton2
+spec:
+  providerRef:
+    name: default
+
+  # Consolidation will de-provision larger than necessary nodes
+  consolidation:
+    enabled: true
+
+  # Resource limits for this provisioner only
+  limits:
+    resources:
+      cpu: 5k
+      memory: 20Ti
+
+  requirements:
+    # Only spin up arm64 nodes
+    - key: "kubernetes.io/arch"
+      operator: In
+      values: ["arm64"]
+
+    # Instance Size
+    - key: "karpenter.k8s.aws/instance-size"
+      operator: In
+      values:
+        - "medium"
+        - "large"
+        - "xlarge"
+        - "2xlarge"
+        - "3xlarge"
+        - "4xlarge"
+        - "6xlarge"
+        - "8xlarge"
+
+    # Availability Zones
+    - key: "topology.kubernetes.io/zone"
+      operator: In
+      values:
+        - "us-east-1a"
+        - "us-east-1b"
+        - "us-east-1c"
+        - "us-east-1d"
+
+    # Try spot, fall over to on-demand
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: ["spot", "on-demand"]
+
+  # Only provision nodes for pods specifying the glr-graviton2 node pool
+  labels:
+    spack.io/node-pool: glr-graviton2

--- a/k8s/karpenter/provisioners/runners/graviton/3/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/graviton/3/provisioners.yaml
@@ -1,0 +1,63 @@
+---
+# Provisioner for graviton3 gitlab runners
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: glr-graviton3
+spec:
+  providerRef:
+    name: default
+
+  # Consolidation will de-provision larger than necessary nodes
+  consolidation:
+    enabled: true
+
+  # Resource limits for this provisioner only
+  limits:
+    resources:
+      cpu: 5k
+      memory: 20Ti
+
+  requirements:
+      # Only spin up arm64 nodes
+    - key: "kubernetes.io/arch"
+      operator: In
+      values: ["arm64"]
+
+    # Only provision nodes with graviton3 processors.
+    # Data gleaned from https://aws.amazon.com/ec2/graviton/
+    - key: "karpenter.k8s.aws/instance-family"
+      operator: In
+      values:
+        - "c7g"
+
+    # Instance Size
+    - key: "karpenter.k8s.aws/instance-size"
+      operator: In
+      values:
+        - "medium"
+        - "large"
+        - "xlarge"
+        - "2xlarge"
+        - "3xlarge"
+        - "4xlarge"
+        - "6xlarge"
+        - "8xlarge"
+
+    # Availability Zones
+    - key: "topology.kubernetes.io/zone"
+      operator: In
+      values:
+        - "us-east-1a"
+        - "us-east-1b"
+        - "us-east-1c"
+        - "us-east-1d"
+
+    # Try spot, fall over to on-demand
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: ["spot", "on-demand"]
+
+  # Only provision nodes for pods specifying the glr-graviton3 node pool
+  labels:
+    spack.io/node-pool: glr-graviton3

--- a/k8s/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
@@ -1,0 +1,56 @@
+---
+# Provisioner for x86_64_v2 gitlab runners
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: glr-x86-64-v2
+spec:
+  providerRef:
+    name: default
+
+  # Consolidation will de-provision larger than necessary nodes
+  consolidation:
+    enabled: true
+
+  # Resource limits for this provisioner only
+  limits:
+    resources:
+      cpu: 5k
+      memory: 20Ti
+
+  requirements:
+    # Only spin up amd64 nodes
+    - key: "kubernetes.io/arch"
+      operator: In
+      values: ["amd64"]
+
+    # Instance Size
+    - key: "karpenter.k8s.aws/instance-size"
+      operator: In
+      values:
+        - "medium"
+        - "large"
+        - "xlarge"
+        - "2xlarge"
+        - "3xlarge"
+        - "4xlarge"
+        - "6xlarge"
+        - "8xlarge"
+
+    # Availability Zones
+    - key: "topology.kubernetes.io/zone"
+      operator: In
+      values:
+        - "us-east-1a"
+        - "us-east-1b"
+        - "us-east-1c"
+        - "us-east-1d"
+
+    # Try spot, fall over to on-demand
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: ["spot", "on-demand"]
+
+  # Only provision nodes for pods specifying the glr-x86-64-v2 node pool
+  labels:
+    spack.io/node-pool: glr-x86-64-v2

--- a/k8s/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
@@ -1,0 +1,119 @@
+---
+# Provisioner for x86_64_v3 gitlab runners
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: glr-x86-64-v3
+spec:
+  providerRef:
+    name: default
+
+  # Consolidation will de-provision larger than necessary nodes
+  consolidation:
+    enabled: true
+
+  # Resource limits for this provisioner only
+  limits:
+    resources:
+      cpu: 5k
+      memory: 20Ti
+
+  requirements:
+    # Only spin up amd64 nodes
+    - key: "kubernetes.io/arch"
+      operator: In
+      values: ["amd64"]
+
+    # Only provision nodes from certain instance families that have been verified
+    # to support x86_64_v3 by archspec.
+    - key: "karpenter.k8s.aws/instance-family"
+      operator: In
+      values:
+        - "c4"
+        - "c5"
+        - "c5a"
+        - "c5ad"
+        - "c5d"
+        - "c5n"
+        - "c6a"
+        - "c6i"
+        - "c6id"
+        - "d2"
+        - "d3"
+        - "d3en"
+        - "dl1"
+        - "f1"
+        - "g3"
+        - "g3s"
+        - "g4ad"
+        - "g4dn"
+        - "g5"
+        - "h1"
+        - "i3"
+        - "i3en"
+        - "i4i"
+        - "inf1"
+        - "m4"
+        - "m5"
+        - "m5a"
+        - "m5ad"
+        - "m5d"
+        - "m5dn"
+        - "m5n"
+        - "m5zn"
+        - "m6a"
+        - "m6i"
+        - "m6id"
+        - "p2"
+        - "p3"
+        - "r4"
+        - "r5"
+        - "r5a"
+        - "r5ad"
+        - "r5b"
+        - "r5d"
+        - "r5dn"
+        - "r5n"
+        - "r6a"
+        - "r6i"
+        - "r6id"
+        - "t2"
+        - "t3"
+        - "t3a"
+        - "trn1"
+        - "vt1"
+        - "x1e"
+        - "x2iedn"
+        - "x2iezn"
+        - "z1d"
+
+    # Instance Size
+    - key: "karpenter.k8s.aws/instance-size"
+      operator: In
+      values:
+        - "medium"
+        - "large"
+        - "xlarge"
+        - "2xlarge"
+        - "3xlarge"
+        - "4xlarge"
+        - "6xlarge"
+        - "8xlarge"
+
+    # Availability Zones
+    - key: "topology.kubernetes.io/zone"
+      operator: In
+      values:
+        - "us-east-1a"
+        - "us-east-1b"
+        - "us-east-1c"
+        - "us-east-1d"
+
+    # Try spot, fall over to on-demand
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: ["spot", "on-demand"]
+
+  # Only provision nodes for pods specifying the glr-x86-64-v3 node pool
+  labels:
+    spack.io/node-pool: glr-x86-64-v3

--- a/k8s/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
@@ -1,0 +1,94 @@
+---
+# Provisioner for x86_64_v4 gitlab runners
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: glr-x86-64-v4
+spec:
+  providerRef:
+    name: default
+
+  # Consolidation will de-provision larger than necessary nodes
+  consolidation:
+    enabled: true
+
+  # Resource limits for this provisioner only
+  limits:
+    resources:
+      cpu: 5k
+      memory: 20Ti
+
+  requirements:
+    # Only spin up amd64 nodes
+    - key: "kubernetes.io/arch"
+      operator: In
+      values: ["amd64"]
+
+    # Only provision nodes from certain instance families that have been verified
+    # to support x86_64_v4 by archspec.
+    - key: "karpenter.k8s.aws/instance-family"
+      operator: In
+      values:
+        - "c5"
+        - "c5d"
+        - "c5n"
+        - "c6i"
+        - "c6id"
+        - "d3"
+        - "d3en"
+        - "dl1"
+        - "g4dn"
+        - "i3en"
+        - "i4i"
+        - "inf1"
+        - "m5"
+        - "m5d"
+        - "m5dn"
+        - "m5n"
+        - "m5zn"
+        - "m6i"
+        - "m6id"
+        - "r5"
+        - "r5b"
+        - "r5d"
+        - "r5dn"
+        - "r5n"
+        - "r6i"
+        - "r6id"
+        - "t3"
+        - "trn1"
+        - "vt1"
+        - "x2iedn"
+        - "x2iezn"
+        - "z1d"
+
+    # Instance Size
+    - key: "karpenter.k8s.aws/instance-size"
+      operator: In
+      values:
+        - "medium"
+        - "large"
+        - "xlarge"
+        - "2xlarge"
+        - "3xlarge"
+        - "4xlarge"
+        - "6xlarge"
+        - "8xlarge"
+
+    # Availability Zones
+    - key: "topology.kubernetes.io/zone"
+      operator: In
+      values:
+        - "us-east-1a"
+        - "us-east-1b"
+        - "us-east-1c"
+        - "us-east-1d"
+
+    # Try spot, fall over to on-demand
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: ["spot", "on-demand"]
+
+  # Only provision nodes for pods specifying the glr-x86-64-v4 node pool
+  labels:
+    spack.io/node-pool: glr-x86-64-v4

--- a/k8s/runners/testing/graviton/2/release.yaml
+++ b/k8s/runners/testing/graviton/2/release.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: runner-testing-graviton2
+  namespace: gitlab
+spec:
+  releaseName: testing-graviton2
+  chart:
+    name: gitlab-runner
+    repository: https://charts.gitlab.io
+    version: 0.37.2  # gitlab-runner@14.7.0
+  values:
+    image: gitlab/gitlab-runner:alpine-v14.7.0
+    imagePullPolicy: IfNotPresent
+    replicas: 1
+
+    gitlabUrl: "https://gitlab.spack.io/"
+    unregisterRunners: true
+    terminationGracePeriodSeconds: 21600  # six hours
+    concurrent: 2
+    checkInterval: 30
+
+    metrics:
+      enabled: true
+
+    rbac:
+      serviceAccountName: runner
+
+    runners:
+      config: |
+        [[runners]]
+          output_limit = 4096
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            helper_image = "gitlab/gitlab-runner-helper:arm-latest"
+            privileged = false
+
+            cpu_request = "750m"
+            cpu_request_overwrite_max_allowed = "16"
+            cpu_limit = "16"
+            cpu_limit_overwrite_max_allowed = "16"
+
+            memory_request = "2G"
+            memory_request_overwrite_max_allowed = "64G"
+            memory_limit = "64G"
+            memory_limit_overwrite_max_allowed = "64G"
+
+            namespace = "pipeline"
+            poll_timeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "fluentbit.io/exclude" = "true"
+              "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab/ci_job_url" = "$CI_JOB_URL"
+              "gitlab/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+              "gitlab/ci_job_id" = "$CI_JOB_ID"
+            [runners.kubernetes.pod_labels]
+              "gitlab/ci_job_size" = "$CI_JOB_SIZE"
+              "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "metrics/gitlab_ci_project_name" = "$CI_PROJECT_NAME"
+              "metrics/gitlab_ci_job_stage" = "$CI_JOB_STAGE"
+              "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
+            [runners.kubernetes.node_selector]
+              "spack.io/node-pool" = "glr-graviton2"
+
+      # default image
+      image: "busybox:1.32.0"
+      imagePullPolicy: "if-not-present"
+      locked: false
+
+      tags: "testing2,arm,aarch64,graviton,graviton2,small,medium,large,huge"
+      runUntagged: false
+      secret: gitlab-gitlab-runner-secret  # from gitlab release
+
+      serviceAccountName: runner
+
+      services: {}
+
+    nodeSelector:
+      spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/testing/graviton/3/release.yaml
+++ b/k8s/runners/testing/graviton/3/release.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: runner-testing-graviton3
+  namespace: gitlab
+spec:
+  releaseName: testing-graviton3
+  chart:
+    name: gitlab-runner
+    repository: https://charts.gitlab.io
+    version: 0.37.2  # gitlab-runner@14.7.0
+  values:
+    image: gitlab/gitlab-runner:alpine-v14.7.0
+    imagePullPolicy: IfNotPresent
+    replicas: 1
+
+    gitlabUrl: "https://gitlab.spack.io/"
+    unregisterRunners: true
+    terminationGracePeriodSeconds: 21600  # six hours
+    concurrent: 2
+    checkInterval: 30
+
+    metrics:
+      enabled: true
+
+    rbac:
+      serviceAccountName: runner
+
+    runners:
+      config: |
+        [[runners]]
+          output_limit = 4096
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            helper_image = "gitlab/gitlab-runner-helper:arm-latest"
+            privileged = false
+
+            cpu_request = "750m"
+            cpu_request_overwrite_max_allowed = "16"
+            cpu_limit = "16"
+            cpu_limit_overwrite_max_allowed = "16"
+
+            memory_request = "2G"
+            memory_request_overwrite_max_allowed = "64G"
+            memory_limit = "64G"
+            memory_limit_overwrite_max_allowed = "64G"
+
+            namespace = "pipeline"
+            poll_timeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "fluentbit.io/exclude" = "true"
+              "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab/ci_job_url" = "$CI_JOB_URL"
+              "gitlab/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+              "gitlab/ci_job_id" = "$CI_JOB_ID"
+            [runners.kubernetes.pod_labels]
+              "gitlab/ci_job_size" = "$CI_JOB_SIZE"
+              "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "metrics/gitlab_ci_project_name" = "$CI_PROJECT_NAME"
+              "metrics/gitlab_ci_job_stage" = "$CI_JOB_STAGE"
+              "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
+            [runners.kubernetes.node_selector]
+              "spack.io/node-pool" = "glr-graviton3"
+
+      # default image
+      image: "busybox:1.32.0"
+      imagePullPolicy: "if-not-present"
+      locked: false
+
+      tags: "testing2,arm,aarch64,graviton,graviton2,graviton3,small,medium,large,huge"
+      runUntagged: false
+      secret: gitlab-gitlab-runner-secret  # from gitlab release
+
+      serviceAccountName: runner
+
+      services: {}
+
+    nodeSelector:
+      spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/testing/x86_64/v2/release.yaml
+++ b/k8s/runners/testing/x86_64/v2/release.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: runner-testing-x86-v2
+  namespace: gitlab
+spec:
+  releaseName: testing-x86-v2
+  chart:
+    name: gitlab-runner
+    repository: https://charts.gitlab.io
+    version: 0.37.2  # gitlab-runner@14.7.0
+  values:
+    image: gitlab/gitlab-runner:alpine-v14.7.0
+    imagePullPolicy: IfNotPresent
+    replicas: 1
+
+    gitlabUrl: "https://gitlab.spack.io/"
+    unregisterRunners: true
+    terminationGracePeriodSeconds: 21600  # six hours
+    concurrent: 2
+    checkInterval: 30
+
+    metrics:
+      enabled: true
+
+    rbac:
+      serviceAccountName: runner
+
+    runners:
+      config: |
+        [[runners]]
+          output_limit = 4096
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            privileged = false
+
+            cpu_request = "750m"
+            cpu_request_overwrite_max_allowed = "12"
+            cpu_limit = "12"
+            cpu_limit_overwrite_max_allowed = "12"
+
+            memory_request = "2G"
+            memory_request_overwrite_max_allowed = "48G"
+            memory_limit = "48G"
+            memory_limit_overwrite_max_allowed = "48G"
+
+            namespace = "pipeline"
+            poll_timeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "fluentbit.io/exclude" = "true"
+              "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab/ci_job_url" = "$CI_JOB_URL"
+              "gitlab/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+              "gitlab/ci_job_id" = "$CI_JOB_ID"
+            [runners.kubernetes.pod_labels]
+              "gitlab/ci_job_size" = "$CI_JOB_SIZE"
+              "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "metrics/gitlab_ci_project_name" = "$CI_PROJECT_NAME"
+              "metrics/gitlab_ci_job_stage" = "$CI_JOB_STAGE"
+              "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
+            [runners.kubernetes.node_selector]
+              "spack.io/node-pool" = "glr-x86-64-v2"
+
+      # default image
+      image: "busybox:1.32.0"
+      imagePullPolicy: "if-not-present"
+      locked: false
+
+      tags: "testing2,x86_64,x86_64_v2,small,medium,large,huge"
+      runUntagged: false
+      secret: gitlab-gitlab-runner-secret  # from gitlab release
+
+      cache: {}
+
+      services: {}
+
+      helpers: {}
+
+    nodeSelector:
+      spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/testing/x86_64/v3/release.yaml
+++ b/k8s/runners/testing/x86_64/v3/release.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: runner-testing-x86-v3
+  namespace: gitlab
+spec:
+  releaseName: testing-x86-v3
+  chart:
+    name: gitlab-runner
+    repository: https://charts.gitlab.io
+    version: 0.37.2  # gitlab-runner@14.7.0
+  values:
+    image: gitlab/gitlab-runner:alpine-v14.7.0
+    imagePullPolicy: IfNotPresent
+    replicas: 1
+
+    gitlabUrl: "https://gitlab.spack.io/"
+    unregisterRunners: true
+    terminationGracePeriodSeconds: 21600  # six hours
+    concurrent: 2
+    checkInterval: 30
+
+    metrics:
+      enabled: true
+
+    rbac:
+      serviceAccountName: runner
+
+    runners:
+      config: |
+        [[runners]]
+          output_limit = 4096
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            privileged = false
+
+            cpu_request = "750m"
+            cpu_request_overwrite_max_allowed = "12"
+            cpu_limit = "12"
+            cpu_limit_overwrite_max_allowed = "12"
+
+            memory_request = "2G"
+            memory_request_overwrite_max_allowed = "48G"
+            memory_limit = "48G"
+            memory_limit_overwrite_max_allowed = "48G"
+
+            namespace = "pipeline"
+            poll_timeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "fluentbit.io/exclude" = "true"
+              "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab/ci_job_url" = "$CI_JOB_URL"
+              "gitlab/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+              "gitlab/ci_job_id" = "$CI_JOB_ID"
+            [runners.kubernetes.pod_labels]
+              "gitlab/ci_job_size" = "$CI_JOB_SIZE"
+              "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "metrics/gitlab_ci_project_name" = "$CI_PROJECT_NAME"
+              "metrics/gitlab_ci_job_stage" = "$CI_JOB_STAGE"
+              "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
+            [runners.kubernetes.node_selector]
+              "spack.io/node-pool" = "glr-x86-64-v3"
+
+      # default image
+      image: "busybox:1.32.0"
+      imagePullPolicy: "if-not-present"
+      locked: false
+
+      tags: "testing2,x86_64,x86_64_v2,x86_64_v3,avx,avx2,small,medium,large,huge"
+      runUntagged: false
+      secret: gitlab-gitlab-runner-secret  # from gitlab release
+
+      cache: {}
+
+      services: {}
+
+      helpers: {}
+
+    nodeSelector:
+      spack.io/node-pool: base  # pool for the runner

--- a/k8s/runners/testing/x86_64/v4/release.yaml
+++ b/k8s/runners/testing/x86_64/v4/release.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: runner-testing-x86-v4
+  namespace: gitlab
+spec:
+  releaseName: testing-x86-v4
+  chart:
+    name: gitlab-runner
+    repository: https://charts.gitlab.io
+    version: 0.37.2  # gitlab-runner@14.7.0
+  values:
+    image: gitlab/gitlab-runner:alpine-v14.7.0
+    imagePullPolicy: IfNotPresent
+    replicas: 1
+
+    gitlabUrl: "https://gitlab.spack.io/"
+    unregisterRunners: true
+    terminationGracePeriodSeconds: 21600  # six hours
+    concurrent: 2
+    checkInterval: 30
+
+    metrics:
+      enabled: true
+
+    rbac:
+      serviceAccountName: runner
+
+    runners:
+      config: |
+        [[runners]]
+          output_limit = 4096
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          [runners.kubernetes]
+            privileged = false
+
+            cpu_request = "750m"
+            cpu_request_overwrite_max_allowed = "12"
+            cpu_limit = "12"
+            cpu_limit_overwrite_max_allowed = "12"
+
+            memory_request = "2G"
+            memory_request_overwrite_max_allowed = "48G"
+            memory_limit = "48G"
+            memory_limit_overwrite_max_allowed = "48G"
+
+            namespace = "pipeline"
+            poll_timeout = 600  # ten minutes
+            service_account = "runner"
+            [runners.kubernetes.pod_annotations]
+              "fluentbit.io/exclude" = "true"
+              "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
+              "gitlab/ci_job_url" = "$CI_JOB_URL"
+              "gitlab/ci_project_url" = "$CI_PROJECT_URL"
+              "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
+              "gitlab/ci_job_id" = "$CI_JOB_ID"
+            [runners.kubernetes.pod_labels]
+              "gitlab/ci_job_size" = "$CI_JOB_SIZE"
+              "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
+              "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
+              "metrics/gitlab_ci_project_name" = "$CI_PROJECT_NAME"
+              "metrics/gitlab_ci_job_stage" = "$CI_JOB_STAGE"
+              "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
+              "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
+            [runners.kubernetes.node_selector]
+              "spack.io/node-pool" = "glr-x86-64-v4"
+
+      # default image
+      image: "busybox:1.32.0"
+      imagePullPolicy: "if-not-present"
+      locked: false
+
+      tags: "testing2,x86_64,x86_64_v2,x86_64_v3,x86_64_v4,avx,avx2,avx512,small,medium,large,huge"
+      runUntagged: false
+      secret: gitlab-gitlab-runner-secret  # from gitlab release
+
+      cache: {}
+
+      services: {}
+
+      helpers: {}
+
+    nodeSelector:
+      spack.io/node-pool: base  # pool for the runner


### PR DESCRIPTION
Also new testing runners to use the new provisioners. The current (old) provisioners and runners remain untouched by this change.