### PR TITLE
Create runner for service jobs

### DIFF
--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -105,7 +105,7 @@ spec:
       imagePullPolicy: "if-not-present"
       locked: false
 
-      tags: "x86_64,x86_64_v2,small,medium,large,huge,public,aws,spack,service"
+      tags: "x86_64,x86_64_v2,small,medium,large,huge,public,aws,spack"
       runUntagged: false
       secret: gitlab-gitlab-runner-secret # from gitlab release
 

--- a/k8s/production/runners/service/release.yaml
+++ b/k8s/production/runners/service/release.yaml
@@ -2,7 +2,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
-  name: runner-graviton2-pub
+  name: runner-service
   namespace: gitlab
 spec:
   interval: 10m
@@ -12,7 +12,7 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: runner-graviton2-pub
+  name: runner-service
   namespace: gitlab
 spec:
   interval: 10m
@@ -22,7 +22,7 @@ spec:
       version: 0.54.0 # gitlab-runner@v16.1.0
       sourceRef:
         kind: HelmRepository
-        name: runner-graviton2-pub
+        name: runner-service
   values:
     image:
       image: gitlab-org/gitlab-runner
@@ -48,17 +48,16 @@ spec:
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
-            helper_image = "gitlab/gitlab-runner-helper:arm-latest"
             privileged = false
             helper_memory_request = "512m"
 
             cpu_request = "750m"
-            cpu_request_overwrite_max_allowed = "16"
+            cpu_request_overwrite_max_allowed = "12"
 
             memory_request = "2G"
-            memory_request_overwrite_max_allowed = "64G"
-            memory_limit = "64G"
-            memory_limit_overwrite_max_allowed = "64G"
+            memory_request_overwrite_max_allowed = "48G"
+            memory_limit = "48G"
+            memory_limit_overwrite_max_allowed = "48G"
 
             namespace = "pipeline"
             poll_timeout = 600  # ten minutes
@@ -98,23 +97,21 @@ spec:
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
-            [runners.kubernetes.node_selector]
-              "spack.io/node-pool" = "glr-graviton2"
 
       # default image
       image: "busybox:1.32.0"
       imagePullPolicy: "if-not-present"
       locked: false
 
-      tags: "arm,aarch64,graviton,graviton2,small,medium,large,huge,public,aws,spack"
+      tags: "spack,service"
       runUntagged: false
       secret: gitlab-gitlab-runner-secret # from gitlab release
-
-      serviceAccountName: runner
 
       cache: {}
 
       services: {}
+
+      helpers: {}
 
     nodeSelector:
       spack.io/node-pool: base # pool for the runner


### PR DESCRIPTION
This creates a separate runner for service jobs, so that they can be placed on any node, instead of just nodes that are part of the `x86-64-v2` or `glr-graviton2` node pools. This will fix a situation that can occur where, if no nodes from these node pools are spun up (specifically, if the karpenter provisioner for these node pools don't have any nodes active at the moment), then karpenter will spin up a new node from that node pool _just_ for the service job, when in reality, it could have run on almost any node with capacity. The new runner has no node selector, and so will run on any node that's capable.

This is a symptom of a more general problem with our infrastructure setup, which is that the concept of "node pools" results in pods being placed in discrete piles of nodes. In reality, our pod placement should be more fluid than that (i.e. "minimum requirements" instead of "exact requirements"). My open PR #446 will address that once it's fixed up and ready.

CC @alecbcs, this slightly conflicts with #579
