### PR TITLE
Remove "Failed Jobs" panel from GitLab CI Failures dashboard

### DIFF
--- a/k8s/prometheus/custom/gitlab-ci-failures-dashboard.yaml
+++ b/k8s/prometheus/custom/gitlab-ci-failures-dashboard.yaml
@@ -36,7 +36,6 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 32,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -298,8 +297,8 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 10,
+            "w": 24,
             "x": 0,
             "y": 10
           },
@@ -348,93 +347,6 @@ data:
           ],
           "title": "Number of CI Failures by Time Unit",
           "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "grafana-opensearch-datasource",
-            "uid": "P9744FCCEAAFBD98F"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
-            "y": 10
-          },
-          "id": 6,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "count"
-              ],
-              "fields": "/^build_id$/",
-              "limit": 1,
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "pluginVersion": "9.3.1",
-          "targets": [
-            {
-              "alias": "",
-              "bucketAggs": [
-                {
-                  "field": "gitlab_job_url.keyword",
-                  "id": "1",
-                  "settings": {
-                    "min_doc_count": "0",
-                    "order": "desc",
-                    "orderBy": "_term",
-                    "size": "0"
-                  },
-                  "type": "terms"
-                }
-              ],
-              "datasource": {
-                "type": "grafana-opensearch-datasource",
-                "uid": "P9744FCCEAAFBD98F"
-              },
-              "format": "table",
-              "metrics": [
-                {
-                  "id": "1",
-                  "type": "logs"
-                }
-              ],
-              "query": "",
-              "queryType": "lucene",
-              "refId": "A",
-              "timeField": "timestamp"
-            }
-          ],
-          "title": "Failed Jobs",
-          "transformations": [],
-          "type": "stat"
         }
       ],
       "schemaVersion": 37,
@@ -451,6 +363,6 @@ data:
       "timezone": "",
       "title": "GitLab CI Failures",
       "uid": "4o5_AQAVz",
-      "version": 2,
+      "version": 3,
       "weekStart": ""
     }


### PR DESCRIPTION
This panel erroneously had a max value of 500, so we're better off not displaying any data for this field rather than displaying incorrect data.

This seems to be documented behavior, but I couldn't find a straightforward way of modifying it.

https://docs.aws.amazon.com/grafana/latest/userguide/using-opensearch-in-AMG.html