### PR TITLE
Upgrade GitLab

### DIFF
--- a/k8s/production/custom/gitlab-setting-updater/cronjobs.yaml
+++ b/k8s/production/custom/gitlab-setting-updater/cronjobs.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: gitlab-setting-updater
+  namespace: gitlab
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    metadata:
+      labels:
+        app: gitlab-setting-updater
+    spec:
+      template:
+        metadata:
+          name: gitlab-setting-updater
+          namespace: gitlab
+          labels:
+            app: gitlab-setting-updater
+        spec:
+          serviceAccountName: gitlab-setting-updater
+          restartPolicy: OnFailure
+          containers:
+            - name: updater
+              image: bitnami/kubectl
+              imagePullPolicy: IfNotPresent
+              command: ["kubectl"]
+              args:
+                [
+                  "exec",
+                  "-i",
+                  "deploy/gitlab-toolbox",
+                  "-c",
+                  "toolbox",
+                  "--",
+                  "/srv/gitlab/bin/rails",
+                  "runner",
+                  "ApplicationSetting.update(max_yaml_size_bytes: 10.megabytes)",
+                ]
+          nodeSelector:
+            spack.io/node-pool: base

--- a/k8s/production/custom/gitlab-setting-updater/serviceaccounts.yaml
+++ b/k8s/production/custom/gitlab-setting-updater/serviceaccounts.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gitlab-setting-updater
+  namespace: gitlab
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitlab-setting-updater
+  namespace: gitlab
+rules:
+  - apiGroups: ["", "extensions", "apps"]
+    resources: ["deployments", "replicasets", "pods", "pods/exec"]
+    verbs: ["get", "watch", "list", "update", "create", "patch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitlab-setting-updater
+  namespace: gitlab
+subjects:
+  - kind: ServiceAccount
+    name: gitlab-setting-updater
+roleRef:
+  kind: Role
+  name: gitlab-setting-updater
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -86,7 +86,7 @@ spec:
           key: postgres-password
         port: 5432
         database: gitlabhq_production
-        username: postgres
+        username: gitlab
 
       redis:
         password:

--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab
-      version: 5.6.3 # gitlab@14.6.3
+      version: 7.0.4 # gitlab@16.0.4
       sourceRef:
         kind: HelmRepository
         name: gitlab
@@ -96,6 +96,9 @@ spec:
         enabled: true
 
       grafana:
+        enabled: false
+
+      kas:
         enabled: false
 
       appConfig:

--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -147,10 +147,6 @@ spec:
           tls:
             enabled: true
             secretName: tls-gitlab-webservice
-        image:
-          pullPolicy: IfNotPresent
-          repository: ghcr.io/spack/gitlab-webservice
-          tag: v14.6.3
         minReplicas: 4
         maxReplicas: 16
         resources:
@@ -173,18 +169,10 @@ spec:
           spack.io/node-pool: gitlab
 
       sidekiq:
-        image:
-          pullPolicy: IfNotPresent
-          repository: ghcr.io/spack/gitlab-sidekiq
-          tag: v14.6.3
         nodeSelector:
           spack.io/node-pool: gitlab
 
       toolbox:
-        image:
-          pullPolicy: IfNotPresent
-          repository: ghcr.io/spack/gitlab-toolbox
-          tag: v14.6.3
         nodeSelector:
           spack.io/node-pool: gitlab
 

--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-graviton2-prot
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 3
 

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-prot
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 3
 

--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-pcluster-prot
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 3
 

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-prot
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v3-prot
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v4-prot
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-graviton2-pub
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-pub
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-pcluster-pub
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 2
 

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-pub
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v3-pub
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v4-pub
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -19,12 +19,14 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.37.2 # gitlab-runner@14.7.0
+      version: 0.53.2 # gitlab-runner@16.0.2
       sourceRef:
         kind: HelmRepository
         name: runner-spack-package-signing
   values:
-    image: gitlab/gitlab-runner:alpine-v14.7.0
+    image:
+      image: gitlab-org/gitlab-runner
+      tag: alpine-v16.0.2
     imagePullPolicy: IfNotPresent
     replicas: 1
 


### PR DESCRIPTION
Note - this should not be merged yet. There are several intermediate upgrades that need to be performed with Flux turned off; this PR encodes what the final state of the cluster should be after the upgrade is complete.