### PR TITLE
Use spot instances exclusively for runners

### DIFF
--- a/k8s/karpenter/provisioners/runners/graviton/2/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/graviton/2/provisioners.yaml
@@ -48,10 +48,10 @@ spec:
         - "us-east-1c"
         - "us-east-1d"
 
-    # Try spot, fall over to on-demand
+    # Only use spot instances for runners
     - key: "karpenter.sh/capacity-type"
       operator: In
-      values: ["spot", "on-demand"]
+      values: ["spot"]
 
   # Only provision nodes for pods specifying the glr-graviton2 node pool
   labels:

--- a/k8s/karpenter/provisioners/runners/graviton/3/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/graviton/3/provisioners.yaml
@@ -55,10 +55,10 @@ spec:
         - "us-east-1c"
         - "us-east-1d"
 
-    # Try spot, fall over to on-demand
+    # Only use spot instances for runners
     - key: "karpenter.sh/capacity-type"
       operator: In
-      values: ["spot", "on-demand"]
+      values: ["spot"]
 
   # Only provision nodes for pods specifying the glr-graviton3 node pool
   labels:

--- a/k8s/karpenter/provisioners/runners/testing/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/testing/provisioners.yaml
@@ -39,10 +39,10 @@ spec:
         - "m6g.4xlarge" # ARM64 instances
         - "m5zn.3xlarge" # AMD64 instances
 
-    # Try spot, fall over to on-demand
+    # Only use spot instances for runners
     - key: "karpenter.sh/capacity-type"
       operator: In
-      values: ["spot", "on-demand"]
+      values: ["spot"]
 
   # Only provision nodes from the glr-large-testing-pub node pool
   labels:

--- a/k8s/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
@@ -48,10 +48,10 @@ spec:
         - "us-east-1c"
         - "us-east-1d"
 
-    # Try spot, fall over to on-demand
+    # Only use spot instances for runners
     - key: "karpenter.sh/capacity-type"
       operator: In
-      values: ["spot", "on-demand"]
+      values: ["spot"]
 
   # Only provision nodes for pods specifying the glr-x86-64-v2 node pool
   labels:

--- a/k8s/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
@@ -111,10 +111,10 @@ spec:
         - "us-east-1c"
         - "us-east-1d"
 
-    # Try spot, fall over to on-demand
+    # Only use spot instances for runners
     - key: "karpenter.sh/capacity-type"
       operator: In
-      values: ["spot", "on-demand"]
+      values: ["spot"]
 
   # Only provision nodes for pods specifying the glr-x86-64-v3 node pool
   labels:

--- a/k8s/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
+++ b/k8s/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
@@ -86,10 +86,10 @@ spec:
         - "us-east-1c"
         - "us-east-1d"
 
-    # Try spot, fall over to on-demand
+    # Only use spot instances for runners
     - key: "karpenter.sh/capacity-type"
       operator: In
-      values: ["spot", "on-demand"]
+      values: ["spot"]
 
   # Only provision nodes for pods specifying the glr-x86-64-v4 node pool
   labels:


### PR DESCRIPTION
As we discussed last week, this PR disables the usage of on-demand instances for runners. Once this is merged, we will examine 1) how this impacts the error rate of jobs (using the taxonomy dashboard), and 2) how this impacts our AWS costs (using AWS Cost Explorer).