### PR TITLE
Don't make releases for snapshot tags

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -47,7 +47,7 @@ jobs:
           - docker-image: upload-gitlab-failure-logs
             image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.1
           - docker-image: snapshot-release-tags
-            image-tags: ghcr.io/spack/snapshot-release-tags:0.0.1
+            image-tags: ghcr.io/spack/snapshot-release-tags:0.0.2
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/images/snapshot-release-tags/snapshot_release_tags.py
+++ b/images/snapshot-release-tags/snapshot_release_tags.py
@@ -39,12 +39,16 @@ if __name__ == "__main__":
     py_gh_repo = py_github.get_repo("spack/spack", lazy=True)
     spackbot_author = InputGitAuthor("spackbot", "noreply@spack.io")
     print(f"Pushing tag {tag_name} for commit {sha}")
-    py_gh_repo.create_git_tag_and_release(
+
+    tag = py_gh_repo.create_git_tag(
         tag=tag_name,
-        tag_message=tag_msg,
-        release_name=tag_name,
-        release_message=tag_msg,
+        message=tag_msg,
         object=sha,
         type="commit",
         tagger=spackbot_author)
+
+    py_gh_repo.create_git_ref(
+        ref=f"refs/tags/{tag_name}",
+        sha=tag.sha)
+
     print("Push done!")

--- a/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
+++ b/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: snapshot-release-tags
-            image: ghcr.io/spack/snapshot-release-tags:0.0.1
+            image: ghcr.io/spack/snapshot-release-tags:0.0.2
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
These should be annotated tags, but not releases on GitHub