### PR TITLE
Defer GitLab pipelines based on main branch history

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -27,7 +27,7 @@ jobs:
           - python-aws-bash
         include:
           - docker-image: gh-gl-sync
-            image-tags: ghcr.io/spack/ci-bridge:0.0.32
+            image-tags: ghcr.io/spack/ci-bridge:0.0.33
           - docker-image: gitlab-api-scrape
             image-tags: ghcr.io/spack/gitlab-api-scrape:0.0.2
           - docker-image: ci-key-rotate

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ services, including:
 * CDash: [cdash.spack.io](https://cdash.spack.io)
 * GitLab: [gitlab.spack.io](https://gitlab.spack.io)
 
+Why isn't my GitLab CI pipeline running yet? Please see our [Deferred Pipelines Documentation](docs/deferred_pipelines.md)
+
 ## Restoring from Backup
 
 - Delete the persistent volume (PV) and persistent volume claim (PVC) for the old volume that's being replaced.

--- a/docs/deferred_pipelines.md
+++ b/docs/deferred_pipelines.md
@@ -53,7 +53,7 @@ For any given PR branch:
 * Get the most recent commit of develop that was tested by GitLab (`latest-tested-develop`).
 * Run `git merge-base <pr-branch> develop` to find the merge base between this PR and develop (`merge-base-sha`).
 * Run `git merge-base --is-ancestor <merge-base-sha> <latest-tested-develop>` to determine if this PR's merge base with develop is an ancestor of `latest-tested-develop`.
-  * If it is, merge this PR branch with `latest-tested-develop` and push it to GitLab for testing
+  * If it is, merge `latest-tested-develop` with this PR branch and push it to GitLab for testing
   * If not, post a status to the `HEAD` commit for this PR on GitHub indicating why the GitLab CI pipelines are not running yet.
 
 ## Tips

--- a/docs/deferred_pipelines.md
+++ b/docs/deferred_pipelines.md
@@ -1,0 +1,69 @@
+# Deferred Pipelines
+
+## Overview
+
+We defer the GitLab CI pipelines for your PR if it is based on a commit of
+`develop` that is newer than what has already been tested by GitLab.
+
+## Background
+
+Spack is fortunate to have a large community of developers (like you!) and our
+development velocity is often quite high. Depending on what changes have been
+made to Spack recently, our GitLab CI pipelines can sometimes take hours to
+complete. For these reasons, we cannot feasibly run GitLab CI pipelines for
+every commit of `develop`.
+
+A key component of our GitLab CI pipeline infrastructure is the
+[_sync script_](https://github.com/spack/spack-infrastructure/blob/main/images/gh-gl-sync/SpackCIBridge.py).
+This runs as a cron job, copying PR branches from GitHub to GitLab where they
+are subjected to CI pipeline testing. The sync script also copies the current
+`HEAD` commit of `develop` to GitLab whenever it notices that there is no
+`develop` pipeline currently running.
+
+## Motivation
+
+As a `develop` pipeline runs, it builds packages and uploads them to Spack's
+public binary mirror. These prebuilt binary packages get reused by subsequent
+pipelines, reducing the total amount of work that our CI system needs to do.
+
+If we allow PR branches to "outrun" the latest tested commit of develop, they
+end up building packages that will also be built by a later `develop` pipeline.
+This wastes time and resources performing unnecessary work.
+
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'rotateCommitLabel': true, 'mainBranchName': 'develop'}} }%%
+gitGraph
+  commit id: "A"
+  commit id: "B (COMPLETE)"
+  commit id: "C"
+  commit id: "D (develop HEAD)"
+  branch PR
+  commit id: "fix/core"
+```
+
+In the figure above, the PR is based off `develop` `HEAD` (commit `D`). If we
+started a GitLab CI pipeline for this PR, it would redundantly build any
+packages that were changed in commit `C` on develop. To solve this problem, we
+defer pushing this PR to GitLab until a `develop` pipeline has completed for
+commit `D` or one of its descendants.
+
+## How it Works
+
+For any given PR branch:
+* Get the most recent commit of develop that was tested by GitLab (`latest-tested-develop`).
+* Run `git merge-base <pr-branch> develop` to find the merge base between this PR and develop (`merge-base-sha`).
+* Run `git merge-base --is-ancestor <merge-base-sha> <latest-tested-develop>` to determine if this PR's merge base with develop is an ancestor of `latest-tested-develop`.
+  * If it is, merge this PR branch with `latest-tested-develop` and push it to GitLab for testing
+  * If not, post a status to the `HEAD` commit for this PR on GitHub indicating why the GitLab CI pipelines are not running yet.
+
+## Tips
+
+After you open a PR, avoid merging or rebasing your branch with `develop`
+unless you really need to pull in these newer changes. Rebasing or merging
+develop into your PR branch is likely to cause your GitLab CI pipelines
+to be deferred for a longer period of time.
+
+Note that the "@spackbot run pipeline" and "@spackbot rebuild everything"
+functions now check if your branch on GitLab is up-to-date before triggering
+a pipeline. So if your PR branch is currently ahead of latest-tested-develop
+spackbot will not be able to help you run a new pipeline.

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -516,7 +516,7 @@ class SpackCIBridge(object):
                 continue
             elif reason == "base":
                 desc = base_backlog_desc
-                url = ""
+                url = "https://github.com/spack/spack-infrastructure/blob/main/docs/deferred_pipelines.md"
             elif reason == "draft":
                 desc = "GitLab CI is disabled for draft PRs"
                 url = ""

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -259,6 +259,8 @@ class SpackCIBridge(object):
         If main_branch was specified, we also fetch that branch from GitHub.
         """
         subprocess.run(["git", "init"], check=True)
+        subprocess.run(["git", "config", "user.email", "noreply@spack.io"], check=True)
+        subprocess.run(["git", "config", "user.name", "spackbot"], check=True)
         subprocess.run(["git", "remote", "add", "github", self.github_repo], check=True)
         subprocess.run(["git", "remote", "add", "gitlab", self.gitlab_repo], check=True)
 

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -179,6 +179,7 @@ class SpackCIBridge(object):
                             print("Failed to merge PR {0} ({1}) with latest tested {2} ({3}). Skipping"
                                   .format(pull.number, pull.head.ref, self.main_branch, self.latest_tested_main_commit))
                             self.unmergeable_shas.append(pull.head.sha)
+                            subprocess.run(["git", "merge", "--abort"])
                             continue
                     else:
                         print(f"Defer pushing {pr_string} because its merge base is NOT an ancestor of "
@@ -261,6 +262,7 @@ class SpackCIBridge(object):
         subprocess.run(["git", "init"], check=True)
         subprocess.run(["git", "config", "user.email", "noreply@spack.io"], check=True)
         subprocess.run(["git", "config", "user.name", "spackbot"], check=True)
+        subprocess.run(["git", "config", "advice.detachedHead", "false"], check=True)
         subprocess.run(["git", "remote", "add", "github", self.github_repo], check=True)
         subprocess.run(["git", "remote", "add", "gitlab", self.gitlab_repo], check=True)
 

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -182,7 +182,7 @@ class SpackCIBridge(object):
                             continue
                     else:
                         print(f"Defer pushing {pr_string} because its merge base is NOT an ancestor of "
-                              "latest_tested_main {merge_base_sha} vs. {self.latest_tested_main_commit}")
+                              f"latest_tested_main {merge_base_sha} vs. {self.latest_tested_main_commit}")
                         backlogged = "base"
 
                 if not backlogged and self.prereq_checks:

--- a/images/gh-gl-sync/test_SpackCIBridge.py
+++ b/images/gh-gl-sync/test_SpackCIBridge.py
@@ -25,7 +25,6 @@ def test_list_github_prs(capfd):
         AttrDict({
             "number": 1,
             "draft": False,
-            "merge_commit_sha": "aaaaaaaa",
             "updated_at": dt,
             "head": {
                 "ref": "improve_docs",
@@ -38,7 +37,6 @@ def test_list_github_prs(capfd):
         AttrDict({
             "number": 2,
             "draft": False,
-            "merge_commit_sha": "bbbbbbbb",
             "updated_at": dt,
             "head": {
                 "ref": "fix_test",
@@ -51,7 +49,6 @@ def test_list_github_prs(capfd):
         AttrDict({
             "number": 3,
             "draft": True,
-            "merge_commit_sha": "cccccccc",
             "updated_at": dt,
             "head": {
                 "ref": "wip",
@@ -78,7 +75,6 @@ def test_list_github_prs(capfd):
 
     github_prs = retval[0]
     assert github_prs["pr_strings"] == ["pr1_improve_docs", "pr2_fix_test", "pr3_wip"]
-    assert github_prs["merge_commit_shas"] == ["aaaaaaaa", "bbbbbbbb", "cccccccc"]
     assert gh_repo.get_pulls.call_count == 1
     out, err = capfd.readouterr()
     expected = """Rate limit after get_pulls(): 5000
@@ -140,23 +136,19 @@ def test_get_open_refspecs():
     """Test the get_open_refspecs and update_refspecs_for_protected_branches methods."""
     open_prs = {
         "pr_strings": ["pr1_this", "pr2_that"],
-        "merge_commit_shas": ["aaaaaaaa", "bbbbbbbb"],
         "base_shas": ["shafoo", "shabar"],
         "head_shas": ["shabaz", "shagah"],
         "backlogged": [False, False]
     }
     bridge = SpackCIBridge.SpackCIBridge()
-    open_refspecs, fetch_refspecs = bridge.get_open_refspecs(open_prs)
+    open_refspecs = bridge.get_open_refspecs(open_prs)
     assert open_refspecs == [
         "pr1_this:pr1_this",
         "pr2_that:pr2_that"
     ]
-    assert fetch_refspecs == [
-        "+aaaaaaaa:refs/remotes/pr1_this",
-        "+bbbbbbbb:refs/remotes/pr2_that"
-    ]
 
     protected_branches = ["develop", "master"]
+    fetch_refspecs = []
     bridge.update_refspecs_for_protected_branches(protected_branches, open_refspecs, fetch_refspecs)
     assert open_refspecs == [
         "pr1_this:pr1_this",
@@ -165,8 +157,6 @@ def test_get_open_refspecs():
         "refs/heads/master:refs/heads/master",
     ]
     assert fetch_refspecs == [
-        "+aaaaaaaa:refs/remotes/pr1_this",
-        "+bbbbbbbb:refs/remotes/pr2_that",
         "+refs/heads/develop:refs/remotes/develop",
         "+refs/heads/master:refs/remotes/master"
     ]
@@ -365,7 +355,6 @@ def test_post_pipeline_status(capfd):
     """Test the post_pipeline_status method."""
     open_prs = {
         "pr_strings": ["pr1_readme"],
-        "merge_commit_shas": ["aaaaaaaa"],
         "base_shas": ["shafoo"],
         "head_shas": ["shabaz"],
         "backlogged": [False]
@@ -415,7 +404,6 @@ def test_pipeline_status_backlogged_by_checks(capfd):
             AttrDict({
                 "number": 1,
                 "draft": False,
-                "merge_commit_sha": "aaaaaaaa",
                 "updated_at": dt,
                 "head": {
                     "ref": "improve_docs",
@@ -491,7 +479,6 @@ def test_pipeline_status_backlogged_for_draft_PR(capfd):
     """Test the post_pipeline_status method for a PR that is backlogged because it is marked as a draft."""
     open_prs = {
         "pr_strings": ["pr1_readme"],
-        "merge_commit_shas": ["aaaaaaaa"],
         "base_shas": ["shafoo"],
         "head_shas": ["shabaz"],
         "backlogged": ["draft"]

--- a/images/gh-gl-sync/test_SpackCIBridge.py
+++ b/images/gh-gl-sync/test_SpackCIBridge.py
@@ -207,8 +207,7 @@ def test_get_pipeline_api_template():
     """Test that pipeline_api_template get constructed properly."""
     bridge = SpackCIBridge.SpackCIBridge(gitlab_host="https://gitlab.spack.io", gitlab_project="zack/my_test_proj")
     template = bridge.pipeline_api_template
-    assert template[0:84] == "https://gitlab.spack.io/api/v4/projects/zack%2Fmy_test_proj/pipelines?updated_after="
-    assert template.endswith("&ref={1}")
+    assert template[0:74] == "https://gitlab.spack.io/api/v4/projects/zack%2Fmy_test_proj/pipelines?ref="
 
 
 def test_dedupe_pipelines():

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gh-gl-sync
   namespace: custom
 spec:
-  schedule: "*/4 * * * *"
+  schedule: "*/5 * * * *"
   jobTemplate:
     spec:
       backoffLimit: 0

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.32
+            image: ghcr.io/spack/ci-bridge:0.0.33
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
Don't push PR branches to GitLab for pipeline testing if they are based on a commit of the main branch that is newer than what has already been tested by GitLab.