### PR TITLE
Specify node selector for gitlab redis pods

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -199,3 +199,5 @@ spec:
       master:
         nodeSelector:
           spack.io/node-pool: gitlab
+      metrics:
+        enabled: true

--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -194,3 +194,8 @@ spec:
 
     postgresql:
       install: false
+
+    redis:
+      master:
+        nodeSelector:
+          spack.io/node-pool: gitlab


### PR DESCRIPTION
This will fix the issue where Redis pods occasionally get scheduled onto ARM-based nodes and fail. While I was reading the docs, I noticed Redis also has an option to export Prometheus metrics, so I went ahead and enabled that as well.