### PR TITLE
Specify `base` node pool for metabase

### DIFF
--- a/k8s/metabase/metabase-deployment.yaml
+++ b/k8s/metabase/metabase-deployment.yaml
@@ -49,3 +49,5 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 10
             failureThreshold: 3
+      nodeSelector:
+        spack.io/node-pool: base


### PR DESCRIPTION
While investigating why metabase was broken, I noticed it would occasionally get scheduled onto ARM nodes and fail with an `exec` error because the Deployment doesn't specify a node selector.