### PR TITLE
Add pipline label to all runner provisioners

### DIFF
--- a/k8s/karpenter/provisioners/runners/graviton/2/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/graviton/2/provisioners.yaml
@@ -57,3 +57,4 @@ spec:
   # Only provision nodes for pods specifying the glr-graviton2 node pool
   labels:
     spack.io/node-pool: glr-graviton2
+    spack.io/pipeline: true

--- a/k8s/karpenter/provisioners/runners/graviton/3/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/graviton/3/provisioners.yaml
@@ -64,3 +64,4 @@ spec:
   # Only provision nodes for pods specifying the glr-graviton3 node pool
   labels:
     spack.io/node-pool: glr-graviton3
+    spack.io/pipeline: true

--- a/k8s/karpenter/provisioners/runners/testing/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/testing/provisioners.yaml
@@ -48,3 +48,4 @@ spec:
   # Only provision nodes from the glr-large-testing-pub node pool
   labels:
     spack.io/node-pool: glr-large-testing-pub
+    spack.io/pipeline: true

--- a/k8s/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
@@ -57,3 +57,4 @@ spec:
   # Only provision nodes for pods specifying the glr-x86-64-v2 node pool
   labels:
     spack.io/node-pool: glr-x86-64-v2
+    spack.io/pipeline: true

--- a/k8s/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
@@ -120,3 +120,4 @@ spec:
   # Only provision nodes for pods specifying the glr-x86-64-v3 node pool
   labels:
     spack.io/node-pool: glr-x86-64-v3
+    spack.io/pipeline: true

--- a/k8s/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
@@ -95,3 +95,4 @@ spec:
   # Only provision nodes for pods specifying the glr-x86-64-v4 node pool
   labels:
     spack.io/node-pool: glr-x86-64-v4
+    spack.io/pipeline: true


### PR DESCRIPTION
This adds the `spack.io/pipeline: true` label to all pipeline provisioners. This was something that was missed during the karpenter switchover.