### PR TITLE
Fix python-gitlab dependency name

### DIFF
--- a/images/opensearch-index-build-logs/requirements.txt
+++ b/images/opensearch-index-build-logs/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.24.85
 botocore==1.27.85
-gitlab==3.13.0
+python-gitlab==3.13.0
 requests==2.28.1


### PR DESCRIPTION
I made a typo in #379, the package is `python-gitlab`, not `gitlab` :roll_eyes: 