### PR TITLE
Update outdated Flux ignore annotations

### DIFF
--- a/k8s/production/cdash/upgrade-db-schema.yaml
+++ b/k8s/production/cdash/upgrade-db-schema.yaml
@@ -5,7 +5,7 @@ metadata:
   name: upgrade-db-schema
   namespace: cdash
   annotations:
-    fluxcd.io/ignore: "true"
+    kustomize.toolkit.fluxcd.io/reconcile: disabled
   labels:
     app: cdash
     svc: web

--- a/k8s/production/metabase/gitlab_ro_user_job.yaml
+++ b/k8s/production/metabase/gitlab_ro_user_job.yaml
@@ -5,7 +5,7 @@ metadata:
   name: job-create-ro-gitlab-postgres-user
   namespace: gitlab
   annotations:
-    fluxcd.io/ignore: "true"
+    kustomize.toolkit.fluxcd.io/reconcile: disabled
 spec:
   template:
     metadata:

--- a/k8s/production/spack/spackbotdev-spack-io/README.md
+++ b/k8s/production/spack/spackbotdev-spack-io/README.md
@@ -8,8 +8,8 @@ The development version of the app is registered as `spack-bot-test` under the [
 
 To experiment with your spackbot changes, you must first temporarily disable flux from interfering with your changes.  This is accomplished by annotating the `spackbotdev-workers` and `spackbotdev-spack-io` deployments as follows:
 
-    kubectl annotate deployment -n spack spackbotdev-spack-io fluxcd.io/ignore="true"
-    kubectl annotate deployment -n spack spackbotdev-workers fluxcd.io/ignore="true"
+    kubectl annotate deployment -n spack spackbotdev-spack-io kustomize.toolkit.fluxcd.io/reconcile="disabled"
+    kubectl annotate deployment -n spack spackbotdev-workers kustomize.toolkit.fluxcd.io/reconcile="disabled"
 
 Now the development/test work cycle proceeds like this:
 


### PR DESCRIPTION
I noticed some resources and documentation contain the old ignore annotation from Flux 1. This explains why the jobs associated with these resources (the cdash migration job and gitlab RO user creation job) are continuing to run and fail in the cluster.