### PR TITLE
Fix error loading taxonomy yaml

### DIFF
--- a/images/upload-gitlab-failure-logs/taxonomy.yaml
+++ b/images/upload-gitlab-failure-logs/taxonomy.yaml
@@ -15,8 +15,8 @@ taxonomy:
         - 'curl: \(60\)'
         - "ConnectionResetError:"
         - "curl.+SSL_ERROR_SYSCALL"
-        - "Job failed \(system failure\):.+TLS handshake timeout"
-        - "curl: \(6\) Could not resolve host"
+        - 'Job failed \(system failure\):.+TLS handshake timeout'
+        - 'curl: \(6\) Could not resolve host'
 
     concretization_error:
       grep_for:


### PR DESCRIPTION
It seems like regexes with escape sequences enclosed in double quotes prevent the `yaml` module from loading the taxonomy.  I'm not sure what detail of yaml syntax I ran afoul of here, but if I replace double quotes with single quotes, it allows me to do the foillowing without errors:

```python
with open(<taxonomy_yaml_path>) as f:
    yaml.safe_load(f)["taxonomy"]
```