### PR TITLE
Drop cray bucket, policies cannot be applied

### DIFF
--- a/terraform/production/s3.tf
+++ b/terraform/production/s3.tf
@@ -15,11 +15,6 @@ locals {
       ]
       allowed = "arn:aws:iam::588562868276:user/pull-requests-binary-mirror"
     }
-
-    "spack-binaries-cray" = {
-      resources = ["*"]
-      allowed = "arn:aws:iam::588562868276:user/cray-binary-mirror"
-    }
   }
 }
 


### PR DESCRIPTION
Dropping this since it is not allowed by the current bucket policy.