### PR TITLE
Remove redis patch from gitlab HelmRelease

### DIFF
--- a/k8s/staging/gitlab/kustomization.yaml
+++ b/k8s/staging/gitlab/kustomization.yaml
@@ -31,8 +31,6 @@ patches:
         path: /spec/values/global/hosts/ssh
         value: ssh.gitlab.staging.spack.io
       - op: remove
-        path: /spec/values/global/redis
-      - op: remove
         path: /spec/values/global/grafana
       - op: replace
         path: /spec/values/gitlab/webservice/minReplicas


### PR DESCRIPTION
I missed this in #591.