### PR TITLE
Update spackbot redis host to new url

### DIFF
--- a/k8s/production/spack/spackbot-spack-io/deployments.yaml
+++ b/k8s/production/spack/spackbot-spack-io/deployments.yaml
@@ -34,7 +34,7 @@ spec:
         - name: SPACKBOT_LOG_LEVEL
           value: "INFO"
         - name: REDIS_HOST
-          value: pr-binary-graduation-queue-production.cev8lh.ng.0001.use1.cache.amazonaws.com
+          value: pr-binary-graduation-queue-prod.cev8lh.ng.0001.use1.cache.amazonaws.com
         - name: REDIS_PORT
           value: "6379"
         - name: TASK_QUEUE_SHORT
@@ -106,7 +106,7 @@ spec:
         - name: SPACKBOT_LOG_LEVEL
           value: "INFO"
         - name: REDIS_HOST
-          value: pr-binary-graduation-queue-production.cev8lh.ng.0001.use1.cache.amazonaws.com
+          value: pr-binary-graduation-queue-prod.cev8lh.ng.0001.use1.cache.amazonaws.com
         - name: REDIS_PORT
           value: "6379"
         - name: TASK_QUEUE_SHORT
@@ -187,7 +187,7 @@ spec:
         - name: SPACKBOT_LOG_LEVEL
           value: "INFO"
         - name: REDIS_HOST
-          value: pr-binary-graduation-queue-production.cev8lh.ng.0001.use1.cache.amazonaws.com
+          value: pr-binary-graduation-queue-prod.cev8lh.ng.0001.use1.cache.amazonaws.com
         - name: REDIS_PORT
           value: "6379"
         - name: TASK_QUEUE_SHORT


### PR DESCRIPTION
This URL changed as a consequence of the cluster migration.