### PR TITLE
Fix redis host for spackbot dev

### DIFF
--- a/k8s/production/spack/spackbotdev-spack-io/deployments.yaml
+++ b/k8s/production/spack/spackbotdev-spack-io/deployments.yaml
@@ -36,7 +36,7 @@ spec:
         - name: SPACKBOT_LOG_LEVEL
           value: "DEBUG"
         - name: REDIS_HOST
-          value: pr-binary-graduation-queue-production.cev8lh.ng.0001.use1.cache.amazonaws.com
+          value: pr-binary-graduation-queue-prod.cev8lh.ng.0001.use1.cache.amazonaws.com
         - name: REDIS_PORT
           value: "6379"
         - name: PR_BINARIES_MIRROR_BASE_URL
@@ -122,7 +122,7 @@ spec:
         - name: SPACKBOT_LOG_LEVEL
           value: "DEBUG"
         - name: REDIS_HOST
-          value: pr-binary-graduation-queue-production.cev8lh.ng.0001.use1.cache.amazonaws.com
+          value: pr-binary-graduation-queue-prod.cev8lh.ng.0001.use1.cache.amazonaws.com
         - name: REDIS_PORT
           value: "6379"
         - name: TASK_QUEUE_SHORT
@@ -213,7 +213,7 @@ spec:
         - name: SPACKBOT_LOG_LEVEL
           value: "DEBUG"
         - name: REDIS_HOST
-          value: pr-binary-graduation-queue-production.cev8lh.ng.0001.use1.cache.amazonaws.com
+          value: pr-binary-graduation-queue-prod.cev8lh.ng.0001.use1.cache.amazonaws.com
         - name: REDIS_PORT
           value: "6379"
         - name: TASK_QUEUE_SHORT


### PR DESCRIPTION
It seems the Redis host for spackbot dev was not updated properly when it changed in #479. 