### PR TITLE
Add info about k8s pod to gitlab job failure record

### DIFF
--- a/images/upload-gitlab-failure-logs/upload_gitlab_failure_logs.py
+++ b/images/upload-gitlab-failure-logs/upload_gitlab_failure_logs.py
@@ -125,6 +125,15 @@ def assign_error_taxonomy(job_input_data: dict[str, Any], job_trace: str):
 
 def collect_pod_status(job_input_data: dict[str, Any], job_trace: str):
     """Collect k8s info about this job and store it in the OpenSearch record"""
+    # Record whether this job was run on a kubernetes pod or via some other
+    # means (a UO runner, for example)
+    job_input_data["kubernetes_job"] = "Using Kubernetes executor" in job_trace
+
+    # If this job wasn't run on kubernetes, there's no pod to fetch so
+    # we can exit early
+    if not job_input_data["kubernetes_job"]:
+        return
+
     # Scan job logs to infer the name of the pod this job was executed on
     runner_name_matches = re.findall(
         rf"Running on (.+) via {job_input_data['runner']['description']}...",


### PR DESCRIPTION
Adds pod "status" metadata for the k8s pod that the failed job is running on. This will allows us to identify jobs that failed due to their pod and/or one of their containers being OOMKilled, etc. 

Here's an example "status" object from a runner pod:

```
{
    "conditions": [
        {
            "last_probe_time": null,
            "last_transition_time": "2023-04-13 18:57:07+00:00",
            "message": null,
            "reason": null,
            "status": "True",
            "type": "Initialized"
        },
        {
            "last_probe_time": null,
            "last_transition_time": "2023-04-13 18:57:08+00:00",
            "message": null,
            "reason": null,
            "status": "True",
            "type": "Ready"
        },
        {
            "last_probe_time": null,
            "last_transition_time": "2023-04-13 18:57:08+00:00",
            "message": null,
            "reason": null,
            "status": "True",
            "type": "ContainersReady"
        },
        {
            "last_probe_time": null,
            "last_transition_time": "2023-04-13 18:56:55+00:00",
            "message": null,
            "reason": null,
            "status": "True",
            "type": "PodScheduled"
        }
    ],
    "container_statuses": [
        {
            "container_id": "containerd://136fc055dfaac36951afae6742476f155e3e7e8d739fa43f5f35de70c402a735",
            "image": "docker.io/ecpe4s/ubuntu20.04-runner-x86_64:2023-01-01",
            "image_id": "docker.io/ecpe4s/ubuntu20.04-runner-x86_64@sha256:026df548cce402c32de68c0a3eee645808c99dd0541e74af4ea3566026da099e",
            "last_state": {
                "running": null,
                "terminated": null,
                "waiting": null
            },
            "name": "build",
            "ready": true,
            "restart_count": 0,
            "started": true,
            "state": {
                "running": {
                    "started_at": "2023-04-13 18:57:07+00:00"
                },
                "terminated": null,
                "waiting": null
            }
        },
        {
            "container_id": "containerd://b9a83080b5b484419619bf9efca1a2d3d4512f7acf1016b6cff88d9795326500",
            "image": "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-98daeee0",
            "image_id": "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper@sha256:8706270c187b607189747b6700f76144abcc81b70c92b8aa295503f6121dfd99",
            "last_state": {
                "running": null,
                "terminated": null,
                "waiting": null
            },
            "name": "helper",
            "ready": true,
            "restart_count": 0,
            "started": true,
            "state": {
                "running": {
                    "started_at": "2023-04-13 18:57:07+00:00"
                },
                "terminated": null,
                "waiting": null
            }
        }
    ],
    "ephemeral_container_statuses": null,
    "host_ip": "10.0.178.163",
    "init_container_statuses": [
        {
            "container_id": "containerd://b0ebebfdbb977ea929efedc9ae25945601f0f026f3533557fdb4fabcb573ed02",
            "image": "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-98daeee0",
            "image_id": "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper@sha256:8706270c187b607189747b6700f76144abcc81b70c92b8aa295503f6121dfd99",
            "last_state": {
                "running": null,
                "terminated": null,
                "waiting": null
            },
            "name": "init-permissions",
            "ready": true,
            "restart_count": 0,
            "started": null,
            "state": {
                "running": null,
                "terminated": {
                    "container_id": "containerd://b0ebebfdbb977ea929efedc9ae25945601f0f026f3533557fdb4fabcb573ed02",
                    "exit_code": 0,
                    "finished_at": "2023-04-13 18:56:55+00:00",
                    "message": null,
                    "reason": "Completed",
                    "signal": null,
                    "started_at": "2023-04-13 18:56:55+00:00"
                },
                "waiting": null
            }
        }
    ],
    "message": null,
    "nominated_node_name": null,
    "phase": "Running",
    "pod_ip": "10.0.166.33",
    "pod_i_ps": [
        {
            "ip": "10.0.166.33"
        }
    ],
    "qos_class": "Burstable",
    "reason": null,
    "start_time": "2023-04-13 18:56:55+00:00"
}
```