### PR TITLE
Fix invalid resource name

### DIFF
--- a/terraform/modules/spack/karpenter.tf
+++ b/terraform/modules/spack/karpenter.tf
@@ -141,13 +141,6 @@ resource "kubectl_manifest" "karpenter_node_template" {
   ]
 }
 
-locals {
-  pcluster_ami_id = {
-    "prod": "ami-00b2c701206072ffc"
-    "staging": "ami-0e2c34d361e37afa2"
-  }
-}
-
 resource "kubectl_manifest" "karpenter_pcluster_node_template" {
   for_each  = toset(["x86-64", "arm64"])
   yaml_body = <<-YAML

--- a/terraform/modules/spack/karpenter.tf
+++ b/terraform/modules/spack/karpenter.tf
@@ -149,7 +149,7 @@ locals {
 }
 
 resource "kubectl_manifest" "karpenter_pcluster_node_template" {
-  for_each  = toset(["x86_64", "arm64"])
+  for_each  = toset(["x86-64", "arm64"])
   yaml_body = <<-YAML
     apiVersion: karpenter.k8s.aws/v1alpha1
     kind: AWSNodeTemplate


### PR DESCRIPTION
Follow on to #527 - underscores are not allowed in resource names. I also removed a local variable that is unused after #527.

I did a `terraform apply` and this applied successfully.