### PR TITLE
Make flux ignore metabase pvc yaml

### DIFF
--- a/k8s/metabase/postgres-pvc.yaml
+++ b/k8s/metabase/postgres-pvc.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: metabase-postgresql
   namespace: monitoring
+  annotations:
+    kustomize.toolkit.fluxcd.io/reconcile: disabled
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
This PVC is automatically created by metabase. Since it's bound to a PV, you can't do a `kubectl apply` on it.  Flux didn't create this resource and doesn't realize it already exists, so it's trying to do a `kubectl apply` anyways and is failing (at least, that's my theory). I've already applied this YAML to the cluster, and it fixed the error.