### PR TITLE
New cron job to publish weekly snapshot releases for Spack

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -46,6 +46,8 @@ jobs:
             image-tags: ghcr.io/spack/gitlab-error-processor:0.0.1
           - docker-image: upload-gitlab-failure-logs
             image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.1
+          - docker-image: snapshot-release-tags
+            image-tags: ghcr.io/spack/snapshot-release-tags:0.0.1
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/images/snapshot-release-tags/Dockerfile
+++ b/images/snapshot-release-tags/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "./snapshot_release_tags.py" ]

--- a/images/snapshot-release-tags/requirements.txt
+++ b/images/snapshot-release-tags/requirements.txt
@@ -1,0 +1,13 @@
+certifi==2023.5.7
+cffi==1.15.1
+charset-normalizer==3.1.0
+cryptography==40.0.2
+Deprecated==1.2.13
+idna==3.4
+pycparser==2.21
+PyGithub==1.58.2
+PyJWT==2.7.0
+PyNaCl==1.5.0
+requests==2.30.0
+urllib3==2.0.2
+wrapt==1.15.0

--- a/images/snapshot-release-tags/snapshot_release_tags.py
+++ b/images/snapshot-release-tags/snapshot_release_tags.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+from datetime import datetime, timezone
+from github import Github, InputGitAuthor
+import json
+import os
+import re
+import subprocess
+import tempfile
+import urllib.request
+
+if __name__ == "__main__":
+    if "GITHUB_TOKEN" not in os.environ:
+        raise Exception("GITHUB_TOKEN environment is not set")
+
+    # Use the GitLab API to get the most recent successful develop pipeline.
+    gitlab_api_url = "https://gitlab.spack.io/api/v4/projects/2"
+    pipeline_api_url = f"{gitlab_api_url}/pipelines?ref=develop&status=success"
+    request = urllib.request.Request(pipeline_api_url)
+    response = urllib.request.urlopen(request)
+    response_data = response.read()
+    try:
+        pipelines = json.loads(response_data)
+    except json.decoder.JSONDecodeError:
+        raise Exception("Failed to parse response as json ({0})".format(response_data))
+
+    if len(pipelines) == 0:
+        raise Exception("No successful develop pipelines found!")
+
+    sha = pipelines[0]["sha"]
+
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    tag_name = f"develop-{date_str}"
+    tag_msg = f"Snapshot release {date_str}"
+
+    # Use the GitHub API to create a tag for this commit of develop.
+    github_token = os.environ.get('GITHUB_TOKEN')
+    py_github = Github(github_token)
+    py_gh_repo = py_github.get_repo("spack/spack", lazy=True)
+    spackbot_author = InputGitAuthor("spackbot", "noreply@spack.io")
+    print(f"Pushing tag {tag_name} for commit {sha}")
+    py_gh_repo.create_git_tag_and_release(
+        tag=tag_name,
+        tag_message=tag_msg,
+        release_name=tag_name,
+        release_message=tag_msg,
+        object=sha,
+        type="commit",
+        tagger=spackbot_author)
+    print("Push done!")

--- a/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
+++ b/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: snapshot-release-tags
+  namespace: custom
+spec:
+  schedule: "0 1 * * 0" # 1am on Sunday
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: snapshot-release-tags
+            image: ghcr.io/spack/snapshot-release-tags:0.0.1
+            imagePullPolicy: IfNotPresent
+            resources:
+              requests:
+                cpu: 500m
+                memory: 500M
+            env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: gh-gl-sync
+                  key: github-access-token
+          nodeSelector:
+            spack.io/node-pool: base


### PR DESCRIPTION
This cron job queries GitLab for the most recent successful develop pipeline and pushes that commit to GitHub as a new tag named develop-YYYY-MM-DD.

This job is scheduled to run once a week on Sunday morning.