### PR TITLE
Add provisioner for base node pool

### DIFF
--- a/k8s/cluster-autoscaler/release.yaml
+++ b/k8s/cluster-autoscaler/release.yaml
@@ -1,3 +1,5 @@
+# TODO: If gitlab node-pool is ever migrated to karpenter, delete this file.
+# This is still necessary, even with the base node-pool gone, since CAS needs to run somewhere
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease

--- a/k8s/karpenter/provisioners/base/provisioner.yaml
+++ b/k8s/karpenter/provisioners/base/provisioner.yaml
@@ -1,0 +1,31 @@
+---
+# Provisioner for base pods
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: base
+spec:
+  providerRef:
+    name: default
+
+  # Consolidation will de-provision larger than necessary nodes
+  consolidation:
+    enabled: true
+
+  limits:
+    resources:
+      cpu: 128 # Limit to 64 t3.small nodes (2 vCPUs each)
+
+  requirements:
+    - key: "node.kubernetes.io/instance-type"
+      operator: In
+      values: ["t3.small"]
+
+    # Always use on-demand
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: ["on-demand"]
+
+  # Only provision nodes for pods specifying the base node pool
+  labels:
+    spack.io/node-pool: base


### PR DESCRIPTION
This adds the karpenter provisioner required for the `base` node pool.

It doesn't seem there's any code here for the autoscaling group associated with the base node pool, so I guess that will just need to be manually deprovisioned?

