### PR TITLE
Put activeDeadlineSeconds in the right spot

### DIFF
--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
-  activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
       backoffLimit: 0
       template:
         spec:

--- a/k8s/production/custom/gitlab-api-scrape/cron-jobs.yaml
+++ b/k8s/production/custom/gitlab-api-scrape/cron-jobs.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   schedule: "0 2 * * *"
   concurrencyPolicy: Forbid
-  activeDeadlineSeconds: 3600 # terminate any running job after 60 minutes
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 3600 # terminate any running job after 60 minutes
       template:
         spec:
           serviceAccountName: gitlab-api-scrape

--- a/k8s/production/custom/opensearch-index-build-logs/cron-jobs.yaml
+++ b/k8s/production/custom/opensearch-index-build-logs/cron-jobs.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   schedule: "0 0 1-31/2 * *"  # Run every other day
   concurrencyPolicy: Forbid
-  activeDeadlineSeconds: 86400 # terminate any running job after 1 day
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 86400 # terminate any running job after 1 day
       template:
         spec:
           restartPolicy: Never

--- a/k8s/production/custom/rotate-keys/cron-jobs.yaml
+++ b/k8s/production/custom/rotate-keys/cron-jobs.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   schedule: "0 */12 * * *"
   concurrencyPolicy: Forbid
-  activeDeadlineSeconds: 3600 # terminate any running job after 60 minutes
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 3600 # terminate any running job after 60 minutes
       template:
         spec:
           serviceAccountName: rotate-keys

--- a/k8s/production/custom/skipped-pipelines/cron-jobs.yaml
+++ b/k8s/production/custom/skipped-pipelines/cron-jobs.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   schedule: "*/30 * * * *"
   concurrencyPolicy: Forbid
-  activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
       template:
         spec:
           restartPolicy: Never

--- a/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
+++ b/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   schedule: "0 1 * * 0" # 1am on Sunday
   concurrencyPolicy: Forbid
-  activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
       backoffLimit: 0
       template:
         spec:

--- a/k8s/production/custom/unstick-pipelines/cron-jobs.yaml
+++ b/k8s/production/custom/unstick-pipelines/cron-jobs.yaml
@@ -7,9 +7,9 @@ spec:
   suspend: true
   schedule: "0 */3 * * *"
   concurrencyPolicy: Forbid
-  activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
       template:
         spec:
           restartPolicy: Never


### PR DESCRIPTION
This belongs in the JobSpec, not the CronJobSpec

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#jobspec-v1-batch https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#cronjobspec-v1-batch