### PR TITLE
CronJob to Backup Cluster Secrets

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -26,6 +26,7 @@ jobs:
           - gitlab-skipped-pipelines
           - notary
           - python-aws-bash
+          - secrets-backup
         include:
           - docker-image: gh-gl-sync
             image-tags: ghcr.io/spack/ci-bridge:0.0.36
@@ -59,6 +60,8 @@ jobs:
             image-tags: ghcr.io/spack/gitlab-error-processor:0.0.1
           - docker-image: upload-gitlab-failure-logs
             image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.1
+          - docker-image: secrets-backup
+            image-tags: ghcr.io/spack/secrets-backup:0.0.1
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/images/secrets-backup/Dockerfile
+++ b/images/secrets-backup/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /scripts/
+
+COPY requirements.txt ./
+COPY backup.py ./
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir -r requirements.txt
+
+ENTRYPOINT [ "python", "./backup.py"]

--- a/images/secrets-backup/backup.py
+++ b/images/secrets-backup/backup.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import functools
+import json
+
+import boto3
+from kubernetes import client, config
+from kubernetes.client.models.v1_config_map import V1ConfigMap
+from kubernetes.client.models.v1_secret import V1Secret
+
+# Instantiate k8s and secrets manager client
+config.load_config()
+v1_client = client.CoreV1Api()
+secrets_client = boto3.client("secretsmanager")
+
+
+@functools.cache
+def get_cluster_name() -> str:
+    config_map: V1ConfigMap = v1_client.read_namespaced_config_map(
+        name="cluster-info", namespace="kube-system"
+    )
+    return config_map.data["cluster-name"]
+
+
+def sync_secret(secret: V1Secret):
+    """Sync the secret to AWS Secrets Manager."""
+    name = secret.metadata.name
+    namespace = secret.metadata.namespace
+    secret_type = secret.type
+    data = json.dumps(secret.data)
+
+    # Create secret name
+    cluster_name = get_cluster_name()
+    unique_secret_name = f"backup__{cluster_name}__{namespace}__{name}"
+
+    # Check for existing secret of same name
+    resp = secrets_client.list_secrets(
+        Filters=[{"Key": "name", "Values": [unique_secret_name]}],
+        MaxResults=1,
+    )
+
+    # Create list of tags
+    secret_tags = [
+        {
+            "Key": "backup",
+            "Value": "true",
+        },
+        {
+            "Key": "cluster",
+            "Value": cluster_name,
+        },
+        {
+            "Key": "namespace",
+            "Value": namespace,
+        },
+        {
+            "Key": "name",
+            "Value": name,
+        },
+        {
+            "Key": "type",
+            "Value": secret_type,
+        },
+    ]
+
+    # Check if secret already exists
+    if len(resp["SecretList"]):
+        secret = resp["SecretList"][0]
+        secret_id = secret["ARN"]
+
+        # Update secret value
+        secrets_client.put_secret_value(
+            SecretId=secret_id,
+            SecretString=data,
+        )
+
+        # Ensure tags are updated
+        secrets_client.tag_resource(SecretId=secret_id, Tags=secret_tags)
+        print(f"Updated existing secret: {unique_secret_name}")
+        return
+
+    # Create new secret
+    secrets_client.create_secret(
+        Name=unique_secret_name, SecretString=data, Tags=secret_tags
+    )
+    print(f"Secret created: {unique_secret_name}")
+
+
+# Watch for all secret changes
+for secret in v1_client.list_secret_for_all_namespaces().items:
+    sync_secret(secret)

--- a/images/secrets-backup/requirements.txt
+++ b/images/secrets-backup/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+kubernetes

--- a/images/secrets-backup/requirements.txt
+++ b/images/secrets-backup/requirements.txt
@@ -1,2 +1,2 @@
-boto3
-kubernetes
+boto3==1.26.68
+kubernetes==25.3.0

--- a/k8s/secrets-backup/cron-jobs.yaml
+++ b/k8s/secrets-backup/cron-jobs.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: secrets-backup
+  namespace: custom
+spec:
+  schedule: "*/10 * * * *" # Run every 10 minutes
+  jobTemplate:
+    metadata:
+      labels:
+        app: secrets-backup
+    spec:
+      template:
+        metadata:
+          labels:
+            app: secrets-backup
+        spec:
+          serviceAccountName: secrets-backup
+          restartPolicy: OnFailure
+          containers:
+            image: ghcr.io/spack/secrets-backup:0.0.1
+            imagePullPolicy: IfNotPresent
+            name: python-backup-script
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1G
+          nodeSelector:
+            spack.io/node-pool: base

--- a/k8s/secrets-backup/service-accounts.yaml
+++ b/k8s/secrets-backup/service-accounts.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secrets-backup
+  namespace: custom
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::588562868276:role/SecretsBackupRole-spack-production
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secrets-backup
+  namespace: custom
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secrets-backup
+  namespace: custom
+subjects:
+  - kind: ServiceAccount
+    name: secrets-backup
+roleRef:
+  kind: Role
+  name: secrets-backup
+  apiGroup: rbac.authorization.k8s.io

--- a/scripts/restore-secret.py
+++ b/scripts/restore-secret.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import json
+import re
+
+import boto3
+import click
+from kubernetes import client, config
+from kubernetes.client.models.v1_secret_list import V1SecretList
+
+# Load k8s config
+config.load_kube_config()
+
+# Setup aws client
+secrets_client = boto3.client("secretsmanager")
+
+
+def get_secret_tag(key: str, tags: list[dict[str, str]]):
+    for d in tags:
+        if d["Key"] == key:
+            return d["Value"]
+
+    raise Exception("Tag not found")
+
+
+def get_context_cluster_name(context: dict):
+    arn = context["context"]["cluster"]
+    match = re.match(r"arn:aws:eks:[a-z0-9-]+:588562868276:cluster\/(.+)", arn)
+    return match.group(1)
+
+
+def get_v1_client(cluster_name: str):
+    # Get cluster context that matches the provided cluster name
+    contexts = config.list_kube_config_contexts()[0]
+    matching = [c for c in contexts if get_context_cluster_name(c) == cluster_name]
+    if len(matching) > 1:
+        raise click.ClickException(
+            f"Multiple contexts found for cluster {cluster_name}."
+        )
+    if not matching:
+        raise click.ClickException(f"No contexts found for cluster {cluster_name}")
+
+    # Return client with context
+    return client.CoreV1Api(
+        api_client=config.new_client_from_config(context=matching[0]["name"])
+    )
+
+
+@click.command(help="Restore a secret from AWS Secrets Manager to the cluster")
+@click.argument("secret-arn")
+@click.option(
+    "-f", "--force", is_flag=True, help="Overwrite existing secrets if found."
+)
+def cmd(secret_arn, force):
+    # Retrieve cluster name, secret namespace and name
+    tags = secrets_client.describe_secret(SecretId=secret_arn)["Tags"]
+    cluster_name = get_secret_tag("cluster", tags)
+    secret_namespace = get_secret_tag("namespace", tags)
+    secret_name = get_secret_tag("name", tags)
+    secret_type = get_secret_tag("type", tags)
+
+    # Get k8s client
+    k8s_client = get_v1_client(cluster_name)
+
+    # Check if secret exists
+    exists = False
+    try:
+        k8s_client.read_namespaced_secret(name=secret_name, namespace=secret_namespace)
+        exists = True
+        if not force:
+            raise click.ClickException(
+                f"Secret {secret_name} already exists in namespace {secret_namespace}."
+                " Please run with the -f flag to overwrite."
+            )
+    except client.ApiException:
+        # Secret doesn't currently exist, do nothing.
+        pass
+
+    # Get backed up secret value
+    secret_data = json.loads(
+        secrets_client.get_secret_value(SecretId=secret_arn)["SecretString"]
+    )
+
+    # Create secret body
+    new_secret_body = client.V1Secret(
+        api_version="v1",
+        kind="Secret",
+        type=secret_type,
+        metadata={"name": secret_name},
+        data=secret_data,
+    )
+
+    # Create secret if it doesn't exist, else patch
+    if not exists:
+        k8s_client.create_namespaced_secret(
+            namespace=secret_namespace, body=new_secret_body
+        )
+        print(f"Secret {secret_name} in namespace {secret_namespace} created!")
+    else:
+        k8s_client.patch_namespaced_secret(
+            namespace=secret_namespace, name=secret_name, body=new_secret_body
+        )
+        print(f"Secret {secret_name} in namespace {secret_namespace} updated!")
+
+
+if __name__ == "__main__":
+    cmd()

--- a/terraform/modules/spack/eks.tf
+++ b/terraform/modules/spack/eks.tf
@@ -119,7 +119,7 @@ resource "aws_iam_role" "ebs_efs_csi_driver" {
 
 resource "aws_iam_role_policy" "ebs_efs_csi_driver" {
   name = "EbsEFsDriverPolicy-${var.deployment_name}"
-  role        = aws_iam_role.ebs_efs_csi_driver.id
+  role = aws_iam_role.ebs_efs_csi_driver.id
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -253,4 +253,64 @@ resource "aws_iam_role_policy" "ebs_efs_csi_driver" {
       }
     ]
   })
+}
+
+
+resource "aws_iam_role" "secrets_backup" {
+  name = "SecretsBackupRole-${var.deployment_name}"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : module.eks.oidc_provider_arn
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${module.eks.oidc_provider}:sub" : "system:serviceaccount:kube-system:ebs-csi-controller-sa",
+            "${module.eks.oidc_provider}:aud" : "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "secrets_backup" {
+  name = "SecretsBackupPolicy-${var.deployment_name}"
+  role = aws_iam_role.secrets_backup.id
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "secretsmanager:CreateSecret",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:GetSecret",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:ListSecrets",
+          "secretsmanager:PutSecretValue",
+          "secretsmanager:TagResource",
+          "secretsmanager:UpdateSecret"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+# Define a configmap that provides the EKS Cluster name
+resource "kubectl_manifest" "cluster_name_config_map" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+        name: cluster-info
+        namespace: kube-system
+    data:
+        cluster-name: ${module.eks.cluster_name}
+  YAML
 }


### PR DESCRIPTION
This will ensure that if a secret is deleted by accident in the cluster, it isn't gone forever. A restoration script is also included.

Some things I'm still unsure about:
1. What else is needed for the image registration, or will the CI publish the docker image all on its own?
2. Is 10 minutes a good interval?
3. Should the backup/restore process include all secret metadata, labels, etc.? Currently it doesn't, but it'd be easy to include that.


I've built the container locally and run both the backup and restore scripts successfully, although I can't fully simulate the behavior in the cluster.