### PR TITLE
Karpenter provisioner fixes

### DIFF
--- a/k8s/karpenter/provisioners/runners/graviton/2/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/graviton/2/provisioners.yaml
@@ -36,6 +36,9 @@ spec:
         - "4xlarge"
         - "6xlarge"
         - "8xlarge"
+        - "10xlarge"
+        - "12xlarge"
+        - "16xlarge"
 
     # Availability Zones
     - key: "topology.kubernetes.io/zone"

--- a/k8s/karpenter/provisioners/runners/graviton/3/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/graviton/3/provisioners.yaml
@@ -43,6 +43,9 @@ spec:
         - "4xlarge"
         - "6xlarge"
         - "8xlarge"
+        - "10xlarge"
+        - "12xlarge"
+        - "16xlarge"
 
     # Availability Zones
     - key: "topology.kubernetes.io/zone"

--- a/k8s/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
@@ -36,6 +36,9 @@ spec:
         - "4xlarge"
         - "6xlarge"
         - "8xlarge"
+        - "10xlarge"
+        - "12xlarge"
+        - "16xlarge"
 
     # Availability Zones
     - key: "topology.kubernetes.io/zone"

--- a/k8s/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
@@ -99,6 +99,9 @@ spec:
         - "4xlarge"
         - "6xlarge"
         - "8xlarge"
+        - "10xlarge"
+        - "12xlarge"
+        - "16xlarge"
 
     # Availability Zones
     - key: "topology.kubernetes.io/zone"

--- a/k8s/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
@@ -74,6 +74,9 @@ spec:
         - "4xlarge"
         - "6xlarge"
         - "8xlarge"
+        - "10xlarge"
+        - "12xlarge"
+        - "16xlarge"
 
     # Availability Zones
     - key: "topology.kubernetes.io/zone"

--- a/k8s/runners/signing/release.yaml
+++ b/k8s/runners/signing/release.yaml
@@ -71,7 +71,7 @@ spec:
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "amd64"
-              "spack.io/node-pool" = "glr-large-pub"
+              "spack.io/node-pool" = "glr-x86-64-v3"
 
             [[runners.kubernetes.volumes.secret]]
               name = "spack-signing-key-encrypted"


### PR DESCRIPTION
* Allow Karpenter to spin up bigger instances
  * c7g.8xlarge is apparently not big enough to build ParaView
* Update node pool for signing runner
  * glr-large-pub doesn't exist anymore