### PR TITLE
Add memory requests to gitlab helper containers

### DIFF
--- a/k8s/runners/protected/graviton/2/release.yaml
+++ b/k8s/runners/protected/graviton/2/release.yaml
@@ -35,6 +35,7 @@ spec:
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"

--- a/k8s/runners/protected/graviton/3/release.yaml
+++ b/k8s/runners/protected/graviton/3/release.yaml
@@ -35,6 +35,7 @@ spec:
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"

--- a/k8s/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/runners/protected/x86_64/v2/release.yaml
@@ -34,6 +34,7 @@ spec:
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"

--- a/k8s/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/runners/protected/x86_64/v3/release.yaml
@@ -34,6 +34,7 @@ spec:
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"

--- a/k8s/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/runners/protected/x86_64/v4/release.yaml
@@ -34,6 +34,7 @@ spec:
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"

--- a/k8s/runners/public/graviton/2/release.yaml
+++ b/k8s/runners/public/graviton/2/release.yaml
@@ -35,6 +35,7 @@ spec:
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"

--- a/k8s/runners/public/graviton/3/release.yaml
+++ b/k8s/runners/public/graviton/3/release.yaml
@@ -35,6 +35,7 @@ spec:
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"

--- a/k8s/runners/public/x86_64/v2/release.yaml
+++ b/k8s/runners/public/x86_64/v2/release.yaml
@@ -34,6 +34,7 @@ spec:
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"

--- a/k8s/runners/public/x86_64/v3/release.yaml
+++ b/k8s/runners/public/x86_64/v3/release.yaml
@@ -34,6 +34,7 @@ spec:
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"

--- a/k8s/runners/public/x86_64/v4/release.yaml
+++ b/k8s/runners/public/x86_64/v4/release.yaml
@@ -34,6 +34,7 @@ spec:
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"

--- a/k8s/runners/signing/release.yaml
+++ b/k8s/runners/signing/release.yaml
@@ -36,6 +36,8 @@ spec:
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
+            helper_memory_request = "512m"
+
             cpu_request = "10"
             cpu_limit = "10"
             memory_request = "8G"

--- a/k8s/runners/testing/graviton/2/release.yaml
+++ b/k8s/runners/testing/graviton/2/release.yaml
@@ -36,6 +36,7 @@ spec:
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"

--- a/k8s/runners/testing/x86_64/v3/release.yaml
+++ b/k8s/runners/testing/x86_64/v3/release.yaml
@@ -35,6 +35,7 @@ spec:
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
+            helper_memory_request = "512m"
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"


### PR DESCRIPTION
Adds a memory request of 512MB for `gitlab-runner-helper` init containers. 512MB is just a guess on my part, based on [what the gitlab runner helper does](https://stackoverflow.com/questions/67620001/what-is-gitlab-gitlab-runner-helper-docker-image-used-for), and may not be ideal. However, setting it can't hurt and is better than what we have now (nothing), and will hopefully help mitigate the OOMKilled issue until we can get an idea of the actual memory requirements of these containers (which will in turn help us determine suitable memory _limits_ to put on this container)