### PR TITLE
gh-gl-sync: Fix broken sync script

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -27,7 +27,7 @@ jobs:
           - python-aws-bash
         include:
           - docker-image: gh-gl-sync
-            image-tags: ghcr.io/spack/ci-bridge:0.0.30
+            image-tags: ghcr.io/spack/ci-bridge:0.0.31
           - docker-image: gitlab-api-scrape
             image-tags: ghcr.io/spack/gitlab-api-scrape:0.0.2
           - docker-image: ci-key-rotate

--- a/images/gh-gl-sync/Dockerfile
+++ b/images/gh-gl-sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10
 
 WORKDIR /scripts/
 COPY requirements.txt ./

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.30
+            image: ghcr.io/spack/ci-bridge:0.0.31
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
The sync script image became broken recently when it was rebuilt and picked up python 3.11.  At that point, one of the dependencies of the `github` package, `wrapt`, started failing.  See here:

https://github.com/GrahamDumpleton/wrapt/issues/196

This pins `python` at 3.10 until the `github` package can update its (possibly transitive) dependency on `wrapt` to the fixed version.