### PR TITLE
Update SMTP username

### DIFF
--- a/k8s/gitlab/release.yaml
+++ b/k8s/gitlab/release.yaml
@@ -72,7 +72,7 @@ spec:
       smtp:
         enabled: true
         address: email-smtp.us-east-1.amazonaws.com
-        user_name: AKIAYSCIUVA2L2NKBRON
+        user_name: AKIAYSCIUVA2PDMR2WN4
         password:
           secret: gitlab-secrets
           key: smtp-password


### PR DESCRIPTION
It seems that the password for the SMTP credentials used by GitLab and Metabase that's currently stored as a secret in the cluster is not correct. So, I regenerated the iam access key, which also resulted in the user name getting changed; this PR updates the GitLab helm release with this new user name.