### PR TITLE
Reenable GitlabPipelinePodStuck alert

### DIFF
--- a/k8s/prometheus/custom/alerts.yaml
+++ b/k8s/prometheus/custom/alerts.yaml
@@ -12,19 +12,18 @@ spec:
    - name: spack-custom-alerts
      rules:
 
-      # Disable this alert for now
-      #  - alert: GitlabPipelinePodStuck
-      #    annotations:
-      #      description: '{{ $labels.pod }} has had no activity for more than 5 minutes.'
-      #      runbook_url: 'TODO'
-      #      summary: 'The pod appears to be stuck.  No CPU, RAM, or Network activity for the last 5 minutes.'
-      #    expr: node_namespace_pod_name:pipeline_stuck_pods_info == 1
-      #    for: 5m
-      #    labels:
-      #      group: gitlab_webservice_error_rate
-      #      severity: warning
-      #      namespace: monitoring
-      #      source_namespace: "{{ $labels.namespace }}"
+       - alert: GitlabPipelinePodStuck
+         annotations:
+           description: '{{ $labels.pod }} has had no activity for more than 5 minutes.'
+           runbook_url: 'TODO'
+           summary: 'The pod appears to be stuck.  No CPU, RAM, or Network activity for the last 5 minutes.'
+         expr: node_namespace_pod_name:pipeline_stuck_pods_info == 1
+         for: 5m
+         labels:
+           group: gitlab_webservice_error_rate
+           severity: info
+           namespace: monitoring
+           source_namespace: "{{ $labels.namespace }}"
 
        - alert: GitLabWebServiceErrorRate5Percent
          annotations:


### PR DESCRIPTION
This alert is needed for our "stuck pod" mitigation in images/gitlab-stuckpods/ to function properly.