### PR TITLE
Add some tooling to support copying stack binaries to root

### DIFF
--- a/images/protected-publish/download_artifacts.py
+++ b/images/protected-publish/download_artifacts.py
@@ -1,0 +1,65 @@
+import argparse
+import os
+import subprocess
+import sys
+
+import gitlab
+
+
+GITLAB_PRIVATE_TOKEN = os.environ.get("GITLAB_TOKEN", None)
+
+
+def download_generate_artifacts(tag, working_dir):
+    if not GITLAB_PRIVATE_TOKEN:
+        print("Error: environment variable GITLAB_TOKEN must contain a valid PAT")
+        sys.exit(1)
+
+    gl = gitlab.Gitlab(url="https://gitlab.spack.io", private_token=GITLAB_PRIVATE_TOKEN)
+
+    project = gl.projects.get(2)
+    pipelines = project.pipelines.list(ref=tag)
+
+    pipeline = pipelines[0]
+    jobs = pipeline.jobs.list(get_all=True)
+
+    current_directory = os.getcwd()
+    lock_paths = []
+
+    for pipeline_job in jobs:
+        if pipeline_job.name.endswith("generate"):
+            job = project.jobs.get(pipeline_job.id, lazy=True)
+            stack_dir = os.path.join(working_dir, pipeline_job.name)
+            artifacts_path = os.path.join(stack_dir, "artifacts.zip")
+            os.makedirs(stack_dir, exist_ok=True)
+            with open(artifacts_path, "wb") as f:
+                job.artifacts(streamed=True, action=f.write)
+            os.chdir(stack_dir)
+            subprocess.run(["unzip", "-bo", artifacts_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            os.unlink(artifacts_path)
+            os.chdir(current_directory)
+            for (dirpath, _, filenames) in os.walk(stack_dir):
+                for f in filenames:
+                    if f == "spack.lock":
+                        lock_paths.append(os.path.join(dirpath,f))
+
+    return lock_paths
+
+
+def main(tag, working_dir):
+    spack_lock_paths = download_generate_artifacts(tag, working_dir)
+
+    for lock_path in spack_lock_paths:
+        print(lock_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="download_artifacs",
+        description="""Given a ref, download the artifacts of all pipeline
+            generation jobs, and print the absolute paths to each one""")
+
+    parser.add_argument("ref", type=str, default="develop", help="Ref (tag or branch) for which you want pipeline artifacts")
+    parser.add_argument("--working-dir", type=str, default=os.getcwd(), help="Directory to store artifacts, default is current working dir")
+    args = parser.parse_args()
+
+    main(args.ref, args.working_dir)

--- a/images/protected-publish/publish.sh
+++ b/images/protected-publish/publish.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+#
+# To run:
+#
+#     $ source /data/scott/Documents/spack/new_protected_publish/script/venv/bin/activate
+#     $ source <path-to>/spack/share/spack/setup-env.sh
+#     $ ./publish.sh
+#
+
+export AWS_PROFILE=spack-llnl
+SPACK_REF="develop-2023-06-25"
+WORKING_DIR="/data/scott/Documents/spack/new_protected_publish/working_dir/${SPACK_REF}"
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SRC_MIRROR_ROOT="s3://spack-binaries/${SPACK_REF}"
+DEST_MIRROR=${SRC_MIRROR_ROOT}
+MIRROR_REGEX="mirror:[[:space:]]+s3://spack-binaries/develop/([^[:space:]]+)"
+
+# Download the public key and trust it, also copy it to the root
+mkdir -p /tmp/temp_gpg_home && chmod 700 /tmp/temp_gpg_home
+curl -fLsS https://spack.github.io/keys/spack-public-binary-key.pub -o /tmp/spack-public-binary-key.pub
+aws s3 cp /tmp/spack-public-binary-key.pub "${DEST_MIRROR}/build_cache/_pgp/spack-public-binary-key.pub"
+export SPACK_GNUPGHOME=/tmp/temp_gpg_home
+spack gpg trust /tmp/spack-public-binary-key.pub
+
+# Download artifacts for each stack, we need the spack.lock and spack.yaml
+mapfile -t lock_paths < <( python "${SCRIPT_DIR}/download_artifacts.py" "${SPACK_REF}" "--working-dir" "${WORKING_DIR}")
+
+# Copy each stack's binaries to the root
+for lock_file in "${lock_paths[@]}"
+do
+    CONCRETE_ENV_DIR=$(dirname $lock_file)
+    SPACK_YAML_PATH="${CONCRETE_ENV_DIR}/spack.yaml"
+    SPACK_YAML_CONTENTS="$(< ${SPACK_YAML_PATH})"
+
+    if [[ $SPACK_YAML_CONTENTS =~ $MIRROR_REGEX ]]
+    then
+        SPACK_STACK_NAME="${BASH_REMATCH[1]}"
+        SRC_MIRROR="${SRC_MIRROR_ROOT}/${SPACK_STACK_NAME}"
+        echo "Sync $SPACK_STACK_NAME FROM ${SRC_MIRROR} TO ${DEST_MIRROR}"
+        STACK_ENV_DIR="${WORKING_DIR}/envs/${SPACK_STACK_NAME}"
+        mkdir -p "${STACK_ENV_DIR}"
+
+        spack env create --without-view --dir "${STACK_ENV_DIR}"
+        cp $lock_file "${STACK_ENV_DIR}/"
+        spack env activate "${STACK_ENV_DIR}"
+        spack env status
+
+        time spack buildcache sync --only-verified "${SRC_MIRROR}" "${DEST_MIRROR}"
+
+        spack env deactivate
+    else
+        echo "Skip publishing specs from ${$lock_file}"
+    fi
+done
+
+# Update the buildcache index at the root
+echo "Updating the buildcache index at ${DEST_MIRROR}"
+time spack buildcache update-index --keys "${DEST_MIRROR}"
+
+# Clean up
+rm -rf /tmp/temp_gpg_home
+rm /tmp/spack-public-binary-key.pub

--- a/images/protected-publish/requirements.txt
+++ b/images/protected-publish/requirements.txt
@@ -1,0 +1,3 @@
+awscli
+boto3
+python-gitlab


### PR DESCRIPTION
Add some scripts to do something similar to what the spack `protected-publish` job currently does, but after the fact, and for an arbitrary ref.  Currently these scripts:

- take an arbitrary ref and fetch the latest pipeline for it
- download artifacts from each of the pipeline generation jobs
- iterate over the downloaded `spack.lock` files, and for each:
  * create and activate the environment
  * use `spack buildcache sync` to copy all environment specs to another location

I am currently using these scripts for two purposes:

- create top-level buildcaches for recent develop snapshots for which protected-publish did not run
- evaluate proposed performance improvements to `spack buildcache sync`

I'm not sure these scripts will ultimately end up in one of our custom images, but we might think about how to use them to take the `protected-publish` job out of spack pipelines.