### PR TITLE
Refactor the taxonomy script for testing classification

### DIFF
--- a/images/upload-gitlab-failure-logs/validate_taxonomy.py
+++ b/images/upload-gitlab-failure-logs/validate_taxonomy.py
@@ -1,0 +1,7 @@
+import upload_gitlab_failure_logs as taxonomy
+import sys
+
+if __name__ == "__main__":
+    for trace_file in sys.argv:
+        with open(trace_file) as trace:
+            print(trace_file, ": ", taxonomy.classify(trace.read()))


### PR DESCRIPTION
I re-worked this a bit so I can use this script as an imported module for testing.

```python
import upload_gitlab_failure_logs as taxonomy

with read("my-test-trace.txt", "r") as trace:
    print(taxonomy.classify(trace))
```