### PR TITLE
Stop constraining node-exporter pods

### DIFF
--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -41,10 +41,6 @@ spec:
           matchLabels:
             alertmanagerConfig: spack
 
-    prometheus-node-exporter:
-      nodeSelector:
-        spack.io/node-pool: base
-
     grafana:
       nodeSelector:
         spack.io/node-pool: base


### PR DESCRIPTION
Partially reverts #550. The node exporter should run on all nodes (that aren't Windows).