### PR TITLE
Fix relative path in staging kustomization

### DIFF
--- a/k8s/production/custom/gitlab-setting-updater/cronjobs.yaml
+++ b/k8s/production/custom/gitlab-setting-updater/cronjobs.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: gitlab
 spec:
   schedule: "0 * * * *"
+  # Only save the most recent run to avoid overpopulating the pod list in the gitlab namespace
+  successfulJobsHistoryLimit: 1
   jobTemplate:
     metadata:
       labels:

--- a/k8s/staging/custom/gitlab-setting-updater/kustomization.yaml
+++ b/k8s/staging/custom/gitlab-setting-updater/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../production/custom/gitlab-setting-updater/cronjobs.yaml
-  - ../../production/custom/gitlab-setting-updater/serviceaccounts.yaml
+  - ../../../production/custom/gitlab-setting-updater/cronjobs.yaml
+  - ../../../production/custom/gitlab-setting-updater/serviceaccounts.yaml


### PR DESCRIPTION
Fixes some issues I noticed with the gitlab updater -

- The relative paths to the production YAML files from #563 are off by one directory. This is causing flux to error when it tries to apply the latest changes from `main` to the cluster.
- By default, k8s keeps the previous three runs of cronjobs around in the pods list. imo we only need to see the most recent to be able to tell that it ran and succeeded, and keeping around two older pods just takes up space in the crowded `gitlab` namespace, so  I updated it to do that. (reference to docs: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits)