### PR TITLE
Set gitlab_db postgres version to 14.7

### DIFF
--- a/terraform/modules/spack/gitlab_db.tf
+++ b/terraform/modules/spack/gitlab_db.tf
@@ -74,7 +74,7 @@ module "gitlab_db" {
   identifier = "gitlab-${var.deployment_name}"
 
   engine               = "postgres"
-  engine_version       = "14.3"
+  engine_version       = "14.7"
   family               = "postgres14"
   major_engine_version = "14"
   instance_class       = var.gitlab_db_instance_class


### PR DESCRIPTION
The gitlab DB is currently on `14.7` in both prod and staging, so this change serves to rectify the terraform code, and results in no infrastructure changes.