### PR TITLE
Mark retried jobs in opensearch failure log script

### DIFF
--- a/images/gitlab-error-processor/job-template.yaml
+++ b/images/gitlab-error-processor/job-template.yaml
@@ -23,6 +23,24 @@ spec:
               secretKeyRef:
                 name: gitlab-error-processor
                 key: gitlab-token
+
+          # postgres credentials
+          - name: GITLAB_POSTGRES_HOST
+            valueFrom:
+              secretKeyRef:
+                name: gitlab-error-processor
+                key: postgresql-gitlab-host
+          - name: GITLAB_POSTGRES_DB
+            value: gitlabhq_production
+          - name: GITLAB_POSTGRES_RO_USER
+            value: gitlab_ro_user
+          - name: GITLAB_POSTGRES_RO_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: gitlab-error-processor
+                key: postgresql-gitlab-ro-user-password
+          
+          # opensearch credentials
           - name: OPENSEARCH_ENDPOINT
             valueFrom:
               secretKeyRef:

--- a/images/upload-gitlab-failure-logs/requirements.txt
+++ b/images/upload-gitlab-failure-logs/requirements.txt
@@ -1,3 +1,4 @@
 opensearch-dsl==2.0.1
 python-gitlab==3.11.0
 PyYAML==6.0
+psycopg2-binary==2.9.5


### PR DESCRIPTION
This PR ended up far from where it started, and it's goal now is to prevent duplicate build failures in opensearch. It also reorganizes the `upload_gitlab_failure_logs.py` file a bit.