### PR TITLE
Switch to emptiness deprovisioning for gitlab nodes

### DIFF
--- a/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
@@ -8,9 +8,8 @@ spec:
   providerRef:
     name: default
 
-  # Consolidation will de-provision larger than necessary nodes
-  consolidation:
-    enabled: true
+  # Terminate nodes after 5 minutes of idle time
+  ttlSecondsAfterEmpty: 300
 
   requirements:
     - key: "node.kubernetes.io/instance-type"


### PR DESCRIPTION
We've been seeing lots of evictions for gitlab pods, and it seems consolidation is the cause. Consolidation doesn't make sense for gitlab nodes anyway, since we only provide one instance type.

These changes are already applied to the cluster.