### PR TITLE
Standardize the number of GitLab runner pods and concurrency values

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 3
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 3
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 3
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 6
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 6
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 6
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 6
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 6
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -33,8 +33,8 @@ spec:
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 6
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 6
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 6
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
 
     metrics:
       enabled: true

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -28,13 +28,13 @@ spec:
       image: gitlab-org/gitlab-runner
       tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
-    replicas: 1
+    replicas: 2
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
-    concurrent: 20
-    checkInterval: 30
+    concurrent: 75
+    checkInterval: 10
     # preEntrypointScript: |
     #   echo "Hello, from large-pub runner"
 


### PR DESCRIPTION
This PR lowers the number of replica GitLab runner pods from 6 to 2 to reduce the number of idle pods in the k8s cluster. It also increases the concurrency of each runner to 75 and decreases the polling interval to 10s which mirrors the values we use internally at LLNL on login nodes, after we found those to be a good fit. Since our runners here mirror the functionality of login node runners, I thought it'd be a good fit to mirror those settings here.