### PR TITLE
Categorize more GitLab CI job failures

### DIFF
--- a/images/upload-gitlab-failure-logs/taxonomy.yaml
+++ b/images/upload-gitlab-failure-logs/taxonomy.yaml
@@ -125,6 +125,7 @@ taxonomy:
     helper_container_not_found:
       grep_for:
         - 'ERROR: Job failed.+:.+container helper not found in pod'
+        - 'container not found \("helper"\)'
 
     docker_daemon:
       grep_for:
@@ -151,6 +152,7 @@ taxonomy:
         - 'To reproduce this build locally, run:'
         - 'Error: No version for .+ satisfies'
         - 'Error: errors occurred during concretization of the environment'
+        - 'cannot load package .+ from the .builtin. repository'
 
     invalid_pipeline_yaml:
       grep_for:


### PR DESCRIPTION
Add a couple more patterns to search for to improve our classification rate.

Over the past week or so, we noticed an increase in the number of unclassified ("other") job failures.