### PR TITLE
Add missing json file to opensearch ingest image

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -41,7 +41,7 @@ jobs:
           - docker-image: python-aws-bash
             image-tags: ghcr.io/spack/python-aws-bash:0.0.1
           - docker-image: opensearch-index-build-logs
-            image-tags: ghcr.io/spack/opensearch-index-build-logs:0.0.2
+            image-tags: ghcr.io/spack/opensearch-index-build-logs:0.0.3
           - docker-image: gitlab-error-processor
             image-tags: ghcr.io/spack/gitlab-error-processor:0.0.1
           - docker-image: upload-gitlab-failure-logs

--- a/images/opensearch-index-build-logs/pipeline_logs_mapping.json5
+++ b/images/opensearch-index-build-logs/pipeline_logs_mapping.json5
@@ -1,0 +1,205 @@
+{
+  mappings: {
+    // Disable date_detection. OpenSearch thinks the `version` field in spec.json is a date
+    // for some reason.
+    date_detection: false,
+    properties: {
+      hash: {
+        type: "text",
+        fields: {
+          keyword: {
+            type: "keyword",
+            ignore_above: 256,
+          },
+        },
+      },
+      install_times: {
+        properties: {
+          phases: {
+            properties: {
+              name: {
+                type: "text",
+                fields: {
+                  keyword: {
+                    type: "keyword",
+                    ignore_above: 256,
+                  },
+                },
+              },
+              seconds: {
+                type: "float",
+              },
+            },
+          },
+          total: {
+            properties: {
+              seconds: {
+                type: "float",
+              },
+            },
+          },
+        },
+      },
+      "spack-build-out": {
+        type: "object",
+        // Don't index this field. The data is unstructured and not really
+        // worth indexing unless there's a need to do so.
+        enabled: false,
+      },
+      spec: {
+        properties: {
+          _meta: {
+            properties: {
+              version: {
+                type: "long",
+              },
+            },
+          },
+          nodes: {
+            properties: {
+              arch: {
+                properties: {
+                  platform: {
+                    type: "text",
+                    fields: {
+                      keyword: {
+                        type: "keyword",
+                        ignore_above: 256,
+                      },
+                    },
+                  },
+                  platform_os: {
+                    type: "text",
+                    fields: {
+                      keyword: {
+                        type: "keyword",
+                        ignore_above: 256,
+                      },
+                    },
+                  },
+                  target: {
+                    type: "object",
+                    // This particular field can be a string or object. OpenSearch can't index a
+                    // field that behaves that way, so disable indexing on it.
+                    enabled: false,
+                  },
+                },
+              },
+              compiler: {
+                properties: {
+                  name: {
+                    type: "text",
+                    fields: {
+                      keyword: {
+                        type: "keyword",
+                        ignore_above: 256,
+                      },
+                    },
+                  },
+                  version: {
+                    type: "text",
+                    fields: {
+                      keyword: {
+                        type: "keyword",
+                        ignore_above: 256,
+                      },
+                    },
+                  },
+                },
+              },
+              dependencies: {
+                properties: {
+                  hash: {
+                    type: "text",
+                    fields: {
+                      keyword: {
+                        type: "keyword",
+                        ignore_above: 256,
+                      },
+                    },
+                  },
+                  name: {
+                    type: "text",
+                    fields: {
+                      keyword: {
+                        type: "keyword",
+                        ignore_above: 256,
+                      },
+                    },
+                  },
+                  type: {
+                    type: "text",
+                    fields: {
+                      keyword: {
+                        type: "keyword",
+                        ignore_above: 256,
+                      },
+                    },
+                  },
+                },
+              },
+              hash: {
+                type: "text",
+                fields: {
+                  keyword: {
+                    type: "keyword",
+                    ignore_above: 256,
+                  },
+                },
+              },
+              name: {
+                type: "text",
+                fields: {
+                  keyword: {
+                    type: "keyword",
+                    ignore_above: 256,
+                  },
+                },
+              },
+              namespace: {
+                type: "text",
+                fields: {
+                  keyword: {
+                    type: "keyword",
+                    ignore_above: 256,
+                  },
+                },
+              },
+              package_hash: {
+                type: "text",
+                fields: {
+                  keyword: {
+                    type: "keyword",
+                    ignore_above: 256,
+                  },
+                },
+              },
+              parameters: {
+                type: "object",
+                enabled: false,
+              },
+              patches: {
+                type: "text",
+                fields: {
+                  keyword: {
+                    type: "keyword",
+                    ignore_above: 256,
+                  },
+                },
+              },
+              version: {
+                type: "text",
+                fields: {
+                  keyword: {
+                    type: "keyword",
+                    ignore_above: 256,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/k8s/production/custom/opensearch-index-build-logs/cron-jobs.yaml
+++ b/k8s/production/custom/opensearch-index-build-logs/cron-jobs.yaml
@@ -12,7 +12,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: opensearch-index-build-logs
-            image: ghcr.io/spack/opensearch-index-build-logs:0.0.2
+            image: ghcr.io/spack/opensearch-index-build-logs:0.0.3
             imagePullPolicy: Always
             env:
             - name: OPENSEARCH_ENDPOINT


### PR DESCRIPTION
The cronjob that crawls the build cache and records timing info, etc. into opensearch is currently failing. I thought #523 would fix it, but even after applying those changes it still fails. The error logs indicated that this .json5 is missing; my guess is that the old cluster was using the image from my fork (https://github.com/mvandenburgh/docker-images/pkgs/container/opensearch-index-build-logs) which does have that file, and when we switched to the new cluster, Flux reset it to the old image and it started failing.