### PR TITLE
Add custom domain for opensearch

### DIFF
--- a/terraform/modules/spack/opensearch.tf
+++ b/terraform/modules/spack/opensearch.tf
@@ -1,3 +1,99 @@
+resource "aws_opensearch_domain" "spack" {
+  domain_name = "spack${var.deployment_name == "production" ? "" : "-${var.deployment_name}"}"
+
+  engine_version = "OpenSearch_1.3"
+
+  advanced_security_options {
+    enabled                        = true
+    internal_user_database_enabled = true
+  }
+
+  auto_tune_options {
+    desired_state       = "ENABLED"
+    rollback_on_disable = "NO_ROLLBACK"
+  }
+
+  cluster_config {
+    instance_count = 2
+    instance_type  = "r6g.xlarge.search"
+    zone_awareness_config {
+      availability_zone_count = 2
+    }
+
+    zone_awareness_enabled = true
+  }
+
+  cognito_options {
+    enabled          = true
+    identity_pool_id = "us-east-1:ff2664d7-a403-42ba-8407-5d90b3eaa948" # TODO: encode this into terraform
+    role_arn         = aws_iam_role.opensearch_cognito_role.arn
+    user_pool_id     = "us-east-1_k6YnDTVBT" # TODO: encode this into terraform
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-0-2019-07"
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    iops        = 3000
+    volume_size = 500
+    volume_type = "gp3"
+  }
+
+  encrypt_at_rest {
+    enabled = true
+    # TODO: encode this KMS resource in terraform
+    kms_key_id = "arn:aws:kms:us-east-1:588562868276:key/6385d11c-f377-4778-96a6-5da54416b3cb"
+  }
+
+  log_publishing_options {
+    # TODO: encode cloudwatch in terraform
+    cloudwatch_log_group_arn = "arn:aws:logs:us-east-1:588562868276:log-group:/aws/OpenSearchService/domains/spack/application-logs"
+    enabled                  = true
+    log_type                 = "ES_APPLICATION_LOGS"
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = 0
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+data "aws_iam_policy" "amazon_opensearch_service_cognito_access" {
+  arn = "arn:aws:iam::aws:policy/AmazonOpenSearchServiceCognitoAccess"
+}
+
+resource "aws_iam_role" "opensearch_cognito_role" {
+  name        = "OpenSearchCognitoAccessRole-${var.deployment_name}"
+  description = "IAM role that gives OpenSearch permissions to configure the Amazon Cognito user and identity pools and use them for authentication."
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "opensearchservice.amazonaws.com"
+        },
+        "Action" : "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "opensearch_congito_role_policy_attach" {
+  role       = aws_iam_role.opensearch_cognito_role.name
+  policy_arn = data.aws_iam_policy.amazon_opensearch_service_cognito_access.arn
+}
+
 resource "aws_iam_role" "fluent_bit_role" {
   name        = "FluentBitRole-${var.deployment_name}"
   description = "IAM role that, when associated with a k8s service account, allows a fluent-bit pod to post logs to OpenSearch."
@@ -38,5 +134,3 @@ resource "aws_iam_role_policy" "fluent_bit_policy" {
     ]
   })
 }
-
-# TODO: encode OpenSearch domain/cluster here too

--- a/terraform/modules/spack/route53.tf
+++ b/terraform/modules/spack/route53.tf
@@ -2,3 +2,11 @@ data "aws_route53_zone" "spack_io" {
   name         = "spack.io"
   private_zone = false
 }
+
+resource "aws_route53_record" "opensearch" {
+  name    = "opensearch.spack.io"
+  records = [aws_opensearch_domain.spack.endpoint]
+  ttl     = 300
+  type    = "CNAME"
+  zone_id = data.aws_route53_zone.spack_io.zone_id
+}

--- a/terraform/modules/spack/route53.tf
+++ b/terraform/modules/spack/route53.tf
@@ -1,0 +1,4 @@
+data "aws_route53_zone" "spack_io" {
+  name         = "spack.io"
+  private_zone = false
+}


### PR DESCRIPTION
Adds Terraform code for provisioning a custom domain for opensearch (`opensearch.spack.io`). I already applied it to AWS, and everything appears to be working.

As part of this PR, I took a quick first pass at encoding OpenSearch into our terraform code. For now I have just encoded the OpenSearch cluster itself, and not any of the related resources like Cognito or Cloudwatch. I think in the future we'll want to have a separate Terraform module for configuring opensearch since there's so many moving parts, but until someone has the bandwidth to do that, I think this is sufficient.