### PR TITLE
Increase concurrency of signing jobs

### DIFF
--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -31,7 +31,7 @@ spec:
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 1
+    concurrent: 20
     checkInterval: 30
     # preEntrypointScript: |
     #   echo "Hello, from large-pub runner"


### PR DESCRIPTION
Signing jobs can take awhile, and only allowing to run one at a time makes them run in serial, dominating the total time spent on protected pipelines (even those that rebuild few specs).  This PR allows up to 20 `sign-pkgs` jobs to run at a time, which should speed up protected pipelines significantly.