### PR TITLE
Add missing dependency to gitlab error upload script

### DIFF
--- a/images/upload-gitlab-failure-logs/requirements.txt
+++ b/images/upload-gitlab-failure-logs/requirements.txt
@@ -1,3 +1,4 @@
+kubernetes==26.1.0
 opensearch-dsl==2.0.1
 python-gitlab==3.11.0
 PyYAML==6.0


### PR DESCRIPTION
I introduced the `kubernetes` python library in #427, but neglected to add it as a dependency.