### PR TITLE
Disable gitlab container registry

### DIFF
--- a/k8s/production/gitlab/certificates.yaml
+++ b/k8s/production/gitlab/certificates.yaml
@@ -16,20 +16,6 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: gitlab-registry
-  namespace: gitlab
-spec:
-  secretName: tls-gitlab-registry
-  issuerRef:
-    name: letsencrypt
-    kind: ClusterIssuer
-  dnsNames:
-    - registry.gitlab.spack.io
-
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
   name: gitlab-minio
   namespace: gitlab
 spec:

--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -54,8 +54,6 @@ spec:
           name: gitlab.spack.io
         minio:
           name: minio.gitlab.spack.io
-        registry:
-          name: registry.gitlab.spack.io
         smartcard:
           enabled: false
         ssh: ssh.gitlab.spack.io
@@ -97,6 +95,9 @@ spec:
       kas:
         enabled: false
 
+      registry:
+        enabled: false
+
       appConfig:
         smartcard:
           enabled: false
@@ -127,11 +128,7 @@ spec:
           memory: 12G
 
     registry:
-      ingress:
-        tls:
-          secretName: tls-gitlab-registry
-      nodeSelector:
-        spack.io/node-pool: gitlab
+      enabled: false
 
     gitlab-runner:
       install: false

--- a/k8s/staging/gitlab/kustomization.yaml
+++ b/k8s/staging/gitlab/kustomization.yaml
@@ -19,15 +19,6 @@ patches:
 
   - target:
       kind: Certificate
-      name: gitlab-registry
-      namespace: gitlab
-    patch: |-
-      - op: replace
-        path: /spec/dnsNames/0
-        value: registry.gitlab.staging.spack.io
-
-  - target:
-      kind: Certificate
       name: gitlab-minio
       namespace: gitlab
     patch: |-
@@ -49,9 +40,6 @@ patches:
       - op: replace
         path: /spec/values/global/hosts/minio/name
         value: minio.gitlab.staging.spack.io
-      - op: replace
-        path: /spec/values/global/hosts/registry/name
-        value: registry.gitlab.staging.spack.io
       - op: replace
         path: /spec/values/global/hosts/ssh
         value: ssh.gitlab.staging.spack.io


### PR DESCRIPTION
We don't (no longer?) use the gitlab container registry, but instead use the github container registry. This PR updates the helm release for gitlab to disable the container registry; I applied this to staging with Flux disabled, and it applied cleanly and terminated the gitlab-registry pods as expected.