### PR TITLE
runners: increase log limit from 4MB to 10MB

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -43,7 +43,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 4096
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -45,7 +45,7 @@ spec:
     runners:
       config: |
         [[runners]]
-          output_limit = 8192
+          output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false


### PR DESCRIPTION
We seem to be using around 25% of our minio storage at the moment (that's where job traces are stored), and currently delete any job traces older than 30 days.  So it seems safe to increase the log output limit, and would reduce the number of jobs that exceed the limit, allowing to see the important parts of more job traces.