### PR TITLE
gh-gl-sync: Make sure merge commit message matches commit parents

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -28,7 +28,7 @@ jobs:
           - python-aws-bash
         include:
           - docker-image: gh-gl-sync
-            image-tags: ghcr.io/spack/ci-bridge:0.0.34
+            image-tags: ghcr.io/spack/ci-bridge:0.0.35
           - docker-image: gitlab-api-scrape
             image-tags: ghcr.io/spack/gitlab-api-scrape:0.0.2
           - docker-image: ci-key-rotate

--- a/k8s/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/custom/gh-gl-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.34
+            image: ghcr.io/spack/ci-bridge:0.0.35
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
We saw recently that fetching from the repo (via `git fetch <remote> refs/pull/<pr_number>/head:<tmp_branch>`) can produce a different pr head sha than the GH api (via `pull.head.sha`).  When that happened, we used the value from the api to make the merge commit message, but the commit contained an older PR HEAD as one of its parents.

This change checks to make sure the two values match.  If they do not match, since we cannot be sure which sha is correct, we avoid making and pushing the merge commit for the PR.

See this Spack PR [comment](https://github.com/spack/spack/pull/34452#issuecomment-1349527215) for an example and description of the problem fixed here.