### PR TITLE
Move oauth2-proxy ingress to monitoring namespace

### DIFF
--- a/k8s/production/prometheus/ingress.yaml
+++ b/k8s/production/prometheus/ingress.yaml
@@ -32,7 +32,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: oauth2-proxy
-  namespace: ingress-nginx
+  namespace: monitoring
 spec:
   ingressClassName: nginx
   rules:

--- a/k8s/staging/prometheus/kustomization.yaml
+++ b/k8s/staging/prometheus/kustomization.yaml
@@ -38,7 +38,7 @@ patches:
   - target:
       kind: Ingress
       name: oauth2-proxy
-      namespace: ingress-nginx
+      namespace: monitoring
     patch: |-
       - op: replace
         path: /spec/rules/0/host


### PR DESCRIPTION
This is follow on work from #548.