### PR TITLE
gh-gl-sync: timeout connections to GitLab API after 10 seconds

### DIFF
--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -439,7 +439,7 @@ class SpackCIBridge(object):
             request = urllib.request.Request(api_url)
             if "GITLAB_TOKEN" in os.environ:
                 request.add_header("Authorization", "Bearer %s" % os.environ["GITLAB_TOKEN"])
-            response = urllib.request.urlopen(request)
+            response = urllib.request.urlopen(request, timeout=10)
         except OSError:
             print('Failed to fetch commit for tested sha {0}'.format(tested_sha))
             return None
@@ -479,7 +479,7 @@ class SpackCIBridge(object):
             request = urllib.request.Request(api_url)
             if "GITLAB_TOKEN" in os.environ:
                 request.add_header("Authorization", "Bearer %s" % os.environ["GITLAB_TOKEN"])
-            response = urllib.request.urlopen(request)
+            response = urllib.request.urlopen(request, timeout=10)
         except OSError as inst:
             print("GitLab API request error accessing {0}".format(api_url))
             print(inst)


### PR DESCRIPTION
Hopefully this will resolve the issue we've noticed where the sync script hangs waiting for a response from the GitLab API.