### PR TITLE
Use editor to input sealed secret values

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Once you have a file containing one or more SealedSecret resources, you'll need 
 ./scripts/secrets/update.py k8s/production/**/sealed-secrets.yaml
 ```
 
-This will prompt you to select the specific secret you want to modify (if several are defined), and which key within the secret's data you want to update (or create a new entry). This prompts you to enter the raw unencrypted value into your shell, which will be sealed, base64 encoded and placed into the file. Comments in the secrets file are not affected by the script, and are encouraged.
+This will prompt you to select the specific secret you want to modify (if several are defined), and which key within the secret's data you want to update (or create a new entry). Then, your locally configured `$EDITOR` (defaults to vim) will be opened for you to enter the raw unencrypted value, which will be sealed, base64 encoded and placed into the file. Comments in the secrets file are not affected by the script, and are encouraged.
+
+When using the editor, surrounding whitespace is automatically removed, to prevent accidental newlines/whitespace/etc. from being included into the secret value (as many editors automatically append a newline, for example). If this is to be avoided (i.e. if you explicity *need* to enter whitespace as the secret value), the `--value` argument can be used to specify the value of your secret.
 
 Sealed Secrets are *write only*, and as such, cannot be read directly from the definitions in this repository. However, if you have cluster access, you can read the secret value from the cluster.
 

--- a/scripts/secrets/update.py
+++ b/scripts/secrets/update.py
@@ -126,7 +126,12 @@ def sealed_secret_cert_path(staging: bool) -> str:
     is_flag=True,
     help="Use the staging cert file.",
 )
-def main(secrets_file: str, staging: bool):
+@click.option(
+    "--value",
+    type=click.STRING,
+    help="Supply the value for the selected secret as an argument.",
+)
+def main(secrets_file: str, staging: bool, value: str):
     # Read in secrets file with comments
     yl = get_yaml_reader()
     with open(secrets_file) as f:
@@ -161,7 +166,7 @@ def main(secrets_file: str, staging: bool):
         key_to_update = click.prompt("Please enter new secret name")
 
     # Retrieve value
-    value = click.prompt(
+    value = value or click.prompt(
         "Please enter new secret value", default="", show_default=False
     )
 

--- a/scripts/secrets/update.py
+++ b/scripts/secrets/update.py
@@ -104,11 +104,7 @@ def get_yaml_reader():
 def sealed_secret_cert_path(staging: bool) -> str:
     env = "staging" if staging else "production"
     default_cert = (
-        Path(__file__).parent.parent.parent
-        / "k8s"
-        / env
-        / "sealed-secrets"
-        / "cert.pem"
+        Path(__file__).parents[2] / "k8s" / env / "sealed-secrets" / "cert.pem"
     )
 
     cert_path = os.getenv("SEALED_SECRETS_CERT", default_cert)

--- a/scripts/secrets/update.py
+++ b/scripts/secrets/update.py
@@ -102,7 +102,11 @@ def get_yaml_reader():
 def sealed_secret_cert_path(staging: bool) -> str:
     env = "staging" if staging else "production"
     default_cert = (
-        Path(__file__).parent.parent / "k8s" / env / "sealed-secrets" / "cert.pem"
+        Path(__file__).parent.parent.parent
+        / "k8s"
+        / env
+        / "sealed-secrets"
+        / "cert.pem"
     )
 
     cert_path = os.getenv("SEALED_SECRETS_CERT", default_cert)

--- a/scripts/secrets/update.py
+++ b/scripts/secrets/update.py
@@ -24,7 +24,7 @@ def select_value(stdscr, values: list[str], titles: list[str] = []):
     curses.init_pair(4, curses.COLOR_WHITE, curses.COLOR_BLACK)
 
     # Clear and refresh the screen for a blank canvas
-    stdscr.clear()
+    stdscr.erase()
     stdscr.refresh()
     curses.noecho()
 
@@ -41,7 +41,7 @@ def select_value(stdscr, values: list[str], titles: list[str] = []):
     k = None
     while True:
         # Initialization
-        win.clear()
+        win.erase()
 
         # Check value
         if k == curses.KEY_DOWN:


### PR DESCRIPTION
The secret update script will now open the user's configured editor (via the `$EDITOR` env var, defaults to `vim`) for inputting the secret value. This will solve the multi-line issue.

If anyone is on MacOS, please let me know how this works for you. I expect it to function the same, but I have no good way of testing it myself.