### PR TITLE
Add protections to our custom cron-job.yaml files

### DIFF
--- a/k8s/production/custom/gitlab-api-scrape/cron-jobs.yaml
+++ b/k8s/production/custom/gitlab-api-scrape/cron-jobs.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: custom
 spec:
   schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  activeDeadlineSeconds: 3600 # terminate any running job after 60 minutes
   jobTemplate:
     spec:
       template:

--- a/k8s/production/custom/opensearch-index-build-logs/cron-jobs.yaml
+++ b/k8s/production/custom/opensearch-index-build-logs/cron-jobs.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: custom
 spec:
   schedule: "0 0 1-31/2 * *"  # Run every other day
+  concurrencyPolicy: Forbid
+  activeDeadlineSeconds: 86400 # terminate any running job after 1 day
   jobTemplate:
     spec:
       template:

--- a/k8s/production/custom/rotate-keys/cron-jobs.yaml
+++ b/k8s/production/custom/rotate-keys/cron-jobs.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: custom
 spec:
   schedule: "0 */12 * * *"
+  concurrencyPolicy: Forbid
+  activeDeadlineSeconds: 3600 # terminate any running job after 60 minutes
   jobTemplate:
     spec:
       template:

--- a/k8s/production/custom/skipped-pipelines/cron-jobs.yaml
+++ b/k8s/production/custom/skipped-pipelines/cron-jobs.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: custom
 spec:
   schedule: "*/30 * * * *"
+  concurrencyPolicy: Forbid
+  activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
   jobTemplate:
     spec:
       template:

--- a/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
+++ b/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   schedule: "0 1 * * 0" # 1am on Sunday
   concurrencyPolicy: Forbid
+  activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
   jobTemplate:
     spec:
       backoffLimit: 0

--- a/k8s/production/custom/unstick-pipelines/cron-jobs.yaml
+++ b/k8s/production/custom/unstick-pipelines/cron-jobs.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   suspend: true
   schedule: "0 */3 * * *"
+  concurrencyPolicy: Forbid
+  activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
Make sure concurrencyPolicy and activeDeadlineSeconds are set for all our custom cron-jobs. This prevents our cron jobs from running longer than expected, and it prevents more than one copy of each job running at the same time.