### PR TITLE
Add sealed-secrets.yaml to runner staging kustomization

### DIFF
--- a/k8s/staging/runners/kustomization.yaml
+++ b/k8s/staging/runners/kustomization.yaml
@@ -6,6 +6,10 @@ resources:
 - ../../production/runners/namespace.yaml
 - ../../production/runners/public/graviton/2/release.yaml
 - ../../production/runners/public/x86_64/v2/release.yaml
+
+patchesStrategicMerge:
+  - rm-secrets.yaml
+
 patches:
   - target:
       kind: SealedSecret

--- a/k8s/staging/runners/kustomization.yaml
+++ b/k8s/staging/runners/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- ../../production/runners/sealed-secrets.yaml
 - ../../production/runners/service-accounts.yaml
 - ../../production/runners/namespace.yaml
 - ../../production/runners/public/graviton/2/release.yaml

--- a/k8s/staging/runners/rm-secrets.yaml
+++ b/k8s/staging/runners/rm-secrets.yaml
@@ -1,0 +1,8 @@
+# This patch removes the SealedSecret with signing key info,
+# as we don't need it for staging.
+$patch: delete
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: spack-intermediate-ci-signing-key
+  namespace: pipeline


### PR DESCRIPTION
#507 doesn't actually work, because I didn't add the `sealed-secrets.yaml` to the `resources` block in the staging kustomization. After doing that, I realized we also need to somehow exclude the other secrets in that YAML file from being included in staging. Documentation on how to remove an entire resources using kustomize seems very minimal, but I found this page that mentions how to do it and followed it https://pet2cattle.com/2022/11/kustomize-delete-resource. Unfortunately, the only way to find out if it works is to merge and see if Flux handles it ok.