### PR TITLE
Remove `no_trace` error, catch timeouts and scheduler failures

### DIFF
--- a/images/upload-gitlab-failure-logs/taxonomy.yaml
+++ b/images/upload-gitlab-failure-logs/taxonomy.yaml
@@ -142,8 +142,9 @@ taxonomy:
       grep_for:
         - 'Error: sha256 checksum failed for .+'
 
-    no_trace: null
-      # See upload_gitlab_failure_logs.py for how this is used
+    # See upload_gitlab_failure_logs.py for how these are used
+    stuck_or_timeout_failure: null
+    scheduler_failure: null
 
   deconflict_order:
     # API Scrape erorrs


### PR DESCRIPTION
All of the `no_trace` errors from the last couple weeks have a `build_failure_reason` of either `stuck_or_timeout_failure` or `scheduler_failure`. So, I think it makes more sense to fall back to those as the `error_taxonomy` if we come across jobs that failed in one of those ways.

Example of scheduler failure: https://gitlab.spack.io/spack/spack/-/jobs/6206168
Example of stuck/timeout failure: https://gitlab.spack.io/spack/spack/-/jobs/6258279