### PR TITLE
Replace Role with ClusterRole for secrets backup script

### DIFF
--- a/k8s/secrets-backup/service-accounts.yaml
+++ b/k8s/secrets-backup/service-accounts.yaml
@@ -8,26 +8,25 @@ metadata:
     eks.amazonaws.com/role-arn: arn:aws:iam::588562868276:role/SecretsBackupRole-production
 
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: secrets-backup
-  namespace: custom
 rules:
   - apiGroups: [""]
-    resources: ["secrets"]
+    resources: ["secrets", "configmaps"]
     verbs: ["get", "watch", "list"]
 
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: secrets-backup
-  namespace: custom
 subjects:
   - kind: ServiceAccount
     name: secrets-backup
+    namespace: custom
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: secrets-backup
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Since the secrets backup cron job attempts to list secrets across _all_ namespaces, the service account it uses requires a binding to a cluster role.