### PR TITLE
Add gitlab as a prometheus scraping target

### DIFF
--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -115,6 +115,12 @@ spec:
           requests:
             cpu: 2000m
             memory: 50G
+        additionalScrapeConfigs:
+          - job_name: "gitlab-metrics"
+            metrics_path: "/-/metrics"
+            scheme: "https"
+            static_configs:
+              - targets: ["gitlab.spack.io"]
         nodeSelector:
           spack.io/node-pool: beefy
 

--- a/k8s/staging/prometheus/kustomization.yaml
+++ b/k8s/staging/prometheus/kustomization.yaml
@@ -109,6 +109,9 @@ patches:
       - op: replace
         path: /spec/values/prometheus/prometheusSpec/externalUrl
         value: prometheus.staging.spack.io
+      - op: replace
+        path: /spec/values/prometheus/prometheusSpec/additionalScrapeConfigs/0/static_configs/0/targets/0
+        value: gitlab.staging.spack.io
 
   - target:
       kind: Deployment


### PR DESCRIPTION
@mvandenburgh This should let prometheus pick up on exported prometheus metrics.