### PR TITLE
Add Karpenter provisioners for gitlab and beefy node pools

### DIFF
--- a/k8s/karpenter/provisioners/beefy/provisioner.yaml
+++ b/k8s/karpenter/provisioners/beefy/provisioner.yaml
@@ -1,0 +1,23 @@
+---
+# Provisioner for beefy pods
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: beefy
+spec:
+  providerRef:
+    name: default
+
+  requirements:
+    - key: "node.kubernetes.io/instance-type"
+      operator: In
+      values: ["r5.2xlarge"]
+
+    # Always use on-demand
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: ["on-demand"]
+
+  # Only provision nodes for pods specifying the beefy node pool
+  labels:
+    spack.io/node-pool: beefy

--- a/k8s/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/karpenter/provisioners/gitlab/provisioner.yaml
@@ -1,0 +1,23 @@
+---
+# Provisioner for gitlab pods
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: gitlab
+spec:
+  providerRef:
+    name: default
+
+  requirements:
+    - key: "node.kubernetes.io/instance-type"
+      operator: In
+      values: ["t3.xlarge"]
+
+    # Always use on-demand
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: ["on-demand"]
+
+  # Only provision nodes for pods specifying the gitlab node pool
+  labels:
+    spack.io/node-pool: gitlab


### PR DESCRIPTION
I already applied these during the migration so that we could avoid having to bring in cluster-autoscaler for the new cluster. 

I basically just looked at the Auto-Scaling groups in AWS to figure out what kind of instance types cluster-autoscaler was using for these node pools; I'm not sure if this is an ideal set up, or if we want to add more instance types for these provisioners, etc. but I'll leave that to @AlmightyYakob.