### PR TITLE
Fix syntax error

### DIFF
--- a/k8s/secrets-backup/cron-jobs.yaml
+++ b/k8s/secrets-backup/cron-jobs.yaml
@@ -18,9 +18,9 @@ spec:
           serviceAccountName: secrets-backup
           restartPolicy: OnFailure
           containers:
+          - name: python-backup-script
             image: ghcr.io/spack/secrets-backup:0.0.1
             imagePullPolicy: IfNotPresent
-            name: python-backup-script
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
Flux failed to apply the changes from #390 due to a minor syntax error - `spec.containers` is a `list`, not a `map`.