### PR TITLE
Update engine_version for gitlab postgres DB

### DIFF
--- a/terraform/modules/spack/gitlab_db.tf
+++ b/terraform/modules/spack/gitlab_db.tf
@@ -5,7 +5,7 @@ module "gitlab_db" {
   identifier = "gitlab-${var.deployment_name}"
 
   engine               = "postgres"
-  engine_version       = "14"
+  engine_version       = "14.3"
   family               = "postgres14"
   major_engine_version = "14"
   instance_class       = var.gitlab_db_instance_class


### PR DESCRIPTION
`terraform plan` reports the `engine_version` of the postgres RDS instance to be `14.3` instead of `14`. This PR results in a no-op `terraform plan` for the RDS instance.