### PR TITLE
Add classification for missing sha256sum command

### DIFF
--- a/images/upload-gitlab-failure-logs/taxonomy.yaml
+++ b/images/upload-gitlab-failure-logs/taxonomy.yaml
@@ -185,6 +185,10 @@ taxonomy:
     checksum_mismatch:
       grep_for:
         - 'Error: sha256 checksum failed for .+'
+    
+    sha256sum_not_found:
+      grep_for:
+        - 'sha256sum: command not found'
 
     # See upload_gitlab_failure_logs.py for how these are used
     stuck_or_timeout_failure: null
@@ -237,4 +241,5 @@ taxonomy:
     # Other Errors
     - 'limit_exceeded'
     - 'execution_timeout'
+    - 'sha256sum_not_found'
     - 'file_not_found'


### PR DESCRIPTION
Recently we've been seeing the following errors:

```
sha256sum: command not found
```

which are being incorrectly classified as `file_not_found`, since this errors seems to directly cause that to occur afterwards.

This will require running reclassifying the last few days of errors if we'd like them to be accurate.