### PR TITLE
Enable gp3 storage class in staging

### DIFF
--- a/k8s/staging/kube-system/kustomization.yaml
+++ b/k8s/staging/kube-system/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../production/kube-system/metrics-server.yaml
+- ../../production/kube-system/gp3-storage-class.yaml


### PR DESCRIPTION
Without this, staging is still defaulting to gp2.