### PR TITLE
Remove rotation of no-longer-used credentials

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -19,7 +19,7 @@ jobs:
           - docker-image: gitlab-api-scrape
             image-tags: ghcr.io/spack/gitlab-api-scrape:0.0.2
           - docker-image: ci-key-rotate
-            image-tags: ghcr.io/spack/ci-key-rotate:0.0.3
+            image-tags: ghcr.io/spack/ci-key-rotate:0.0.4
           - docker-image: ci-key-clear
             image-tags: ghcr.io/spack/ci-key-clear:0.0.1
           - docker-image: gitlab-stuckpods

--- a/images/ci-key-rotate/rotate_gitlab_aws_access_keys.py
+++ b/images/ci-key-rotate/rotate_gitlab_aws_access_keys.py
@@ -67,4 +67,3 @@ if __name__ == '__main__':
     rotate_iam_keys('pull-requests-binary-mirror', gitlab_variable_prefix='PR_')
     rotate_iam_keys('protected-binary-mirror', gitlab_variable_prefix='PROTECTED_')
     rotate_iam_keys('cray-binary-mirror', gitlab_variable_prefix='CRAY_')
-    rotate_iam_keys('develop-binary-mirror')

--- a/k8s/production/custom/rotate-keys/cron-jobs.yaml
+++ b/k8s/production/custom/rotate-keys/cron-jobs.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: rotate-gitlab-aws-access-keys
-            image: ghcr.io/spack/ci-key-rotate:0.0.3
+            image: ghcr.io/spack/ci-key-rotate:0.0.4
             imagePullPolicy: IfNotPresent
             env:
             - name: GITLAB_TOKEN


### PR DESCRIPTION
Examination of recent failed pod logs shows that we are failing to updating gitlab ci variables that no longer exist.  This PR removes that IAM account from the list of those that get rotated.

<details>

<summary>Log excerpt</summary>

Note how it is the `develop-binary-mirror` iam account where we fail to update the gitlab ci variables.  Those are no longer present as they have been unused for the last year or so.

```
Traceback (most recent call last):
Begin IAM key rotation for user "pull-requests-binary-mirror"
Querying AWS IAM for access keys
Deleting old IAM access key
Creating new IAM access key
Updating GitLab to use new IAM access key
IAM key rotation for user "pull-requests-binary-mirror" complete!
Begin IAM key rotation for user "protected-binary-mirror"
Querying AWS IAM for access keys
Deleting old IAM access key
Creating new IAM access key
Updating GitLab to use new IAM access key
IAM key rotation for user "protected-binary-mirror" complete!
Begin IAM key rotation for user "cray-binary-mirror"
Querying AWS IAM for access keys
Deleting old IAM access key
Creating new IAM access key
Updating GitLab to use new IAM access key
IAM key rotation for user "cray-binary-mirror" complete!
Begin IAM key rotation for user "develop-binary-mirror"
Querying AWS IAM for access keys
Deleting old IAM access key
Creating new IAM access key
Updating GitLab to use new IAM access key
  File "/scripts/./rotate_gitlab_aws_access_keys.py", line 70, in <module>
    rotate_iam_keys('develop-binary-mirror')
  File "/scripts/./rotate_gitlab_aws_access_keys.py", line 54, in rotate_iam_keys
    update_gitlab_variable(gitlab_secret_key, gitlab_secret_value)
  File "/scripts/./rotate_gitlab_aws_access_keys.py", line 14, in update_gitlab_variable
    urllib.request.urlopen(request)
  File "/usr/local/lib/python3.11/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/urllib/request.py", line 525, in open
    response = meth(req, response)
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/urllib/request.py", line 634, in http_response
    response = self.parent.error(
               ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/urllib/request.py", line 563, in error
    return self._call_chain(*args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/urllib/request.py", line 496, in _call_chain
    result = func(*args)
             ^^^^^^^^^^^
  File "/usr/local/lib/python3.11/urllib/request.py", line 643, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```

</details>