### PR TITLE
Use emptiness deprovisioning method for runner nodes

### DIFF
--- a/k8s/karpenter/provisioners/runners/graviton/2/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/graviton/2/provisioners.yaml
@@ -8,9 +8,8 @@ spec:
   providerRef:
     name: default
 
-  # Consolidation will de-provision larger than necessary nodes
-  consolidation:
-    enabled: true
+  # Terminate nodes after 5 minutes of idle time
+  ttlSecondsAfterEmpty: 300
 
   # Resource limits for this provisioner only
   limits:

--- a/k8s/karpenter/provisioners/runners/graviton/3/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/graviton/3/provisioners.yaml
@@ -8,9 +8,8 @@ spec:
   providerRef:
     name: default
 
-  # Consolidation will de-provision larger than necessary nodes
-  consolidation:
-    enabled: true
+  # Terminate nodes after 5 minutes of idle time
+  ttlSecondsAfterEmpty: 300
 
   # Resource limits for this provisioner only
   limits:

--- a/k8s/karpenter/provisioners/runners/testing/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/testing/provisioners.yaml
@@ -8,9 +8,8 @@ spec:
   providerRef:
     name: default
 
-  # Consolidation will de-provision larger than necessary nodes
-  consolidation:
-    enabled: true
+  # Terminate nodes after 5 minutes of idle time
+  ttlSecondsAfterEmpty: 300
 
   # Resource limits for this provisioner only
   limits:

--- a/k8s/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
@@ -8,9 +8,8 @@ spec:
   providerRef:
     name: default
 
-  # Consolidation will de-provision larger than necessary nodes
-  consolidation:
-    enabled: true
+  # Terminate nodes after 5 minutes of idle time
+  ttlSecondsAfterEmpty: 300
 
   # Resource limits for this provisioner only
   limits:

--- a/k8s/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
@@ -8,9 +8,8 @@ spec:
   providerRef:
     name: default
 
-  # Consolidation will de-provision larger than necessary nodes
-  consolidation:
-    enabled: true
+  # Terminate nodes after 5 minutes of idle time
+  ttlSecondsAfterEmpty: 300
 
   # Resource limits for this provisioner only
   limits:

--- a/k8s/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
@@ -8,9 +8,8 @@ spec:
   providerRef:
     name: default
 
-  # Consolidation will de-provision larger than necessary nodes
-  consolidation:
-    enabled: true
+  # Terminate nodes after 5 minutes of idle time
+  ttlSecondsAfterEmpty: 300
 
   # Resource limits for this provisioner only
   limits:


### PR DESCRIPTION
Consolidation doesn't really make sense for runner nodes, since all runner pods are marked as `do-not-evict` and as such, consolidation will at best just not work, and at worst cause higher costs / scheduling issues.