### PR TITLE
Provide role arn in provider eks get-token args

### DIFF
--- a/terraform/modules/spack/outputs.tf
+++ b/terraform/modules/spack/outputs.tf
@@ -9,3 +9,7 @@ output "cluster_endpoint" {
 output "cluster_ca_certificate" {
     value = base64decode(module.eks.cluster_certificate_authority_data)
 }
+
+output "cluster_access_role_arn" {
+    value = aws_iam_role.eks_cluster_access.arn
+}

--- a/terraform/production/.terraform.lock.hcl
+++ b/terraform/production/.terraform.lock.hcl
@@ -142,6 +142,26 @@ provider "registry.terraform.io/hashicorp/random" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.9.1"
+  constraints = ">= 0.7.2"
+  hashes = [
+    "h1:NUv/YtEytDQncBQ2mTxnUZEy/rmDlPYmE9h2iokR0vk=",
+    "zh:00a1476ecf18c735cc08e27bfa835c33f8ac8fa6fa746b01cd3bcbad8ca84f7f",
+    "zh:3007f8fc4a4f8614c43e8ef1d4b0c773a5de1dcac50e701d8abc9fdc8fcb6bf5",
+    "zh:5f79d0730fdec8cb148b277de3f00485eff3e9cf1ff47fb715b1c969e5bbd9d4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8c8094689a2bed4bb597d24a418bbbf846e15507f08be447d0a5acea67c2265a",
+    "zh:a6d9206e95d5681229429b406bc7a9ba4b2d9b67470bda7df88fa161508ace57",
+    "zh:aa299ec058f23ebe68976c7581017de50da6204883950de228ed9246f309e7f1",
+    "zh:b129f00f45fba1991db0aa954a6ba48d90f64a738629119bfb8e9a844b66e80b",
+    "zh:ef6cecf5f50cda971c1b215847938ced4cb4a30a18095509c068643b14030b00",
+    "zh:f1f46a4f6c65886d2dd27b66d92632232adc64f92145bf8403fe64d5ffa5caea",
+    "zh:f79d6155cda7d559c60d74883a24879a01c4d5f6fd7e8d1e3250f3cd215fb904",
+    "zh:fd59fa73074805c3575f08cd627eef7acda14ab6dac2c135a66e7a38d262201c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.0.4"
   constraints = ">= 3.0.0"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -43,8 +43,14 @@ provider "helm" {
     cluster_ca_certificate = module.production_cluster.cluster_ca_certificate
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
-      args        = ["eks", "get-token", "--cluster-name", module.production_cluster.cluster_name, "--region", "us-east-1"]
       command     = "aws"
+      args = [
+        "eks",
+        "get-token",
+        "--region", "us-east-1",
+        "--cluster-name", module.production_cluster.cluster_name,
+        "--role", module.production_cluster.cluster_access_role_arn
+      ]
     }
   }
 }
@@ -54,8 +60,14 @@ provider "kubectl" {
   cluster_ca_certificate = module.production_cluster.cluster_ca_certificate
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
-    args        = ["eks", "get-token", "--cluster-name", module.production_cluster.cluster_name, "--region", "us-east-1"]
     command     = "aws"
+    args = [
+      "eks",
+      "get-token",
+      "--region", "us-east-1",
+      "--cluster-name", module.production_cluster.cluster_name,
+      "--role", module.production_cluster.cluster_access_role_arn
+    ]
   }
 }
 
@@ -64,8 +76,14 @@ provider "kubernetes" {
   cluster_ca_certificate = module.production_cluster.cluster_ca_certificate
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
-    args        = ["eks", "get-token", "--cluster-name", module.production_cluster.cluster_name, "--region", "us-east-1"]
     command     = "aws"
+    args = [
+      "eks",
+      "get-token",
+      "--region", "us-east-1",
+      "--cluster-name", module.production_cluster.cluster_name,
+      "--role", module.production_cluster.cluster_access_role_arn
+    ]
   }
 }
 


### PR DESCRIPTION
The `kubectl`, `kubernetes` and `helm` providers would all raise `Unauthorized` when trying to run terraform apply/plan, even though `kubectl` functioned from the CLI without issue. This is because the role arn is provided in the local kube config file, but it was missing here.