### PR TITLE
Fix broken python-aws-bash image build

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -32,7 +32,7 @@ jobs:
           - docker-image: ./images/notary
             image-tags: ghcr.io/spack/notary:latest
           - docker-image: ./images/python-aws-bash
-            image-tags: ghcr.io/spack/python-aws-bash:0.0.1
+            image-tags: ghcr.io/spack/python-aws-bash:0.0.2
           - docker-image: ./images/opensearch-index-build-logs
             image-tags: ghcr.io/spack/opensearch-index-build-logs:0.0.4
           - docker-image: ./images/gitlab-error-processor

--- a/images/python-aws-bash/Dockerfile
+++ b/images/python-aws-bash/Dockerfile
@@ -1,10 +1,7 @@
 FROM python:3
 
-# bug in spack s3 handling requires older botocore:
-#     https://github.com/spack/spack/issues/28830
-RUN pip install --upgrade \
-    awscli==1.22.46 \
-    boto3==1.20.35 \
-    botocore==1.23.46
+WORKDIR /scripts/
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
 
 ENTRYPOINT ["/bin/bash"]

--- a/images/python-aws-bash/requirements.txt
+++ b/images/python-aws-bash/requirements.txt
@@ -1,0 +1,3 @@
+awscli
+boto3
+botocore


### PR DESCRIPTION
After a recent PR merge, I noticed the `python-aws-bash` image [failing](https://github.com/spack/spack-infrastructure/actions/runs/5753437333/job/15596635909#step:4:326) to build.

I think it was pinning `awscli` to an older version that was causing the build to hit this [issue](https://github.com/yaml/pyyaml/issues/601) with older versions of `pyyaml`.

As you can see in the deleted comment from this PR, there was a bug in older version of `boto3` that was preventing us from moving forward, but that bug has been fixed, and anyway spack had been [fixed](https://github.com/spack/spack/pull/31610) a year ago to support both older and newer versions of `boto3`.   So I thought we could move forward and remove all the pinning from these dependencies.

Just to be sure, I tested that I could `spack buildcache update-index <mirror-url>` with the new image resulting from removing all the version pinning, and it seems to work fine.  

However, this recent build failure makes me wonder if we should really be re-building, re-tagging, and pushing all these images with every merge to `main`.  If some breakage creeps in via dependencies, then overwriting the tags the way we do will cause us to lose the previously working version and start using the broken one immediately (and not be able to go back).  Or maybe I'm missing some detail that prevents this from happening. 