### PR TITLE
signing script: Do not fail when there is nothing to sign

### DIFF
--- a/images/notary/sign.sh
+++ b/images/notary/sign.sh
@@ -54,7 +54,7 @@ gpg --import-ownertrust <(echo -e "${INTERMEDIATE_CI_PUBLIC_KEY_ID}:6:\n${UO_INT
 
 
 # Check downloaded spec files,  die if not signed/verified
-for FILE in $WORKINGDIR/*; do
+for FILE in $( find $WORKINGDIR -type f ); do
     echo "VERIFY: ${FILE}"
     gpg --no-tty --quiet ${FILE}
     rm ${FILE}
@@ -66,7 +66,7 @@ gpg --no-tty --import <(aws-encryption-cli --decrypt -S -w "key=${KMS_KEY_ARN}" 
 
 
 # Sign Keys with reputational key
-for FILE in $WORKINGDIR/*; do
+for FILE in $( find $WORKINGDIR -type f ); do
    echo "SIGN: ${FILE}"
    gpg --no-tty --output ${FILE}.sig --clearsign ${FILE}
    rm ${FILE}


### PR DESCRIPTION
Using the globbing pattern seems to produce an empty match when there are no spec files in the working directory.  Replacing the glob with the results of find prevents entering the loop unless there are any actual files in the directory.

Normally if there was nothing to rebuild, we would not schedule this job anyway.  So this is guarding an exceptional case, where all the scheduled rebuild jobs failed, something we saw when the version of gpg in one of the rebuild images was incompatible with one of the intermediate signing keys.