### PR TITLE
Update UUID of postgres data source in grafana

### DIFF
--- a/k8s/prometheus/custom/gitlab-ci-failures-dashboard.yaml
+++ b/k8s/prometheus/custom/gitlab-ci-failures-dashboard.yaml
@@ -159,7 +159,7 @@ data:
         {
           "datasource": {
             "type": "postgres",
-            "uid": "Kf0LnP-4z"
+            "uid": "PCC52D03280B7034C"
           },
           "fieldConfig": {
             "defaults": {
@@ -211,7 +211,7 @@ data:
             {
               "datasource": {
                 "type": "postgres",
-                "uid": "Kf0LnP-4z"
+                "uid": "PCC52D03280B7034C"
               },
               "editorMode": "code",
               "format": "table",
@@ -241,7 +241,7 @@ data:
             {
               "datasource": {
                 "type": "postgres",
-                "uid": "Kf0LnP-4z"
+                "uid": "PCC52D03280B7034C"
               },
               "editorMode": "code",
               "format": "table",
@@ -385,7 +385,7 @@ data:
         {
           "datasource": {
             "type": "postgres",
-            "uid": "Kf0LnP-4z"
+            "uid": "PCC52D03280B7034C"
           },
           "fieldConfig": {
             "defaults": {
@@ -432,7 +432,7 @@ data:
             {
               "datasource": {
                 "type": "postgres",
-                "uid": "Kf0LnP-4z"
+                "uid": "PCC52D03280B7034C"
               },
               "editorMode": "code",
               "format": "table",


### PR DESCRIPTION
For some reason, grafana was re-deployed, and since the postgres data source isn't encoded into the helm release for grafana (yet), it was erased. Since all references to data sources in grafanas use the datasource ID, this updates all mentions of the postgres data source to the new ID.