### PR TITLE
Improved opensearch pipeline logs upload script

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -54,7 +54,7 @@ jobs:
           - docker-image: python-aws-bash
             image-tags: ghcr.io/spack/python-aws-bash:0.0.1
           - docker-image: opensearch-index-build-logs
-            image-tags: ghcr.io/spack/opensearch-index-build-logs:0.0.1
+            image-tags: ghcr.io/spack/opensearch-index-build-logs:0.0.2
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/images/opensearch-index-build-logs/Dockerfile
+++ b/images/opensearch-index-build-logs/Dockerfile
@@ -1,8 +1,14 @@
-FROM python:3.10
+FROM python:3.11-slim
 
 WORKDIR /scripts/
+
+# psycopg2 dependencies
+RUN apt-get update && apt-get install -y libpq-dev gcc
+
 COPY requirements.txt ./
+RUN pip install --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt
-COPY build_logs_to_opensearch.py ./
+
+COPY . .
 
 ENTRYPOINT [ "python", "./build_logs_to_opensearch.py"]

--- a/images/opensearch-index-build-logs/build_logs_to_opensearch.py
+++ b/images/opensearch-index-build-logs/build_logs_to_opensearch.py
@@ -8,18 +8,33 @@ import tarfile
 from datetime import datetime
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Any
 
 import boto3
+import gitlab
+import psycopg2
+from psycopg2.extras import RealDictCursor
+import pyjson5
 import requests
 from botocore import UNSIGNED
 from botocore.client import Config
-from botocore.exceptions import ClientError
 
 # Authenticate the boto3 client with AWS.
 # Since the spack build cache is a public S3 bucket, we don't need credentials
 s3 = boto3.client(
-    "s3", config=Config(signature_version=UNSIGNED), region_name="us-east-1"
+    "s3",
+    config=Config(retries={"mode": "adaptive"}, signature_version=UNSIGNED),
+    region_name="us-east-1",
 )
+
+db_conn = psycopg2.connect(
+    host=os.environ["GITLAB_PG_HOST"],
+    port=os.environ["GITLAB_PG_PORT"],
+    dbname=os.environ["GITLAB_PG_DBNAME"],
+    user=os.environ["GITLAB_PG_USER"],
+    password=os.environ["GITLAB_PG_PASS"],
+)
+cur = db_conn.cursor(cursor_factory=RealDictCursor)
 
 logging.basicConfig(level=logging.ERROR)  # Only log ERROR messages
 
@@ -32,30 +47,74 @@ OPENSEARCH_PASSWORD = os.environ["OPENSEARCH_PASSWORD"]
 
 TODAY = datetime.today()
 
+gl = gitlab.Gitlab("https://gitlab.spack.io", os.environ["GITLAB_TOKEN"])
+
+
+def get_gitlab_build_job_metadata(build_hash: str) -> dict[str, Any]:
+    """
+    Get metadata from the gitlab job that performed this build.
+
+    Searches metabase for the gitlab job with the given build hash,
+    then uses the resulting job ID to get the job's metadata from
+    the gitlab API.
+    """
+    shortened_build_hash = build_hash[:7]
+
+    cur.execute(
+        """
+        SELECT id
+        FROM ci_builds
+        WHERE name LIKE '%%' || %(hash)s || '%%'
+        AND status = 'success'
+        ORDER BY id DESC
+        """,
+        {"hash": shortened_build_hash},
+    )
+    results = [dict(r) for r in cur.fetchall()]
+    gitlab_job_id = int(results[0]["id"])
+    project = gl.projects.get(2)
+    job = project.jobs.get(gitlab_job_id)
+    return json.loads(job.to_json())
+
 
 def post_logs(log_data):
     """Post the given JSON log data to OpenSearch."""
+
+    def _convert_booleans_to_strings(obj):
+        if isinstance(obj, bool):
+            return str(obj).lower()
+        if isinstance(obj, (list, tuple)):
+            return [_convert_booleans_to_strings(item) for item in obj]
+        if isinstance(obj, dict):
+            return {
+                key: _convert_booleans_to_strings(value) for key, value in obj.items()
+            }
+        return obj
+
     res = requests.post(
         f"{OPENSEARCH_ENDPOINT}/pipeline-logs-{TODAY.strftime('%Y.%m.%d')}/_doc",
-        data=json.dumps(log_data),
+        data=json.dumps(_convert_booleans_to_strings(log_data)),
         headers={"Content-Type": "application/json"},
         auth=(OPENSEARCH_USERNAME, OPENSEARCH_PASSWORD),
     )
-    if res.status_code >= 400:
-        logging.error(f"Failed to POST logs to OpenSearch. Log dump: {log_data}")
+    res.raise_for_status()
 
 
 def upload_to_opensearch(
-    spec_json: dict, install_times_json: dict, spack_build_out: dict[str, str]
+    build_hash: str,
+    spec_json: dict,
+    install_times_json: dict,
 ):
     """
     Given a spec.json, install_times.json, and spack-build-out files, package them all
     into a single JSON document and POSTs them to the OpenSearch API.
     """
-    document = {}
+    document: dict[str, Any] = {}
+
+    document["hash"] = build_hash
     document["spec"] = spec_json["spec"]
     document["install_times"] = install_times_json
-    document["spack-build-out"] = spack_build_out
+    document["gitlab_job_metadata"] = get_gitlab_build_job_metadata(build_hash)
 
     post_logs(document)
 
@@ -68,98 +127,146 @@ def create_opensearch_index():
     not create a new one.
     """
     index_name = f"pipeline-logs-{TODAY.strftime('%Y.%m.%d')}"
+    with open(Path(__file__).parent / "pipeline_logs_mapping.json5") as fd:
+        index_mappings = pyjson5.load(fd)
     res = requests.put(
         f"{OPENSEARCH_ENDPOINT}/{index_name}",
-        # Disable date_detection. OpenSearch thinks the `version` field in spec.json is a date
-        # for some reason.
-        data=json.dumps({"mappings": {"date_detection": False}}),
+        data=json.dumps(index_mappings),
         headers={"Content-Type": "application/json"},
         auth=(OPENSEARCH_USERNAME, OPENSEARCH_PASSWORD),
     )
     if res.status_code >= 400:
         logging.error(
-            f'Failed to create opensearch index "{index_name}", server responded with status {res.status_code}'
+            f'Failed to create opensearch index "{index_name}", '
+            f"server responded with status {res.status_code}"
         )
+        try:
+            logging.error(res.json())
+        except json.JSONDecodeError:
+            logging.error(res.text)
 
 
 def fetch_and_upload_tarball(spec_json_sig_key: str):
     logging.info(f'Fetching and uploading "{spec_json_sig_key}"...')
 
-    # Extract metadata from *.spec.json.sig filename
-    (os_arch, compiler, package, hash) = re.findall(
-        rf"{PREFIX}/(.+)-(.+-[\d+\.]+)-(.+)-(.+).spec.json.sig",
-        spec_json_sig_key,
-    )[0]
+    build_hash = spec_json_sig_key[: -len(".spec.json.sig")][-32:]
+    shortened_build_hash = build_hash[:7]
+
+    cur.execute(
+        """
+        SELECT name
+        FROM ci_builds
+        WHERE name LIKE '%%' || %(hash)s || '%%'
+        AND status = 'success'
+        ORDER BY id DESC
+        """,
+        {"hash": shortened_build_hash},
+    )
+    results = [dict(r) for r in cur.fetchall()]
+
+    if not len(results):
+        logging.error(f"No gitlab job entry found for {spec_json_sig_key}")
+        return
+
+    gitlab_job_name: str = results[0]["name"]
+
+    compiler = gitlab_job_name.split()[3].replace("@", "-")
+    os_arch = gitlab_job_name.split()[4]
+
+    package_regex = (
+        rf"{PREFIX}\/{os_arch}-{compiler}-(.+)-[a-zA-Z0-9]{{32}}.spec.json.sig"
+    )
+    try:
+        # Extract package name from *.spec.json.sig filename
+        package: str = re.findall(package_regex, spec_json_sig_key)[0]
+    except IndexError:
+        logging.error(f'Regex "{package_regex}" failed to extract package name')
+        return
+
+    # Check if a document with this hash already exists, and if so don't upload it.
+    res = requests.get(
+        f"{OPENSEARCH_ENDPOINT}/pipeline-logs*/_search",
+        data=json.dumps({"query": {"match": {"hash": build_hash}}}),
+        headers={"Content-Type": "application/json"},
+        auth=(OPENSEARCH_USERNAME, OPENSEARCH_PASSWORD),
+    )
+    res.raise_for_status()
+
+    if res.json()["hits"]["total"]["value"] > 0:
+        logging.info(
+            f"Skipping upload of record with build hash {build_hash} - already exists."
+        )
+        return
 
     binary_prefix = f"{PREFIX}/{os_arch}/{compiler}/{package}"
+    file_path = f"{binary_prefix}/{os_arch}-{compiler}-{package}-{build_hash}.spack"
 
-    # Download the tarball, extract it to a temp directory, parse the build logs we're
-    # interested in, and POST them to the OpenSearch cluster.
-    with NamedTemporaryFile("rb+") as f:
-        file_path = f"{binary_prefix}/{os_arch}-{compiler}-{package}-{hash}.spack"
-        try:
+    try:
+        # Download the tarball, extract it to a temp directory, parse the build logs we're
+        # interested in, and POST them to the OpenSearch cluster.
+        with NamedTemporaryFile("rb+") as f:
             s3.download_fileobj(BUCKET, file_path, f)
-        except ClientError as e:
-            logging.error(e)
-            return
-        with tarfile.open(f.name, mode="r:gz") as tar, TemporaryDirectory() as temp_dir:
-            tar.extract(f"{package}-{hash}/.spack/spec.json", path=temp_dir)
-            tar.extract(f"{package}-{hash}/.spack/install_times.json", path=temp_dir)
-
-            spec_json = json.loads(
-                (
-                    Path(temp_dir) / f"{package}-{hash}" / ".spack" / "spec.json"
-                ).read_text()
-            )
-            install_times = json.loads(
-                (
-                    Path(temp_dir)
-                    / f"{package}-{hash}"
-                    / ".spack"
-                    / "install_times.json"
-                ).read_text()
-            )
-
-            spack_build_out: dict[str, str] = {}
-
-            # Find all files with name in format of
-            # `spack-build-<phase-name>-<phase-number>-out.txt`
-            spack_build_out_paths = re.findall(
-                rf"{package}-{hash}/.spack/spack-build-(\d+)-(.+)-out.txt",
-                "\n".join(tar.getnames()),
-            )
-
-            # Extract all spack-build-<phase-name>-<phase-number>-out.txt files from the tarball
-            # and add them as seperate entries in the spack_build_out JSON object.
-            for phase_number, phase_name in spack_build_out_paths:
+            with tarfile.open(
+                f.name, mode="r:gz"
+            ) as tar, TemporaryDirectory() as temp_dir:
+                tar.extract(f"{package}-{build_hash}/.spack/spec.json", path=temp_dir)
                 tar.extract(
-                    f"{package}-{hash}/.spack/spack-build-{phase_number}-{phase_name}-out.txt",
-                    path=temp_dir,
+                    f"{package}-{build_hash}/.spack/install_times.json", path=temp_dir
                 )
-                spack_build_out[f"{phase_number}-{phase_name}"] = (
-                    Path(temp_dir)
-                    / f"{package}-{hash}"
-                    / ".spack"
-                    / f"spack-build-{phase_number}-{phase_name}-out.txt"
-                ).read_text()
 
-            upload_to_opensearch(spec_json, install_times, spack_build_out)
+                spec_json = json.loads(
+                    (
+                        Path(temp_dir)
+                        / f"{package}-{build_hash}"
+                        / ".spack"
+                        / "spec.json"
+                    ).read_text()
+                )
+                install_times = json.loads(
+                    (
+                        Path(temp_dir)
+                        / f"{package}-{build_hash}"
+                        / ".spack"
+                        / "install_times.json"
+                    ).read_text()
+                )
+
+                upload_to_opensearch(build_hash, spec_json, install_times)
+    except Exception as e:
+        # Catch all exceptions and log error instead of crashing script
+        logging.error(f'Error occurred while processing Key "{spec_json_sig_key}"')
+        logging.error(f"Tarball S3 Key = {file_path}")
+        logging.error(str(e))
+        if isinstance(e, requests.HTTPError):
+            try:
+                logging.error(str(e.response.json()) + "\n\n")
+            except json.JSONDecodeError:
+                logging.error(str(e.response.content) + "\n\n")
+        return
 
 
 def main():
     """Iterate over the entire S3 bucket and send any new build logs to OpenSearch."""
     create_opensearch_index()
+
+    all_pages = []
     paginator = s3.get_paginator("list_objects_v2")
-    for result in paginator.paginate(Bucket=BUCKET, Prefix=PREFIX):
-        for obj in result["Contents"]:
-            # Ignore files that don't end in spec.json.sig
-            if not obj.get("Key", "").endswith(".spec.json.sig"):
-                continue
-            # Ignore files that aren't from today
-            if obj["LastModified"].date() != TODAY.date():
-                continue
-            fetch_and_upload_tarball(obj["Key"])
+    for page in paginator.paginate(Bucket=BUCKET, Prefix=PREFIX):
+        contents = [
+            key["Key"]
+            for key in page["Contents"]
+            if key["Key"].endswith(".spec.json.sig")
+        ]
+        all_pages.extend(contents)
+
+    # TODO: parallelize this
+    for spec_key_json in all_pages:
+        fetch_and_upload_tarball(spec_key_json)
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    finally:
+        cur.close()
+        db_conn.close()

--- a/k8s/custom/opensearch-index-build-logs/cron-jobs.yaml
+++ b/k8s/custom/opensearch-index-build-logs/cron-jobs.yaml
@@ -12,8 +12,8 @@ spec:
           restartPolicy: Never
           containers:
           - name: opensearch-index-build-logs
-            image: ghcr.io/spack/opensearch-index-build-logs:0.0.1
-            imagePullPolicy: IfNotPresent
+            image: ghcr.io/spack/opensearch-index-build-logs:0.0.2
+            imagePullPolicy: Always
             env:
             - name: OPENSEARCH_ENDPOINT
               valueFrom:
@@ -30,5 +30,35 @@ spec:
                 secretKeyRef:
                   name: opensearch-index-build-logs
                   key: opensearch-password
+            - name: GITLAB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-index-build-logs
+                  key: gitlab-token
+            - name: GITLAB_PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-index-build-logs
+                  key: gitlab_pg_host
+            - name: GITLAB_PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-index-build-logs
+                  key: gitlab_pg_port
+            - name: GITLAB_PG_DBNAME
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-index-build-logs
+                  key: gitlab_pg_dbname
+            - name: GITLAB_PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-index-build-logs
+                  key: gitlab_pg_user
+            - name: GITLAB_PG_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-index-build-logs
+                  key: gitlab_pg_pass
           nodeSelector:
             spack.io/node-pool: base

--- a/k8s/custom/opensearch-index-build-logs/cron-jobs.yaml
+++ b/k8s/custom/opensearch-index-build-logs/cron-jobs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: opensearch-index-build-logs
   namespace: custom
 spec:
-  schedule: "0 0 * * *"
+  schedule: "0 0 1-31/2 * *"  # Run every other day
   jobTemplate:
     spec:
       template:

--- a/k8s/custom/opensearch-index-build-logs/secrets-dummy.yaml
+++ b/k8s/custom/opensearch-index-build-logs/secrets-dummy.yaml
@@ -10,3 +10,9 @@ stringData:
   opensearch-endpoint: The endpoint of the opensearch API. Should be the same as the "host" from k8s/logging/secrets.yaml
   opensearch-username: Admin user name for the OpenSearch cluster. Set using the AWS console.
   opensearch-password: Password for the admin account of the OpenSearch cluster. Set using the AWS console.
+  gitlab_pg_host: GitLab PostgreSQL DB hostname
+  gitlab_pg_port: GitLab PostgreSQL DB port
+  gitlab_pg_dbname: GitLab PostgreSQL DB name
+  gitlab_pg_user: GitLab PostgreSQL DB username
+  gitlab_pg_pass: GitLab PostgreSQL DB password
+  gitlab-token: Gitlab token allowing read access to gitlab jobs


### PR DESCRIPTION
- Fixed regex bug where certain spackball filenames wouldn't get parsed correctly,
leading to an incorrect s3 prefix being queried for
- Check if a spackball already exists in opensearch *before* downloading
and extracting it
- Include metadata from the gitlab job that built each spackball

This has been running in the cluster for a while now and seems to work as expected.