### PR TITLE
Wait an hour before considering a pipeline as skipped

### DIFF
--- a/images/gitlab-skipped-pipelines/skipped_pipelines.py
+++ b/images/gitlab-skipped-pipelines/skipped_pipelines.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import urllib.parse
+from datetime import datetime, timedelta, timezone
 
 import requests
 
@@ -58,18 +59,62 @@ def find_and_run_skipped_pipelines():
     """Query gitlab for all branches. Start a pipeline for any branch whose
     HEAD commit does not already have one.
     """
+
+    pr_branch_regex = re.compile("pr([0-9]+)")
+
+    now = datetime.now(timezone.utc)
+    two_days_ago = now - timedelta(days=2)
+    one_hour_ago = now - timedelta(hours=1)
+
+    after_param = datetime.strftime(two_days_ago, '%Y-%m-%d')
+    events_url = f"{GITLAB_API_URL}/events?action=pushed&after={after_param}"
+    print(f"Getting push events from GitLab from the past two days")
+    events = paginate(events_url)
+    print(f"Found {len(events)} push events")
+
+    recently_pushed_branches = []
+
+    for event in events:
+        if "created_at" not in event or "push_data" not in event or "commit_to" not in event["push_data"]:
+            continue
+
+        branch_name = event["push_data"]["ref"]
+        if branch_name is None:
+            continue
+
+        head_commit = event["push_data"]["commit_to"]
+        if head_commit is None:
+            continue
+
+        m = pr_branch_regex.search(branch_name)
+        if not m:
+            continue
+
+        pushed_at_str = event["created_at"]
+        # strptime only support microseconds (not milliseconds).
+        # Time for some string massaging.
+        pushed_at_str = pushed_at_str.split(".")[0]
+        pushed_at_str += "Z+0000"
+        pushed_at = datetime.strptime(pushed_at_str, "%Y-%m-%dT%H:%M:%SZ%z")
+        if pushed_at > one_hour_ago:
+            recently_pushed_branches.append(branch_name)
+
     print(f"Attempting to find & fix skipped pipelines")
     branches_url = f"{GITLAB_API_URL}/repository/branches"
     branches = paginate(branches_url)
     print(f"Found {len(branches)} branches")
 
-    regexp = re.compile("pr([0-9]+)")
     for branch in branches:
         branch_name = branch["name"]
-        m = regexp.search(branch_name)
+        m = pr_branch_regex.search(branch_name)
         if not m:
             print(f"Not a PR branch: {branch_name}")
             continue
+
+        if branch_name in recently_pushed_branches:
+            print(f"Skip {branch_name} since it was pushed to GitLab within the last hour")
+            continue
+
         branch_commit = branch["commit"]["id"]
         pipelines_url = f"{GITLAB_API_URL}/pipelines?sha={branch_commit}"
         pipelines = paginate(pipelines_url)


### PR DESCRIPTION
Update our skipped pipelines mitigation to wait an hour before using the API to trigger a pipeline for a branch that otherwise does not have one for its HEAD commit.

This resolves a problem we noticed recently where GitLab eventually reacted to the original push event. That resulted in two pipelines for a given commit.