### PR TITLE
Add `concurrencyPolicy: Forbid` to sync script cron job

### DIFF
--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: custom
 spec:
   schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       backoffLimit: 0


### PR DESCRIPTION
This prevents more than one copy of the sync script from running at the same time.

https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#concurrency-policy