### PR TITLE
Fix oauth2-proxy github configuration

### DIFF
--- a/k8s/production/prometheus/oauth2-proxy.yaml
+++ b/k8s/production/prometheus/oauth2-proxy.yaml
@@ -20,8 +20,7 @@ spec:
       containers:
       - args:
         # Note: all of these args are duplicated in the kustomization config.
-        - --github-org=spack
-        - --github-user=danlamanna
+        - --github-user=danlamanna,mvandenburgh,zackgalbreath,almightyyakob,scottwittenburg,kwryankrattiger
         - --provider=github
         - --email-domain=*
         - --upstream=file:///dev/null

--- a/k8s/staging/prometheus/kustomization.yaml
+++ b/k8s/staging/prometheus/kustomization.yaml
@@ -121,8 +121,7 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/args
         value:
-          - --github-org=spack
-          - --github-user=danlamanna
+          - --github-user=danlamanna,mvandenburgh,zackgalbreath,almightyyakob,scottwittenburg,kwryankrattiger
           - --provider=github
           - --email-domain=*
           - --upstream=file:///dev/null


### PR DESCRIPTION
We're currently pinned to v7.2.1 of oauth2-proxy due to https://github.com/oauth2-proxy/oauth2-proxy/issues/1724, and it appears the `github-org/repo` flag isn't working in that release due to https://github.com/oauth2-proxy/oauth2-proxy/pull/1650. For now I'm hardcoding usernames to who might reasonably want access and keeping an eye on oauth2-proxy updates.