### PR TITLE
Add a "service" tag to x86_64_v2 runners

### DIFF
--- a/k8s/runners/public/graviton/2/release.yaml
+++ b/k8s/runners/public/graviton/2/release.yaml
@@ -103,7 +103,7 @@ spec:
       imagePullPolicy: "if-not-present"
       locked: false
 
-      tags: "arm,aarch64,graviton,graviton2,small,medium,large,huge,public,aws,spack"
+      tags: "arm,aarch64,graviton,graviton2,small,medium,large,huge,public,aws,spack,service"
       runUntagged: false
       secret: gitlab-gitlab-runner-secret # from gitlab release
 

--- a/k8s/runners/public/x86_64/v2/release.yaml
+++ b/k8s/runners/public/x86_64/v2/release.yaml
@@ -102,7 +102,7 @@ spec:
       imagePullPolicy: "if-not-present"
       locked: false
 
-      tags: "x86_64,x86_64_v2,small,medium,large,huge,public,aws,spack"
+      tags: "x86_64,x86_64_v2,small,medium,large,huge,public,aws,spack,service"
       runUntagged: false
       secret: gitlab-gitlab-runner-secret # from gitlab release
 


### PR DESCRIPTION
Having this tag on these runners, which should include some of the cheaper and more available instances we provision, will allow us to target these instances for the likes of the noop, cleanup, and reindex jobs.