### PR TITLE
Add an S3 Gateway Endpoint to VPC config

### DIFF
--- a/terraform/modules/spack/main.tf
+++ b/terraform/modules/spack/main.tf
@@ -22,3 +22,6 @@ terraform {
     }
   }
 }
+
+# Data source that allows us to dynamically determine the current AWS region
+data "aws_region" "current" {}

--- a/terraform/modules/spack/vpc.tf
+++ b/terraform/modules/spack/vpc.tf
@@ -41,3 +41,13 @@ resource "aws_db_subnet_group" "spack" {
   name       = "spack-db-subnet-group-${var.deployment_name}"
   subnet_ids = module.vpc.private_subnets
 }
+
+# S3 Gateway Endpoint to allow cheaper traffic between our
+# public/private subnets and S3.
+# https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html
+resource "aws_vpc_endpoint" "s3_gateway" {
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  vpc_endpoint_type = "Gateway"
+  vpc_id            = module.vpc.vpc_id
+  route_table_ids   = concat(module.vpc.private_route_table_ids, module.vpc.public_route_table_ids)
+}


### PR DESCRIPTION
AWS docs - https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html
Terraform docs - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint

This will help reduce S3 access costs from within our VPC.