### PR TITLE
error taxononmy: more flavors of existing classes

### DIFF
--- a/images/upload-gitlab-failure-logs/taxonomy.yaml
+++ b/images/upload-gitlab-failure-logs/taxonomy.yaml
@@ -14,11 +14,15 @@ taxonomy:
         - "HTTP Error 404"
         - 'curl: \(60\)'
         - "ConnectionResetError:"
+        - "curl.+SSL_ERROR_SYSCALL"
+        - "Job failed \(system failure\):.+TLS handshake timeout"
+        - "curl: \(6\) Could not resolve host"
 
     concretization_error:
       grep_for:
         - "does not satisfy"
         - "Error: errors occurred during concretization"
+        - "Error: concretization failed for the following reasons"
 
     job_log_missing:
         grep_for:


### PR DESCRIPTION
Add more regexes to existing error categories, based on recent failures categorized as `other`.  This adds three new kinds of `network_error`, and a new kind of `concretization_error`.  Examples linked below:

- `network_error`:
  - https://gitlab.spack.io/spack/spack/-/jobs/6550068
  - https://gitlab.spack.io/spack/spack/-/jobs/6545225
  - https://gitlab.spack.io/spack/spack/-/jobs/6543161
- `concretization_error`: https://gitlab.spack.io/spack/spack/-/jobs/6549992