### PR TITLE
Add karpenter service monitor

### DIFF
--- a/k8s/karpenter/service-monitor.yaml
+++ b/k8s/karpenter/service-monitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: karpenter
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karpenter
+  endpoints:
+    - port: http-metrics
+  namespaceSelector:
+    matchNames: ["karpenter"]


### PR DESCRIPTION
This allows for prometheus to access the exposed karpenter metrics

This has been running on the cluster for over a month, and is just the code change.