### PR TITLE
Switch Flux to use this repo instead of fork

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -71,7 +71,7 @@ provider "kubernetes" {
 
 
 provider "github" {
-  owner = "mvandenburgh" # TODO: change this
+  owner = "spack"
   token = jsondecode(data.aws_secretsmanager_secret_version.flux_github_token.secret_string).flux_github_token
 }
 
@@ -101,8 +101,8 @@ module "production_cluster" {
   ]
 
   flux_repo_name   = "spack-infrastructure"
-  flux_repo_owner  = "mvandenburgh"
-  flux_branch      = "flux2"
+  flux_repo_owner  = "spack"
+  flux_branch      = "main"
   flux_target_path = "k8s/"
 
   cdash_db_instance_class  = "db.m6g.large"


### PR DESCRIPTION
Changes the Flux configuration for the production cluster to point at spack/spack-infrastructure instead of mvandenburgh/spack-infrastructure.