### PR TITLE
Specify base node pool for event-exporter

### DIFF
--- a/k8s/production/monitoring/kubernetes-event-exporter/deployments.yaml
+++ b/k8s/production/monitoring/kubernetes-event-exporter/deployments.yaml
@@ -25,6 +25,8 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: cfg
+      nodeSelector:
+        spack.io/node-pool: base
       volumes:
         - name: cfg
           secret:


### PR DESCRIPTION
This will ensure the event-exporter doesn't get scheduled on ARM nodes or windows-based nodes.