### PR TITLE
Add missing dependency to image

### DIFF
--- a/images/opensearch-index-build-logs/requirements.txt
+++ b/images/opensearch-index-build-logs/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.24.85
 botocore==1.27.85
+gitlab==3.13.0
 requests==2.28.1


### PR DESCRIPTION
I noticed the gitlab logs => opensearch script was failing due to this package missing. Not sure how this job was running successfully before...