### PR TITLE
Fix incorrect OIDC sub field in secrets-backup iam role

### DIFF
--- a/terraform/modules/spack/eks.tf
+++ b/terraform/modules/spack/eks.tf
@@ -269,7 +269,7 @@ resource "aws_iam_role" "secrets_backup" {
         "Action" : "sts:AssumeRoleWithWebIdentity",
         "Condition" : {
           "StringEquals" : {
-            "${module.eks.oidc_provider}:sub" : "system:serviceaccount:kube-system:ebs-csi-controller-sa",
+            "${module.eks.oidc_provider}:sub" : "system:serviceaccount:custom:secrets-backup",
             "${module.eks.oidc_provider}:aud" : "sts.amazonaws.com"
           }
         }


### PR DESCRIPTION
I had copy/pasted the necessary string for the OIDC `sub` field in the secrets backup iam role, but never changed it to match the namespace and service account for the secrets-backup cron job. 