### PR TITLE
Add pie chart to error taxonomy dashboard

### DIFF
--- a/k8s/prometheus/custom/gitlab-ci-failures-dashboard.yaml
+++ b/k8s/prometheus/custom/gitlab-ci-failures-dashboard.yaml
@@ -36,6 +36,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
+      "id": 32,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -88,7 +89,7 @@ data:
           },
           "gridPos": {
             "h": 10,
-            "w": 24,
+            "w": 17,
             "x": 0,
             "y": 0
           },
@@ -148,6 +149,96 @@ data:
           ],
           "title": "CI Failures by Type",
           "type": "barchart"
+        },
+        {
+          "datasource": {
+            "type": "grafana-opensearch-datasource",
+            "uid": "P9744FCCEAAFBD98F"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": []
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 7,
+            "x": 17,
+            "y": 0
+          },
+          "id": 7,
+          "options": {
+            "displayLabels": [
+              "value",
+              "name"
+            ],
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [
+                {
+                  "field": "error_taxonomy.keyword",
+                  "id": "1",
+                  "settings": {
+                    "min_doc_count": "0",
+                    "order": "desc",
+                    "orderBy": "_term",
+                    "size": "10"
+                  },
+                  "type": "terms"
+                }
+              ],
+              "datasource": {
+                "type": "grafana-opensearch-datasource",
+                "uid": "P9744FCCEAAFBD98F"
+              },
+              "format": "table",
+              "metrics": [
+                {
+                  "id": "2",
+                  "type": "count"
+                }
+              ],
+              "query": "",
+              "queryType": "lucene",
+              "refId": "A",
+              "timeField": "timestamp"
+            }
+          ],
+          "title": "CI Failures by Type",
+          "type": "piechart"
         },
         {
           "datasource": {
@@ -353,13 +444,13 @@ data:
         "list": []
       },
       "time": {
-        "from": "now-1h",
+        "from": "now-7d",
         "to": "now"
       },
       "timepicker": {},
       "timezone": "",
       "title": "GitLab CI Failures",
       "uid": "4o5_AQAVz",
-      "version": 1,
+      "version": 2,
       "weekStart": ""
     }


### PR DESCRIPTION
~~Depends on #411~~

Adds a pie chart to easily visualize taxonomy percentages

![image](https://user-images.githubusercontent.com/11370025/225981779-03e7c391-fe93-44f7-8e86-97f5550513b2.png)
