### PR TITLE
Add classification for failed jobs with no trace

### DIFF
--- a/images/upload-gitlab-failure-logs/taxonomy.yaml
+++ b/images/upload-gitlab-failure-logs/taxonomy.yaml
@@ -142,6 +142,9 @@ taxonomy:
       grep_for:
         - 'Error: sha256 checksum failed for .+'
 
+    no_trace: null
+      # See upload_gitlab_failure_logs.py for how this is used
+
   deconflict_order:
     # API Scrape erorrs
     - 'job_log_missing'


### PR DESCRIPTION
Another kind of error being labeled as `other` are jobs with no trace, like this one https://gitlab.spack.io/spack/spack/-/jobs/6258279.