### PR TITLE
Misc terraform fixes

### DIFF
--- a/terraform/gitlab_db.tf
+++ b/terraform/gitlab_db.tf
@@ -23,8 +23,8 @@ module "gitlab_db" {
   create_cloudwatch_log_group     = true
 
   backup_retention_period = 7
-  skip_final_snapshot     = true
-  deletion_protection     = false
+  skip_final_snapshot     = false
+  deletion_protection     = true
 
   allocated_storage     = 500
   max_allocated_storage = 1000

--- a/terraform/gitlab_db.tf
+++ b/terraform/gitlab_db.tf
@@ -1,4 +1,4 @@
-module "db" {
+module "gitlab_db" {
   source  = "terraform-aws-modules/rds/aws"
   version = "5.2.3"
 
@@ -29,10 +29,10 @@ module "db" {
   allocated_storage     = 500
   max_allocated_storage = 1000
 
-  vpc_security_group_ids = [module.security_group.security_group_id]
+  vpc_security_group_ids = [module.postgres_security_group.security_group_id]
 }
 
-module "security_group" {
+module "postgres_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "4.16.2"
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -41,7 +41,11 @@ provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.default.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)
-    token                  = data.aws_eks_cluster_auth.default.token
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name, "--region", "us-east-1"]
+      command     = "aws"
+    }
   }
 }
 
@@ -64,13 +68,21 @@ data "aws_eks_cluster_auth" "default" {
 provider "kubectl" {
   host                   = data.aws_eks_cluster.default.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.default.token
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name, "--region", "us-east-1"]
+    command     = "aws"
+  }
 }
 
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.default.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.default.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.default.token
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name, "--region", "us-east-1"]
+    command     = "aws"
+  }
 }
 
 


### PR DESCRIPTION
- Updates the way Terraform authenticates with the cluster to dynamically fetch a kube token instead of relying on the one that was generated when the cluster was created (that one is now expired, so `terraform apply` will not work currently without these changes)
- Makes gitlab/cdash DB terraform modules have consistent naming
- Turn on delete protection for gitlab DB