### PR TITLE
Manage elasticache engine/version with Terraform

### DIFF
--- a/terraform/modules/spack/elasticache.tf
+++ b/terraform/modules/spack/elasticache.tf
@@ -7,6 +7,8 @@ resource "aws_elasticache_replication_group" "pr_binary_graduation_task_queue" {
   replication_group_id = "pr-binary-graduation-queue-${var.deployment_name}"
   description          = "Used by python RQ module to store pending tasks for workers"
 
+  engine               = "redis"
+  engine_version       = "7.0"
   node_type            = "cache.t3.small"
   port                 = 6379
   parameter_group_name = "default.redis7"


### PR DESCRIPTION
Will allow us to bump the elasticache/redis version more easily. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster#engine_version