### PR TITLE
Remove CPU limits from pipeline pods

### DIFF
--- a/k8s/runners/protected/graviton/2/release.yaml
+++ b/k8s/runners/protected/graviton/2/release.yaml
@@ -39,8 +39,6 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
-            cpu_limit = "16"
-            cpu_limit_overwrite_max_allowed = "16"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/runners/protected/graviton/3/release.yaml
+++ b/k8s/runners/protected/graviton/3/release.yaml
@@ -39,8 +39,6 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
-            cpu_limit = "16"
-            cpu_limit_overwrite_max_allowed = "16"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/runners/protected/x86_64/v2/release.yaml
@@ -38,8 +38,6 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
-            cpu_limit = "16"
-            cpu_limit_overwrite_max_allowed = "16"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/runners/protected/x86_64/v3/release.yaml
@@ -38,8 +38,6 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
-            cpu_limit = "16"
-            cpu_limit_overwrite_max_allowed = "16"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/runners/protected/x86_64/v4/release.yaml
@@ -38,8 +38,6 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
-            cpu_limit = "16"
-            cpu_limit_overwrite_max_allowed = "16"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/runners/public/graviton/2/release.yaml
+++ b/k8s/runners/public/graviton/2/release.yaml
@@ -39,8 +39,6 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
-            cpu_limit = "16"
-            cpu_limit_overwrite_max_allowed = "16"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/runners/public/graviton/3/release.yaml
+++ b/k8s/runners/public/graviton/3/release.yaml
@@ -39,8 +39,6 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
-            cpu_limit = "16"
-            cpu_limit_overwrite_max_allowed = "16"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/runners/public/x86_64/v2/release.yaml
+++ b/k8s/runners/public/x86_64/v2/release.yaml
@@ -38,8 +38,6 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"
-            cpu_limit = "12"
-            cpu_limit_overwrite_max_allowed = "12"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "48G"

--- a/k8s/runners/public/x86_64/v3/release.yaml
+++ b/k8s/runners/public/x86_64/v3/release.yaml
@@ -38,8 +38,6 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"
-            cpu_limit = "12"
-            cpu_limit_overwrite_max_allowed = "12"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "48G"

--- a/k8s/runners/public/x86_64/v4/release.yaml
+++ b/k8s/runners/public/x86_64/v4/release.yaml
@@ -38,8 +38,6 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"
-            cpu_limit = "12"
-            cpu_limit_overwrite_max_allowed = "12"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "48G"


### PR DESCRIPTION
These were originally set up for our m5zn.3xlarges. Now that we are using Karpenter, hardcoding this limit to 12 vCPUS no longer makes sense.