### PR TITLE
Rotate the credentials of another user

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -19,7 +19,7 @@ jobs:
           - docker-image: gitlab-api-scrape
             image-tags: ghcr.io/spack/gitlab-api-scrape:0.0.2
           - docker-image: ci-key-rotate
-            image-tags: ghcr.io/spack/ci-key-rotate:0.0.2
+            image-tags: ghcr.io/spack/ci-key-rotate:0.0.3
           - docker-image: ci-key-clear
             image-tags: ghcr.io/spack/ci-key-clear:0.0.1
           - docker-image: gitlab-webservice

--- a/images/ci-key-rotate/rotate_gitlab_aws_access_keys.py
+++ b/images/ci-key-rotate/rotate_gitlab_aws_access_keys.py
@@ -66,4 +66,5 @@ if __name__ == '__main__':
 
     rotate_iam_keys('pull-requests-binary-mirror', gitlab_variable_prefix='PR_')
     rotate_iam_keys('protected-binary-mirror', gitlab_variable_prefix='PROTECTED_')
+    rotate_iam_keys('cray-binary-mirror', gitlab_variable_prefix='CRAY_')
     rotate_iam_keys('develop-binary-mirror')

--- a/k8s/production/custom/rotate-keys/cron-jobs.yaml
+++ b/k8s/production/custom/rotate-keys/cron-jobs.yaml
@@ -13,7 +13,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: rotate-gitlab-aws-access-keys
-            image: ghcr.io/spack/ci-key-rotate:0.0.2
+            image: ghcr.io/spack/ci-key-rotate:0.0.3
             imagePullPolicy: IfNotPresent
             env:
             - name: GITLAB_TOKEN


### PR DESCRIPTION
The user `cray-binary-mirror` is associated with a permissions policy granting access to a new cray-only bucket.  This PR makes sure the users credentials get rotated along with all the others.