### PR TITLE
Add deprovisioning for beefy and gitlab provisioners

### DIFF
--- a/k8s/karpenter/provisioners/beefy/provisioner.yaml
+++ b/k8s/karpenter/provisioners/beefy/provisioner.yaml
@@ -8,6 +8,10 @@ spec:
   providerRef:
     name: default
 
+  # Consolidation will de-provision larger than necessary nodes
+  consolidation:
+    enabled: true
+
   requirements:
     - key: "node.kubernetes.io/instance-type"
       operator: In

--- a/k8s/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/karpenter/provisioners/gitlab/provisioner.yaml
@@ -8,6 +8,10 @@ spec:
   providerRef:
     name: default
 
+  # Consolidation will de-provision larger than necessary nodes
+  consolidation:
+    enabled: true
+
   requirements:
     - key: "node.kubernetes.io/instance-type"
       operator: In


### PR DESCRIPTION
I noticed that our `beefy` and `gitlab` node pools are currently not configured with any deprovisioning, meaning nodes that are provisioned for these node pools will stay there indefinitely, whether they're being used or not. This may not be a huge problem, but imo every provisioner should be configured with a deprovisioner of some sort, as otherwise large bursts of activity can leave empty nodes that rack up costs.

I defaulted to consolidation with these, but I'm not really sure if that fits the use case for these node pools. @zackgalbreath what do you think?