### PR TITLE
Suspend the stuck pipelines cronjob

### DIFF
--- a/k8s/production/custom/unstick-pipelines/cron-jobs.yaml
+++ b/k8s/production/custom/unstick-pipelines/cron-jobs.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cancel-and-restart-stuck-pipelines
   namespace: custom
 spec:
+  suspend: true
   schedule: "0 */3 * * *"
   jobTemplate:
     spec:


### PR DESCRIPTION
This mitigation is currently not having the intended effect, as we have seen months-old pipelines still stuck in the "running" state, even with this cronjob running every three hours since forever.  We are also seeing multiple repeated develop pipelines (and pipelines for some PRs) running on the same sha.  Since this mitigation seems to be doing more harm than good, let's pause it until we can figure out what's wrong with it (or what's wrong with gitlab).