### PR TITLE
Add regex to catch checksum mismatches

### DIFF
--- a/images/upload-gitlab-failure-logs/taxonomy.yaml
+++ b/images/upload-gitlab-failure-logs/taxonomy.yaml
@@ -125,6 +125,10 @@ taxonomy:
       grep_for:
         - 'Error: No binary for .+ found when cache-only specified'
 
+    checksum_mismatch:
+      grep_for:
+        - 'Error: sha256 checksum failed for .+'
+
   deconflict_order:
     # API Scrape erorrs
     - 'job_log_missing'
@@ -143,6 +147,7 @@ taxonomy:
     - 'dial_backend'
     - 'remote_disconnect'
     # Spack Errors
+    - 'checksum_mismatch'
     - 'no_binary_for_spec'
     - 'db_match'
     - 'db_hash'


### PR DESCRIPTION
Catch errors in job traces that look like:

```
==> Error: sha256 checksum failed for /tmp/root/spack-stage/spack-stage-6chx1po1/linux-amzn2-aarch64-gcc-7.3.1-hdf5-1.14.0-46e6jm4jqbvmhr4vclfziiu7fbfamdp7.spack
```

Found, for example, [here](https://gitlab.spack.io/spack/spack/-/jobs/6081120).