### PR TITLE
Improvements to docker publish workflow

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - images/**
+
 
 jobs:
   publish:

--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - production
 
 jobs:
   publish:

--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -11,21 +11,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        docker-image:
-          - gh-gl-sync
-          - gitlab-api-scrape
-          - ci-key-rotate
-          - ci-key-clear
-          - gitlab-webservice
-          - gitlab-sidekiq
-          - gitlab-toolbox
-          - gitops
-          - gitlab-stuckpods
-          - gitlab-clear-pipelines
-          - gitlab-skipped-pipelines
-          - notary
-          - python-aws-bash
-          - secrets-backup
         include:
           - docker-image: gh-gl-sync
             image-tags: ghcr.io/spack/ci-bridge:0.0.36


### PR DESCRIPTION
Fixes some minor inconveniences/issues that I happened to notice in our docker build workflow.

- Removes the publishing of new images on push to the `production` branch. We don't use `production` for change control anymore so it is no longer "special" and shouldn't trigger new image builds.
- Removes some redundant entries in the `matrix` object - all of the removed items are duplicated in the `include` object.
- Limits the docker publish workflow to only run when an image is actually changed. We're currently wasting cycles rebuilding and uploading every docker image, even if none of them change.