### PR TITLE
Create one NAT gateway per AZ

### DIFF
--- a/terraform/modules/spack/vpc.tf
+++ b/terraform/modules/spack/vpc.tf
@@ -6,17 +6,17 @@ module "vpc" {
   name = "spack-${var.deployment_name}"
   cidr = var.vpc_cidr
 
-  azs = var.availability_zones
-  public_subnets = var.public_subnets
-  private_subnets = var.private_subnets
+  azs              = var.availability_zones
+  public_subnets   = var.public_subnets
+  private_subnets  = var.private_subnets
   database_subnets = var.database_subnets
 
   # Create a DB subnet group for RDS (see rds.tf)
   create_database_subnet_group = true
 
-  enable_nat_gateway   = true
-  single_nat_gateway   = false
-  enable_dns_hostnames = true
+  enable_nat_gateway     = true
+  single_nat_gateway     = false
+  enable_dns_hostnames   = true
   one_nat_gateway_per_az = true
 
   public_subnet_tags = {

--- a/terraform/modules/spack/vpc.tf
+++ b/terraform/modules/spack/vpc.tf
@@ -17,6 +17,7 @@ module "vpc" {
   enable_nat_gateway   = true
   single_nat_gateway   = false
   enable_dns_hostnames = true
+  one_nat_gateway_per_az = true
 
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1


### PR DESCRIPTION
We discovered recently that one thing causing high AWS costs is the fact that we don't have a NAT gateway in every availability zone. The terraform vpc module we use exposes a parameter that allows us to configure that, so I've enabled that here.