### PR TITLE
Fix incorrect argument name in EKS TF module

### DIFF
--- a/terraform/modules/spack/eks.tf
+++ b/terraform/modules/spack/eks.tf
@@ -62,7 +62,7 @@ module "eks" {
 
   cluster_addons = {
     aws-ebs-csi-driver = {
-      version                  = "v1.14.0-eksbuild.1"
+      addon_version            = "v1.14.0-eksbuild.1"
       service_account_role_arn = aws_iam_role.ebs_efs_csi_driver.arn
     }
   }

--- a/terraform/modules/spack/eks.tf
+++ b/terraform/modules/spack/eks.tf
@@ -62,7 +62,7 @@ module "eks" {
 
   cluster_addons = {
     aws-ebs-csi-driver = {
-      addon_version            = "v1.14.0-eksbuild.1"
+      addon_version            = "v1.15.0-eksbuild.1"
       service_account_role_arn = aws_iam_role.ebs_efs_csi_driver.arn
     }
   }


### PR DESCRIPTION
See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon#example-usage

Since I was specifying the addon version incorrectly, the Terraform EKS module was defaulting to the latest. 