### PR TITLE
Add another regex for image_pull error type

### DIFF
--- a/images/upload-gitlab-failure-logs/taxonomy.yaml
+++ b/images/upload-gitlab-failure-logs/taxonomy.yaml
@@ -120,6 +120,7 @@ taxonomy:
       grep_for:
         - 'Job failed (system failure): prepare environment: image pull failed'
         - 'ERROR: Job failed (system failure): failed to pull image'
+        - 'image pull failed: Back-off pulling image'
 
     no_binary_for_spec:
       grep_for:


### PR DESCRIPTION
Some image pull errors are getting classified as `other` because the exact text of the error sometimes doesn't match the two existing regexes perfectly. I added another regex which is less specific and should catch more of these.