### PR TITLE
Proposed overhaul of building/deployment of custom pcluster AMIs

### DIFF
--- a/.github/workflows/build_pcluster_amis.yml
+++ b/.github/workflows/build_pcluster_amis.yml
@@ -1,0 +1,97 @@
+name: Build pcluster AMIs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Cancel any workflows that are already running
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    name: Build AMI [${{ matrix.architecture }}, ${{ matrix.aws-region }}]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: x86_64
+            source-ami-id: ami-011244318c573c915
+            aws-region: us-east-1
+          - architecture: arm64
+            source-ami-id: ami-0d87b43677ef96ab9
+            aws-region: us-east-1
+          - architecture: x86_64
+            source-ami-id: ami-08f1611028f2254b3
+            aws-region: us-west-2
+          - architecture: arm64
+            source-ami-id: ami-0597a0565f343efb8
+            aws-region: us-west-2
+    steps:
+      - name: Checkout `spack-infrastructure` repo
+        uses: actions/checkout@v3
+
+      - name: Checkout `awslabs/amazon-eks-ami` repo
+        uses: actions/checkout@v3
+        with:
+          repository: awslabs/amazon-eks-ami
+          path: amazon-eks-ami
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2.0.0
+        with:
+          role-to-assume: arn:aws:iam::588562868276:role/GitHubActionsRole
+          aws-region: ${{ matrix.aws-region }}
+
+      - name: Setup packer
+        uses: hashicorp/setup-packer@v2.0.0
+        with:
+          version: latest
+
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          # Disable the github actions "wrapper" for Terraform
+          # because it transforms the output such that it can't
+          # be read by `jq`.
+          terraform_wrapper: false
+
+      - name: Initialize terraform
+        working-directory: terraform/production
+        run: terraform init -input=false
+
+      - name: Get k8s version from terraform state
+        working-directory: terraform/production
+        run: |
+          K8S_VERSION=$(terraform show -json | jq '.values.root_module.child_modules[] | select(.address == "module.production_cluster") | .child_modules[] | select(.address == "module.production_cluster.module.eks") | .resources[] | select(.address == "module.production_cluster.module.eks.aws_eks_cluster.this[0]") | .values.version')
+          K8S_VERSION=$(echo $K8S_VERSION | tr -d '"') # Remove inlined quotes
+          echo "K8S_VERSION=$K8S_VERSION" >> $GITHUB_ENV
+
+      - name: Build AMI with packer if it doesn't exist
+        working-directory: amazon-eks-ami
+        run: |
+          IMAGE_NAME="pcluster_${{ matrix.architecture }}_${{ env.K8S_VERSION }}"
+          FOUND_AMIS=$(aws ec2 describe-images --filters "Name=name,Values=$IMAGE_NAME" | jq '.Images | length')
+
+          # Only build the AMI if it doesn't exist
+          if [ $FOUND_AMIS -eq 0 ]; then
+            make ${{ env.K8S_VERSION }} \
+              arch="${{ matrix.architecture }}" \
+              name="$IMAGE_NAME" \
+              ami_name="$IMAGE_NAME" \
+              aws_region="${{ matrix.aws-region }}" \
+              source_ami_filter_name="aws-parallelcluster-*" \
+              source_ami_id="${{ matrix.source-ami-id }}" \
+              source_ami_owners="247102896272" \
+              launch_block_device_mappings_volume_size=35
+          else
+            echo 'AMI "$IMAGE_NAME" already exists.'
+          fi

--- a/terraform/modules/spack/eks.tf
+++ b/terraform/modules/spack/eks.tf
@@ -8,7 +8,7 @@ module "eks" {
   version = "19.5.1"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.27"
+  cluster_version = var.kubernetes_version
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets

--- a/terraform/modules/spack/variables.tf
+++ b/terraform/modules/spack/variables.tf
@@ -23,6 +23,11 @@ variable "availability_zones" {
   type        = list(string)
 }
 
+variable "kubernetes_version" {
+  description = "The version of kubernetes to run on the EKS cluster."
+  type        = string
+}
+
 variable "flux_repo_name" {
   description = "Name of GitHub repo to configure Flux with."
   type        = string
@@ -66,5 +71,5 @@ variable "provision_opensearch_cluster" {
 
 variable "ses_email_domain" {
   description = "Domain to use for SES email."
-  type        = string
+  type = string
 }

--- a/terraform/production/github_actions_iam.tf
+++ b/terraform/production/github_actions_iam.tf
@@ -1,0 +1,104 @@
+data "tls_certificate" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.github_actions.certificates.0.sha1_fingerprint]
+}
+
+resource "aws_iam_role" "github_actions" {
+  name        = "GitHubActionsRole"
+  description = "Managed by Terraform. IAM Role that a GitHub Actions runner can assume to authenticate with AWS."
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : aws_iam_openid_connect_provider.github_actions.arn
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringLike" : {
+            "token.actions.githubusercontent.com:sub" : "repo:spack/spack-infrastructure:ref:refs/heads/main",
+            "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  # Inline policy that allows GitHub actions to create AMIs using packer.
+  # Docs: https://developer.hashicorp.com/packer/plugins/builders/amazon#iam-task-or-instance-role
+  inline_policy {
+    name = "PackerAMICreationPolicy"
+    policy = jsonencode({
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Resource" : "*",
+          "Action" : [
+            "ec2:AttachVolume",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:CopyImage",
+            "ec2:CreateImage",
+            "ec2:CreateKeypair",
+            "ec2:CreateSecurityGroup",
+            "ec2:CreateSnapshot",
+            "ec2:CreateTags",
+            "ec2:CreateVolume",
+            "ec2:DeleteKeyPair",
+            "ec2:DeleteSecurityGroup",
+            "ec2:DeleteSnapshot",
+            "ec2:DeleteVolume",
+            "ec2:DeregisterImage",
+            "ec2:DescribeImageAttribute",
+            "ec2:DescribeImages",
+            "ec2:DescribeInstances",
+            "ec2:DescribeInstanceStatus",
+            "ec2:DescribeRegions",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSnapshots",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeTags",
+            "ec2:DescribeVolumes",
+            "ec2:DetachVolume",
+            "ec2:GetPasswordData",
+            "ec2:ModifyImageAttribute",
+            "ec2:ModifyInstanceAttribute",
+            "ec2:ModifySnapshotAttribute",
+            "ec2:RegisterImage",
+            "ec2:RunInstances",
+            "ec2:StopInstances",
+            "ec2:TerminateInstances"
+          ]
+        },
+        {
+          "Effect" : "Allow",
+          "Action" : [
+            "s3:GetObject"
+          ],
+          "Resource" : "arn:aws:s3:::amazon-eks/*"
+        }
+      ]
+    })
+  }
+
+  # Inline policy that allows GitHub actions to read the Terraform state file
+  inline_policy {
+    name = "TerraformStateBucketAccessPolicy"
+    policy = jsonencode({
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Resource" : "arn:aws:s3:::spack-terraform-state/terraform.tfstate",
+          "Action" : ["s3:GetObject"]
+      }]
+    })
+  }
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -98,6 +98,8 @@ module "production_cluster" {
 
   deployment_name = "prod"
 
+  kubernetes_version = "1.27"
+
   availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d"]
 
   vpc_cidr = "192.168.0.0/16"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -99,6 +99,8 @@ module "staging_cluster" {
 
   deployment_name = "staging"
 
+  kubernetes_version = "1.27"
+
   availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
 
   vpc_cidr = "192.168.0.0/16"


### PR DESCRIPTION
## Background
Currently, we have a need to run a specific AMI on some of our gitlab runner nodes. This pcluster AMI was provided by Amazon and is not "[EKS-optimized](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-amis.html)". That is, it is not configured with the software needed for it to join an EKS cluster as a node. AWS provides a [Packer template](https://github.com/awslabs/amazon-eks-ami) that takes in a source AMI and builds a custom "EKS-optimized" version of that AMI. I did that using the pcluster AMI as the source AMI, and after pointing the pcluster Karpenter provisioner at the resulting "EKS-optimized" AMI, the nodes are able to join the cluster as expected. 

There is one caveat to this solution - the Packer template is coupled to the version of kubernetes running on the cluster; for the pcluster AMIs that I built manually, I had to specify `1.24` as the k8s version as part of the Packer build process.
This introduces some technical debt in that we will have to remember to rebuilt these AMIs when we move to a new version of kubernetes.

## Solution
This PR attempts to alleviate this by doing the following:

- The custom "EKS-optimized" pcluster AMIs are now built in CI. The kubernetes version is extracted from the Terraform state at build time so that we can ensure AMIs are always available for the current version of the cluster.
- The karpenter node template now refers to the AMIs by name instead of ID ([docs](https://karpenter.sh/preview/concepts/node-templates/#specamiselector)), and the name contains the k8s version string. This ensures that the karpenter node template is always referring to the corresponding pcluster AMI for the current kubernetes version, even if the AMI gets rebuilt.