### PR TITLE
Add runner pod affinity

### DIFF
--- a/k8s/runners/protected/graviton/2/release.yaml
+++ b/k8s/runners/protected/graviton/2/release.yaml
@@ -61,6 +61,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -70,6 +84,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/protected/graviton/3/release.yaml
+++ b/k8s/runners/protected/graviton/3/release.yaml
@@ -61,6 +61,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -70,6 +84,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/runners/protected/x86_64/v2/release.yaml
@@ -60,6 +60,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -69,6 +83,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/runners/protected/x86_64/v3/release.yaml
@@ -60,6 +60,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -69,6 +83,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/runners/protected/x86_64/v4/release.yaml
@@ -60,6 +60,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -69,6 +83,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/public/graviton/2/release.yaml
+++ b/k8s/runners/public/graviton/2/release.yaml
@@ -61,6 +61,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -70,6 +84,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/public/graviton/3/release.yaml
+++ b/k8s/runners/public/graviton/3/release.yaml
@@ -61,6 +61,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -70,6 +84,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/public/x86_64/v2/release.yaml
+++ b/k8s/runners/public/x86_64/v2/release.yaml
@@ -60,6 +60,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -69,6 +83,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/public/x86_64/v3/release.yaml
+++ b/k8s/runners/public/x86_64/v3/release.yaml
@@ -60,6 +60,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -69,6 +83,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/public/x86_64/v4/release.yaml
+++ b/k8s/runners/public/x86_64/v4/release.yaml
@@ -60,6 +60,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -69,6 +83,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/signing/release.yaml
+++ b/k8s/runners/signing/release.yaml
@@ -70,6 +70,20 @@ spec:
             #
             # TODO what capabilities can we drop from the container?
             # cap_drop =
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -79,6 +93,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"
               "metrics/gitlab_ci_project_name" = "$CI_PROJECT_NAME"

--- a/k8s/runners/testing/graviton/2/release.yaml
+++ b/k8s/runners/testing/graviton/2/release.yaml
@@ -64,6 +64,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -73,6 +87,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"

--- a/k8s/runners/testing/x86_64/v3/release.yaml
+++ b/k8s/runners/testing/x86_64/v3/release.yaml
@@ -63,6 +63,20 @@ spec:
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
             service_account = "runner"
+
+            # Place pod close to other pipeline pods if possible ("pack" the pods tightly)
+            # Docs: https://docs.gitlab.com/runner/executors/kubernetes.html#define-nodes-where-pods-are-scheduled
+            [runners.kubernetes.affinity]
+              [runners.kubernetes.affinity.pod_affinity]
+                [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution]]
+                [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term]
+                  topology_key = "topology.kubernetes.io/zone"
+                  [runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector]
+                    [[runners.kubernetes.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
+                      key = "spack.io/runner"
+                      operator = "In"
+                      values = ["true"]
+
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
@@ -72,6 +86,7 @@ spec:
               "gitlab/ci_runner_description" = "$CI_RUNNER_DESCRIPTION"
               "gitlab/ci_job_id" = "$CI_JOB_ID"
             [runners.kubernetes.pod_labels]
+              "spack.io/runner" = "true"
               "gitlab/ci_job_size" = "$CI_JOB_SIZE"
               "metrics/gitlab_ci_pipeline_id" = "$CI_PIPELINE_ID"
               "metrics/gitlab_ci_project_namespace" = "$CI_PROJECT_NAMESPACE"


### PR DESCRIPTION
This PR is aimed at placing pods on nodes that already have pods running ("pod packing"), in order to prevent low node utilization.