### PR TITLE
Make gp3 the default StorageClass

### DIFF
--- a/k8s/production/kube-system/gp3-storage-class.yaml
+++ b/k8s/production/kube-system/gp3-storage-class.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gp3
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-provisioner: kubernetes.io/aws-ebs
+provisioner: ebs.csi.aws.com
 parameters:
   type: gp3
   fsType: ext4

--- a/k8s/production/kube-system/gp3-storage-class.yaml
+++ b/k8s/production/kube-system/gp3-storage-class.yaml
@@ -1,0 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp3
+  fsType: ext4
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
This new StorageClass is a copy of our previous default except that `gp2` has been replaced with `gp3`.