### PR TITLE
Add kustomization for gitlab setting updater

### DIFF
--- a/k8s/staging/custom/gitlab-setting-updater/kustomization.yaml
+++ b/k8s/staging/custom/gitlab-setting-updater/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../production/custom/gitlab-setting-updater/cronjobs.yaml
+  - ../../production/custom/gitlab-setting-updater/serviceaccounts.yaml


### PR DESCRIPTION
Follow up to #546 

This will enable the gitlab setting updater CronJob to run in staging.