### PR TITLE
Add label to gitlab error processing Jobs

### DIFF
--- a/images/gitlab-error-processor/job-template.yaml
+++ b/images/gitlab-error-processor/job-template.yaml
@@ -3,9 +3,14 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: gitlab-error-processing-job
+  labels:
+    app: gitlab-error-processing-job
 spec:
   ttlSecondsAfterFinished: 7200
   template:
+    metadata:
+      labels:
+        app: gitlab-error-processing-job
     spec:
       restartPolicy: OnFailure
       containers:


### PR DESCRIPTION
Currently I don't think there's any way to filter `gitlab-error-processing-job` in the kube-events OpenSearch index. This PR adds a `label` to those Jobs so that this is possible.