### PR TITLE
Encode fluent-bit role into Terraform

### DIFF
--- a/k8s/production/fluent-bit/release.yaml
+++ b/k8s/production/fluent-bit/release.yaml
@@ -33,10 +33,9 @@ spec:
 
   values:
     serviceAccount:
-      create: true
+      # This service account is created by Terraform
+      create: false
       name: fluent-bit
-      annotations:
-        eks.amazonaws.com/role-arn: arn:aws:iam::588562868276:role/FluentBitRole-production
 
     resources:
       requests:

--- a/terraform/modules/spack/opensearch.tf
+++ b/terraform/modules/spack/opensearch.tf
@@ -212,3 +212,17 @@ resource "aws_iam_role_policy" "fluent_bit_policy" {
     ]
   })
 }
+
+resource "kubectl_manifest" "fluent_bit_service_account" {
+  count = var.provision_opensearch_cluster ? 1 : 0
+
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: fluent-bit
+      namespace: fluent-bit
+      annotations:
+        eks.amazonaws.com/role-arn: ${aws_iam_role.fluent_bit_role[0].arn}
+  YAML
+}


### PR DESCRIPTION
The fluent-bit ServiceAccount is now outdated for the same reason as the notary ServiceAccount. Like #485, this PR encodes the IAM role into Terraform to avoid this from happening in the future.