### PR TITLE
Add missing dummy secrets

### DIFF
--- a/k8s/custom/gh-gl-sync/secrets-dummy.yaml
+++ b/k8s/custom/gh-gl-sync/secrets-dummy.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: gh-gl-sync
+  namespace: custom
+  annotations:
+    fluxcd.io/ignore: "true"
+data:
+  github-access-token: "" # This token must have repo:status permissions
+  gitlab-ssh-key: ""

--- a/k8s/custom/gitlab-api-scrape/secrets-dummy.yaml
+++ b/k8s/custom/gitlab-api-scrape/secrets-dummy.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitlab-api-scrape
+  namespace: custom
+  annotations:
+    fluxcd.io/ignore: "true"
+data:
+  gitlab-private-token: "" # gitlab access token (get from https://gitlab.spack.io/spack/spack/-/settings/access_tokens)

--- a/k8s/custom/rotate-keys/secrets-dummy.yaml
+++ b/k8s/custom/rotate-keys/secrets-dummy.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rotate-keys
+  namespace: custom
+  annotations:
+    fluxcd.io/ignore: "true"
+data:
+  gitlab-token: "" # gitlab access token (get from https://gitlab.spack.io/spack/spack/-/settings/access_tokens)

--- a/k8s/gitlab/release.yaml
+++ b/k8s/gitlab/release.yaml
@@ -59,9 +59,10 @@ spec:
       smtp:
         enabled: true
         address: email-smtp.us-east-1.amazonaws.com
-        user_name: AKIAYSCIUVA2HA4WTV6O
+        user_name: AKIAYSCIUVA2L2NKBRON
         password:
-          secret: smtp-password
+          secret: gitlab-secrets
+          key: smtp-password
         port: 465
         tls: true
 
@@ -72,7 +73,7 @@ spec:
           key: postgres-password
         port: 5432
         database: gitlabhq_production
-        username: gitlab
+        username: postgres
 
       redis:
         password:

--- a/k8s/gitlab/secrets.yaml
+++ b/k8s/gitlab/secrets.yaml
@@ -12,3 +12,4 @@ stringData:
       psql:
         host: host.rds.example.com # fake hostname
   postgres-password: password # fake password
+  smtp-password: password # fake password


### PR DESCRIPTION
While setting the cluster back up, I came across some secrets that were referenced in various services that didn't have a corresponding "dummy" file in the spack-infrastructure repo.