### PR TITLE
[Pipeline Overview Dashboard] Add table showing cpu and pods per node

### DIFF
--- a/k8s/prometheus/custom/gitlab-pipeline-dashboard.yaml
+++ b/k8s/prometheus/custom/gitlab-pipeline-dashboard.yaml
@@ -480,46 +480,129 @@ data:
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "thresholds"
               },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "inspect": false
+              },
               "mappings": [],
-              "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
               }
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "label_karpenter_k8s_aws_instance_memory"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 147
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "label_karpenter_k8s_aws_instance_generation"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 172
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "label_karpenter_k8s_aws_instance_cpu"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 153
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "node"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 222
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Pods"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 68
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "CPU"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 149
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 3,
+            "h": 16,
+            "w": 6,
             "x": 0,
             "y": 9
           },
-          "id": 18,
+          "id": 40,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+            "footer": {
               "fields": "",
-              "values": false
+              "reducer": [
+                "sum"
+              ],
+              "show": false
             },
-            "textMode": "auto"
+            "frameIndex": 1,
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": false,
+                "displayName": "CPU"
+              }
+            ]
           },
           "pluginVersion": "9.3.1",
           "targets": [
@@ -530,15 +613,242 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(kube_node_labels{label_spack_io_pipeline=\"true\"} * on(node) group_left() kube_node_status_capacity{resource=\"cpu\"})",
+              "expr": "kube_node_labels{label_spack_io_pipeline=\"true\"} * on(node) group_left() sum by(node) (kube_pod_info{namespace=\"pipeline\", node!=\"\"})",
+              "format": "table",
               "instant": true,
               "interval": "",
-              "legendFormat": "CPU",
-              "refId": "Total CPU"
+              "legendFormat": "{{node}}",
+              "range": false,
+              "refId": "pods per node"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "(kube_node_labels{label_spack_io_pipeline=\"true\"} * on(node) group_left(internal_ip) kube_node_info) * on(internal_ip) group_left label_replace(100 * sum by(instance) (sum without (cpu)(irate(node_cpu_seconds_total{mode!=\"idle\"}[3m])) / ignoring(mode) group_left sum without(mode, cpu) (irate(node_cpu_seconds_total[3m]))), 'internal_ip', '$1', 'instance', '(.+):.+')",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "{{node}}",
+              "range": false,
+              "refId": "cpu per node"
             }
           ],
-          "title": "CPU Total",
-          "type": "stat"
+          "title": "Pods per Node",
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "node",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Time 1": true,
+                  "Time 2": true,
+                  "Value #cpu per node": false,
+                  "Value #pods per node": false,
+                  "container": true,
+                  "container 1": true,
+                  "container 2": true,
+                  "endpoint": true,
+                  "endpoint 1": true,
+                  "endpoint 2": true,
+                  "instance": true,
+                  "instance 1": true,
+                  "instance 2": true,
+                  "internal_ip": true,
+                  "job": true,
+                  "job 1": true,
+                  "job 2": true,
+                  "label_beta_kubernetes_io_arch": true,
+                  "label_beta_kubernetes_io_arch 1": true,
+                  "label_beta_kubernetes_io_arch 2": true,
+                  "label_beta_kubernetes_io_instance_type": true,
+                  "label_beta_kubernetes_io_instance_type 1": true,
+                  "label_beta_kubernetes_io_instance_type 2": true,
+                  "label_beta_kubernetes_io_os": true,
+                  "label_beta_kubernetes_io_os 1": true,
+                  "label_beta_kubernetes_io_os 2": true,
+                  "label_failure_domain_beta_kubernetes_io_region": true,
+                  "label_failure_domain_beta_kubernetes_io_region 1": true,
+                  "label_failure_domain_beta_kubernetes_io_region 2": true,
+                  "label_failure_domain_beta_kubernetes_io_zone": true,
+                  "label_failure_domain_beta_kubernetes_io_zone 1": true,
+                  "label_failure_domain_beta_kubernetes_io_zone 2": true,
+                  "label_k8s_io_cloud_provider_aws": true,
+                  "label_k8s_io_cloud_provider_aws 1": true,
+                  "label_k8s_io_cloud_provider_aws 2": true,
+                  "label_karpenter_k8s_aws_instance_ami_id": true,
+                  "label_karpenter_k8s_aws_instance_ami_id 1": true,
+                  "label_karpenter_k8s_aws_instance_ami_id 2": true,
+                  "label_karpenter_k8s_aws_instance_category": true,
+                  "label_karpenter_k8s_aws_instance_category 1": true,
+                  "label_karpenter_k8s_aws_instance_category 2": true,
+                  "label_karpenter_k8s_aws_instance_cpu": true,
+                  "label_karpenter_k8s_aws_instance_cpu 1": true,
+                  "label_karpenter_k8s_aws_instance_cpu 2": true,
+                  "label_karpenter_k8s_aws_instance_family": true,
+                  "label_karpenter_k8s_aws_instance_family 1": true,
+                  "label_karpenter_k8s_aws_instance_family 2": true,
+                  "label_karpenter_k8s_aws_instance_generation": true,
+                  "label_karpenter_k8s_aws_instance_generation 1": true,
+                  "label_karpenter_k8s_aws_instance_generation 2": true,
+                  "label_karpenter_k8s_aws_instance_hypervisor": true,
+                  "label_karpenter_k8s_aws_instance_hypervisor 1": true,
+                  "label_karpenter_k8s_aws_instance_hypervisor 2": true,
+                  "label_karpenter_k8s_aws_instance_local_nvme": true,
+                  "label_karpenter_k8s_aws_instance_local_nvme 1": true,
+                  "label_karpenter_k8s_aws_instance_local_nvme 2": true,
+                  "label_karpenter_k8s_aws_instance_memory": true,
+                  "label_karpenter_k8s_aws_instance_memory 1": true,
+                  "label_karpenter_k8s_aws_instance_memory 2": true,
+                  "label_karpenter_k8s_aws_instance_pods": true,
+                  "label_karpenter_k8s_aws_instance_pods 1": true,
+                  "label_karpenter_k8s_aws_instance_pods 2": true,
+                  "label_karpenter_k8s_aws_instance_size": true,
+                  "label_karpenter_k8s_aws_instance_size 1": true,
+                  "label_karpenter_k8s_aws_instance_size 2": true,
+                  "label_karpenter_sh_capacity_type": true,
+                  "label_karpenter_sh_capacity_type 1": true,
+                  "label_karpenter_sh_capacity_type 2": true,
+                  "label_karpenter_sh_initialized": true,
+                  "label_karpenter_sh_initialized 1": true,
+                  "label_karpenter_sh_initialized 2": true,
+                  "label_karpenter_sh_provisioner_name": true,
+                  "label_karpenter_sh_provisioner_name 1": true,
+                  "label_karpenter_sh_provisioner_name 2": true,
+                  "label_kubernetes_io_arch": true,
+                  "label_kubernetes_io_arch 1": true,
+                  "label_kubernetes_io_arch 2": true,
+                  "label_kubernetes_io_hostname": true,
+                  "label_kubernetes_io_hostname 1": true,
+                  "label_kubernetes_io_hostname 2": true,
+                  "label_kubernetes_io_os": true,
+                  "label_kubernetes_io_os 1": true,
+                  "label_kubernetes_io_os 2": true,
+                  "label_node_kubernetes_io_instance_type": true,
+                  "label_node_kubernetes_io_instance_type 1": true,
+                  "label_node_kubernetes_io_instance_type 2": true,
+                  "label_spack_io_node_pool": true,
+                  "label_spack_io_node_pool 1": true,
+                  "label_spack_io_node_pool 2": true,
+                  "label_spack_io_pipeline": true,
+                  "label_spack_io_pipeline 1": true,
+                  "label_spack_io_pipeline 2": true,
+                  "label_topology_ebs_csi_aws_com_zone": true,
+                  "label_topology_ebs_csi_aws_com_zone 1": true,
+                  "label_topology_ebs_csi_aws_com_zone 2": true,
+                  "label_topology_kubernetes_io_region": true,
+                  "label_topology_kubernetes_io_region 1": true,
+                  "label_topology_kubernetes_io_region 2": true,
+                  "label_topology_kubernetes_io_zone": true,
+                  "label_topology_kubernetes_io_zone 1": true,
+                  "label_topology_kubernetes_io_zone 2": true,
+                  "namespace": true,
+                  "namespace 1": true,
+                  "namespace 2": true,
+                  "pod": true,
+                  "pod 1": true,
+                  "pod 2": true,
+                  "service": true,
+                  "service 1": true,
+                  "service 2": true
+                },
+                "indexByName": {
+                  "Time 1": 3,
+                  "Time 2": 39,
+                  "Value #cpu per node": 1,
+                  "Value #pods per node": 2,
+                  "container 1": 4,
+                  "container 2": 40,
+                  "endpoint 1": 5,
+                  "endpoint 2": 41,
+                  "instance 1": 6,
+                  "instance 2": 42,
+                  "internal_ip": 43,
+                  "job 1": 7,
+                  "job 2": 44,
+                  "label_beta_kubernetes_io_arch 1": 8,
+                  "label_beta_kubernetes_io_arch 2": 45,
+                  "label_beta_kubernetes_io_instance_type 1": 9,
+                  "label_beta_kubernetes_io_instance_type 2": 46,
+                  "label_beta_kubernetes_io_os 1": 10,
+                  "label_beta_kubernetes_io_os 2": 47,
+                  "label_failure_domain_beta_kubernetes_io_region 1": 11,
+                  "label_failure_domain_beta_kubernetes_io_region 2": 48,
+                  "label_failure_domain_beta_kubernetes_io_zone 1": 12,
+                  "label_failure_domain_beta_kubernetes_io_zone 2": 49,
+                  "label_k8s_io_cloud_provider_aws 1": 13,
+                  "label_k8s_io_cloud_provider_aws 2": 50,
+                  "label_karpenter_k8s_aws_instance_ami_id 1": 14,
+                  "label_karpenter_k8s_aws_instance_ami_id 2": 51,
+                  "label_karpenter_k8s_aws_instance_category 1": 15,
+                  "label_karpenter_k8s_aws_instance_category 2": 52,
+                  "label_karpenter_k8s_aws_instance_cpu 1": 16,
+                  "label_karpenter_k8s_aws_instance_cpu 2": 53,
+                  "label_karpenter_k8s_aws_instance_family 1": 17,
+                  "label_karpenter_k8s_aws_instance_family 2": 54,
+                  "label_karpenter_k8s_aws_instance_generation 1": 18,
+                  "label_karpenter_k8s_aws_instance_generation 2": 55,
+                  "label_karpenter_k8s_aws_instance_hypervisor 1": 19,
+                  "label_karpenter_k8s_aws_instance_hypervisor 2": 56,
+                  "label_karpenter_k8s_aws_instance_local_nvme 1": 38,
+                  "label_karpenter_k8s_aws_instance_local_nvme 2": 75,
+                  "label_karpenter_k8s_aws_instance_memory 1": 20,
+                  "label_karpenter_k8s_aws_instance_memory 2": 57,
+                  "label_karpenter_k8s_aws_instance_pods 1": 21,
+                  "label_karpenter_k8s_aws_instance_pods 2": 58,
+                  "label_karpenter_k8s_aws_instance_size 1": 22,
+                  "label_karpenter_k8s_aws_instance_size 2": 59,
+                  "label_karpenter_sh_capacity_type 1": 23,
+                  "label_karpenter_sh_capacity_type 2": 60,
+                  "label_karpenter_sh_initialized 1": 24,
+                  "label_karpenter_sh_initialized 2": 61,
+                  "label_karpenter_sh_provisioner_name 1": 25,
+                  "label_karpenter_sh_provisioner_name 2": 62,
+                  "label_kubernetes_io_arch 1": 26,
+                  "label_kubernetes_io_arch 2": 63,
+                  "label_kubernetes_io_hostname 1": 27,
+                  "label_kubernetes_io_hostname 2": 64,
+                  "label_kubernetes_io_os 1": 28,
+                  "label_kubernetes_io_os 2": 65,
+                  "label_node_kubernetes_io_instance_type 1": 29,
+                  "label_node_kubernetes_io_instance_type 2": 66,
+                  "label_spack_io_node_pool 1": 30,
+                  "label_spack_io_node_pool 2": 67,
+                  "label_spack_io_pipeline 1": 31,
+                  "label_spack_io_pipeline 2": 68,
+                  "label_topology_ebs_csi_aws_com_zone 1": 32,
+                  "label_topology_ebs_csi_aws_com_zone 2": 69,
+                  "label_topology_kubernetes_io_region 1": 33,
+                  "label_topology_kubernetes_io_region 2": 70,
+                  "label_topology_kubernetes_io_zone 1": 34,
+                  "label_topology_kubernetes_io_zone 2": 71,
+                  "namespace 1": 35,
+                  "namespace 2": 72,
+                  "node": 0,
+                  "pod 1": 36,
+                  "pod 2": 73,
+                  "service 1": 37,
+                  "service 2": 74
+                },
+                "renameByName": {
+                  "Value": "Pods",
+                  "Value #cpu per node": "CPU",
+                  "Value #pods per node": "Pods"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -576,8 +886,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 21,
-            "x": 3,
+            "w": 18,
+            "x": 6,
             "y": 9
           },
           "id": 32,
@@ -622,70 +932,6 @@ data:
                 "mode": "thresholds"
               },
               "mappings": [],
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 3,
-            "x": 0,
-            "y": 17
-          },
-          "id": 20,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "pluginVersion": "9.3.1",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": false,
-              "expr": "sum((label_replace(node_memory_MemTotal_bytes, 'internal_ip', '$1', 'instance', '(.+):.+') and on(internal_ip) kube_node_labels{label_spack_io_node_pool=~\"glr.*\"} * on(node) group_left(internal_ip) kube_node_info))",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "Bytes",
-              "refId": "A"
-            }
-          ],
-          "title": "RAM Total",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
               "max": 100,
               "min": 0,
               "thresholds": {
@@ -711,8 +957,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 21,
-            "x": 3,
+            "w": 18,
+            "x": 6,
             "y": 17
           },
           "id": 34,
@@ -867,53 +1113,44 @@ data:
           "type": "timeseries"
         },
         {
-          "id": 39,
-          "gridPos": {
-            "h": 12,
-            "w": 24,
-            "x": 0,
-            "y": 38
-          },
-          "type": "timeseries",
-          "title": "Pod counts for PRs/develop",
           "datasource": {
-            "uid": "${DS_PROMETHEUS}",
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
               "custom": {
-                "drawStyle": "line",
-                "lineInterpolation": "linear",
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
                 "barAlignment": 0,
-                "lineWidth": 2,
+                "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
-                "spanNulls": false,
-                "showPoints": "auto",
-                "pointSize": 5,
-                "stacking": {
-                  "mode": "none",
-                  "group": "A"
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
                 },
-                "axisPlacement": "auto",
-                "axisLabel": "",
-                "axisColorMode": "text",
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
                 "scaleDistribution": {
                   "type": "linear"
                 },
-                "axisCenteredZero": false,
-                "hideFrom": {
-                  "tooltip": false,
-                  "viz": false,
-                  "legend": false
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
                 },
                 "thresholdsStyle": {
                   "mode": "off"
                 }
-              },
-              "color": {
-                "mode": "palette-classic"
               },
               "mappings": [],
               "thresholds": {
@@ -932,16 +1169,23 @@ data:
             },
             "overrides": []
           },
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 38
+          },
+          "id": 39,
           "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
             "tooltip": {
               "mode": "single",
               "sort": "none"
-            },
-            "legend": {
-              "showLegend": true,
-              "displayMode": "list",
-              "placement": "bottom",
-              "calcs": []
             }
           },
           "targets": [
@@ -958,7 +1202,9 @@ data:
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Pod counts for PRs/develop",
+          "type": "timeseries"
         },
         {
           "collapsed": false,
@@ -970,7 +1216,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 38
+            "y": 50
           },
           "id": 2,
           "panels": [],
@@ -1051,7 +1297,7 @@ data:
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 39
+            "y": 51
           },
           "id": 24,
           "options": {
@@ -1186,7 +1432,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 49
+            "y": 61
           },
           "id": 6,
           "options": {
@@ -1280,7 +1526,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 58
+            "y": 70
           },
           "id": 8,
           "options": {
@@ -1321,7 +1567,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 67
+            "y": 79
           },
           "id": 26,
           "panels": [],
@@ -1338,7 +1584,7 @@ data:
           "type": "row"
         }
       ],
-      "refresh": "10s",
+      "refresh": "30s",
       "schemaVersion": 37,
       "style": "dark",
       "tags": [
@@ -1374,6 +1620,6 @@ data:
       "timezone": "",
       "title": "Pipeline / Overview",
       "uid": "UMI_eRy7z",
-      "version": 3,
+      "version": 4,
       "weekStart": ""
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11370025/232911665-16dd5547-2c45-44ee-b78a-20d1b4919db0.png)

Here's how it would look. This removes the "CPU Total" and "RAM Total", as there's not really room otherwise. IMO those two don't really provide much valuable info, but if other disagree, I can find some other place to put the table.

The table defaults to sorting by CPU ascending, so you can immediately see idling nodes and how many pipeline pods are on them.