### PR TITLE
Delete pipeline-logs index if no records were added to it

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -41,7 +41,7 @@ jobs:
           - docker-image: python-aws-bash
             image-tags: ghcr.io/spack/python-aws-bash:0.0.1
           - docker-image: opensearch-index-build-logs
-            image-tags: ghcr.io/spack/opensearch-index-build-logs:0.0.3
+            image-tags: ghcr.io/spack/opensearch-index-build-logs:0.0.4
           - docker-image: gitlab-error-processor
             image-tags: ghcr.io/spack/gitlab-error-processor:0.0.1
           - docker-image: upload-gitlab-failure-logs

--- a/k8s/production/custom/opensearch-index-build-logs/cron-jobs.yaml
+++ b/k8s/production/custom/opensearch-index-build-logs/cron-jobs.yaml
@@ -12,7 +12,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: opensearch-index-build-logs
-            image: ghcr.io/spack/opensearch-index-build-logs:0.0.3
+            image: ghcr.io/spack/opensearch-index-build-logs:0.0.4
             imagePullPolicy: Always
             env:
             - name: OPENSEARCH_ENDPOINT


### PR DESCRIPTION
Currently, we first create a new pipeline-logs index before iterating through the build cache and adding any new builds to it. However if there are no new builds, the index sits there with zero documents. This adds logic to delete the index if this happens.