### PR TITLE
[Failed Jobs Dashboard] Order by Doc Count instead of Term Value in Pie Chart

### DIFF
--- a/k8s/prometheus/custom/gitlab-ci-failures-dashboard.yaml
+++ b/k8s/prometheus/custom/gitlab-ci-failures-dashboard.yaml
@@ -36,6 +36,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
+      "id": 32,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -213,7 +214,7 @@ data:
                   "settings": {
                     "min_doc_count": "0",
                     "order": "desc",
-                    "orderBy": "_term",
+                    "orderBy": "_count",
                     "size": "10"
                   },
                   "type": "terms"
@@ -363,6 +364,6 @@ data:
       "timezone": "",
       "title": "GitLab CI Failures",
       "uid": "4o5_AQAVz",
-      "version": 3,
+      "version": 4,
       "weekStart": ""
     }


### PR DESCRIPTION
I was previously ordering by "Term Value", which I thought would be the document count, but now I have no idea what it means, since it was giving the wrong results.