### PR TITLE
Add cronjob to create binary cache summary index

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -48,6 +48,8 @@ jobs:
             image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.1
           - docker-image: snapshot-release-tags
             image-tags: ghcr.io/spack/snapshot-release-tags:0.0.2
+          - docker-image: cache-indexer
+            image-tags: ghcr.io/spack/cache-indexer:0.0.1
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/images/cache-indexer/Dockerfile
+++ b/images/cache-indexer/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+
+WORKDIR /scripts
+RUN pip install --upgrade awscli
+COPY cache_indexer.py ./
+
+ENTRYPOINT ["python", "./cache_indexer.py"]

--- a/images/cache-indexer/Dockerfile
+++ b/images/cache-indexer/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3
 
 WORKDIR /scripts
-RUN pip install --upgrade awscli
+RUN pip install --upgrade boto3
 COPY cache_indexer.py ./
 
 ENTRYPOINT ["python", "./cache_indexer.py"]

--- a/images/cache-indexer/cache_indexer.py
+++ b/images/cache-indexer/cache_indexer.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+import json
+import re
+import subprocess
+
+
+# Describe the spack refs to include in the cache.spack.io website
+REF_REGEXES = [
+    re.compile(r"^develop-[\d]+-[\d]+-[\d]+$"), # dev snapshot mirrors
+    re.compile(r"^develop$"),                   # main develop mirror
+    re.compile(r"^v[\d]+\.[\d]+\.[\d]+$"),      # mirrors for point releases
+]
+
+# Stacks or other "subdirectories" to ignore under *any* ref
+SUBREF_IGNORE_REGEXES = [
+    re.compile(r"^deprecated$"),
+    re.compile(r"^e4s-mac$"),
+]
+
+
+def get_label(subref):
+    if subref == "build_cache":
+        return "root" # or top-level?
+    for regex in SUBREF_IGNORE_REGEXES:
+        if regex.match(subref):
+            return None
+    return subref
+
+
+def get_matching_ref(ref):
+    for regex in REF_REGEXES:
+        if regex.match(ref):
+            return ref
+    return None
+
+
+def build_json(root_url, index_paths):
+    json_data = {}
+
+    for p in index_paths:
+        parts = p.split("/")
+        ref = get_matching_ref(parts[0])
+        if ref:
+            if ref not in json_data:
+                json_data[ref] = []
+            mirror_label = get_label(parts[1])
+            if mirror_label:
+                json_data[ref].append({
+                    "label": mirror_label,
+                    "url": f"{root_url}/{p}",
+                })
+
+    return json_data
+
+
+def query_bucket(root_url):
+    cmd = f"aws s3 ls {root_url} --recursive | grep -E \"build_cache\/index\.json$\""
+    task = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    data = task.stdout.read()
+    assert task.wait() == 0
+
+    lines = [s.strip() for s in data.decode("utf-8").split("\n") if s]
+    regex = re.compile(f"([^\s]+)$")
+    results = []
+
+    for line in lines:
+        m = regex.search(line)
+        if m:
+            results.append(m.group(1))
+
+    return results
+
+
+if __name__ == "__main__":
+    root_url = "s3://spack-binaries"
+
+    results = query_bucket(root_url)
+    json_data = build_json(root_url, results)
+
+    # with open("results.txt") as fd:
+    #     results = [l.strip() for l in fd]
+    # json_data = build_json(root_url, results)
+
+    with open("output.json", "w") as fd:
+        fd.write(json.dumps(json_data))
+
+    cmd = ["aws", "s3", "cp", "output.json", "s3://spack-binaries/cache_spack_io_index.json"]
+    proc = subprocess.run(cmd, capture_output=True)
+    print(" ".join(cmd))
+    print(proc.stdout)
+    print(proc.stderr)

--- a/k8s/production/custom/cache-indexer/cron-jobs.yaml
+++ b/k8s/production/custom/cache-indexer/cron-jobs.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: index-binary-caches
+  namespace: custom
+spec:
+  schedule: "0 23 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: index-binary-caches
+          restartPolicy: Never
+          containers:
+          - name: index-binary-caches
+            image: ghcr.io/spack/cache-indexer:0.0.1
+            imagePullPolicy: IfNotPresent
+          nodeSelector:
+            spack.io/node-pool: base

--- a/k8s/production/custom/cache-indexer/service-accounts.yaml
+++ b/k8s/production/custom/cache-indexer/service-accounts.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: index-binary-caches
-  namespace: custom
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::588562868276:role/FullCRUDAccessToBucketSpackBinaries

--- a/k8s/production/custom/cache-indexer/service-accounts.yaml
+++ b/k8s/production/custom/cache-indexer/service-accounts.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: index-binary-caches
+  namespace: custom
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::588562868276:role/FullCRUDAccessToBucketSpackBinaries

--- a/terraform/production/service_account_roles.tf
+++ b/terraform/production/service_account_roles.tf
@@ -77,6 +77,74 @@ resource "kubectl_manifest" "notary_service_account" {
   ]
 }
 
+# IAM Role for granting read access to spack-binaries and write access to the cache index
+data "aws_iam_policy_document" "cache_indexer_assume_role_policy" {
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.production_cluster.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.production_cluster.oidc_provider_arn]
+    }
+  }
+}
+
+resource "aws_iam_role" "cache_indexer" {
+  name               = "CacheIndexer"
+  assume_role_policy = data.aws_iam_policy_document.cache_indexer_assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "cache_indexer_policy" {
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "arn:aws:s3:::spack-binaries/*"
+    ]
+  }
+
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["s3:PutObject", "s3:DeleteObject"]
+
+    resources = [
+      "arn:aws:s3:::spack-binaries/cache_spack_io_index.json"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "cache_indexer_policy" {
+  name   = "CacheIndexerPolicy"
+  role   = aws_iam_role.cache_indexer.id
+  policy = data.aws_iam_policy_document.cache_indexer_policy.json
+}
+
+resource "kubectl_manifest" "cache_indexer_service_account" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: index-binary-caches
+      namespace: custom
+      annotations:
+        eks.amazonaws.com/role-arn: ${aws_iam_role.cache_indexer.arn}
+  YAML
+  depends_on = [
+    aws_iam_role_policy.cache_indexer_policy
+  ]
+}
+
 # The IAM role granting Spackbot full access to spack-binaries-prs S3 bucket.
 resource "aws_iam_role" "full_crud_access_spack_binaries_prs" {
   name        = "FullCRUDAccessToBucketSpackBinariesPRs"


### PR DESCRIPTION
This builds a new image containing a python script that iterates over `s3://spack-binaries` to build a summary index describing all the mirrors that the cache.spack.io website should contain.  Then the image is used in a nightly cron job that builds the index and pushes to the root of the `s3://spack-binaries` bucket.

This still needs some updates to the `service_account_roles.tf` file to create a role granting read/write permission to the spack-binaries bucket.