### PR TITLE
Add GitLab OIDC provider

### DIFF
--- a/terraform/modules/spack/gitlab_runner_iam.tf
+++ b/terraform/modules/spack/gitlab_runner_iam.tf
@@ -1,0 +1,124 @@
+locals {
+  gitlab_domain = "gitlab${var.deployment_name == "prod" ? "" : ".staging"}.spack.io"
+
+  mirror_roles = {
+    "pr_binary_mirror" = {
+      "role_name_suffix"     = "PRBinaryMirror${var.deployment_name == "prod" ? "" : "-${var.deployment_name}"}",
+      "role_arn_ci_var_name" = "PR_BINARY_MIRROR_ROLE_ARN",
+      "conditions"           = ["project_path:${data.gitlab_project.spack.path_with_namespace}:ref_type:branch:ref:pr*"],
+    },
+    "protected_binary_mirror" = {
+      "role_name_suffix"     = "ProtectedBinaryMirror${var.deployment_name == "prod" ? "" : "-${var.deployment_name}"}",
+      "role_arn_ci_var_name" = "PROTECTED_BINARY_MIRROR_ROLE_ARN",
+      "conditions" = [
+        "project_path:${data.gitlab_project.spack.path_with_namespace}:ref_type:branch:ref:develop",
+        "project_path:${data.gitlab_project.spack.path_with_namespace}:ref_type:branch:ref:releases/v*",
+        "project_path:${data.gitlab_project.spack.path_with_namespace}:ref_type:tag:ref:develop-*",
+        "project_path:${data.gitlab_project.spack.path_with_namespace}:ref_type:tag:ref:v*"
+      ],
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "gitlab_project" "spack" {
+  path_with_namespace = "spack/spack"
+}
+
+data "tls_certificate" "gitlab" {
+  url = "https://${local.gitlab_domain}"
+}
+
+resource "aws_iam_openid_connect_provider" "gitlab" {
+  url             = "https://${local.gitlab_domain}"
+  client_id_list  = keys(local.mirror_roles)
+  thumbprint_list = [data.tls_certificate.gitlab.certificates.0.sha1_fingerprint]
+}
+
+data "aws_iam_policy_document" "gitlab_oidc_assume_role" {
+  for_each = local.mirror_roles
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.gitlab_domain}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.gitlab_domain}:aud"
+      values   = [each.key]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${local.gitlab_domain}:sub"
+      values   = each.value.conditions
+    }
+  }
+}
+
+resource "aws_iam_role" "gitlab_runner" {
+  for_each = data.aws_iam_policy_document.gitlab_oidc_assume_role
+
+  name                 = "GitLabRunner${local.mirror_roles[each.key].role_name_suffix}"
+  assume_role_policy   = each.value.json
+  max_session_duration = 3600 * 6 # only allow a max of 6 hours for a session to be active
+}
+
+data "aws_iam_policy_document" "gitlab_runner" {
+  for_each = var.deployment_name == "staging" ? local.mirror_roles : {}
+
+  statement {
+    effect  = "Allow"
+    actions = ["s3:PutObject", "s3:DeleteObject"]
+
+    resources = [
+      each.key == "protected_binary_mirror" ? "${module.protected_binary_mirror.bucket_arn}/*" : "${module.pr_binary_mirror.bucket_arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "gitlab_runner" {
+  for_each = data.aws_iam_policy_document.gitlab_runner
+
+  name        = "WriteBinariesTo${local.mirror_roles[each.key].role_name_suffix}"
+  description = "Managed by Terraform. IAM Policy that provides access to S3 buckets for binary mirrors."
+  policy      = each.value.json
+}
+
+resource "aws_iam_role_policy_attachment" "gitlab_runner" {
+  for_each = aws_iam_policy.gitlab_runner
+
+  role       = aws_iam_role.gitlab_runner[each.key].name
+  policy_arn = each.value.arn
+}
+
+resource "gitlab_project_variable" "binary_mirror_role_arn" {
+  for_each = resource.aws_iam_role.gitlab_runner
+
+  project = data.gitlab_project.spack.id
+  key     = local.mirror_roles[each.key].role_arn_ci_var_name
+  value   = each.value.arn
+}
+
+# attachments for the pre-existing hardcoded policies in production
+resource "aws_iam_role_policy_attachment" "legacy_gitlab_runner_pr_binary_mirror" {
+  for_each = var.deployment_name == "prod" ? toset(["arn:aws:iam::588562868276:policy/DeleteObjectsFromBucketSpackBinariesPRs",
+  "arn:aws:iam::588562868276:policy/PutObjectsInBucketSpackBinariesPRs"]) : []
+
+  role       = aws_iam_role.gitlab_runner["pr_binary_mirror"].name
+  policy_arn = each.value
+}
+
+resource "aws_iam_role_policy_attachment" "legacy_gitlab_runner_protected_binary_mirror" {
+  for_each = var.deployment_name == "prod" ? toset(["arn:aws:iam::588562868276:policy/DeleteObjectsFromBucketSpackBinaries",
+  "arn:aws:iam::588562868276:policy/PutObjectsInBucketSpackBinaries"]) : []
+
+  role       = aws_iam_role.gitlab_runner["protected_binary_mirror"].name
+  policy_arn = each.value
+}

--- a/terraform/production/.terraform.lock.hcl
+++ b/terraform/production/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/fluxcd/flux" {
   constraints = "~> 0.22.2"
   hashes = [
     "h1:CXJxJQ/rHO2E4l1KTFo+WL854S/zZltaH5POd5XFL6s=",
+    "h1:cIZibxKmCJy0uQprGwkMtow3XjPjWoX8V0StDGKE+gM=",
     "zh:1aabb23cf485f658ef36b44219dc36821a917441892777c95a1d9bc5e3d88bd0",
     "zh:208073c9d67b536d992f0845f0e2ef0229566d9722b88d95d730b7b72edcd406",
     "zh:45c0139bfd03263365172e18cf9ac3bc495b1175ec7556412971c4032625c333",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/gavinbunney/kubectl" {
   version     = "1.14.0"
   constraints = "~> 1.14"
   hashes = [
+    "h1:ItrWfCZMzM2JmvDncihBMalNLutsAk7kyyxVRaipftY=",
     "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
     "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
     "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
@@ -40,10 +42,34 @@ provider "registry.terraform.io/gavinbunney/kubectl" {
   ]
 }
 
+provider "registry.terraform.io/gitlabhq/gitlab" {
+  version     = "16.3.0"
+  constraints = "16.3.0"
+  hashes = [
+    "h1:Cbbpz1Wh8ThCtfpuDqmxO1UJ0uEZrm51cTEfHhpWzsg=",
+    "zh:0f608005570dd7c5aaf4c5f9eb0fc0d46cc89ec37bd70fdabdc2a0f2894567cc",
+    "zh:18281ce018fc3a0cf28574defc033023731b2c5b504956864a5be9a39867144d",
+    "zh:19e210711ace72aa832ac51d962c67af3f7e6757ee660aef898aa9a7adb0daa5",
+    "zh:2a0b81b01dcbcb8b8c77e2610d4e909f09cedcff7862ceb563207a1a6b822a05",
+    "zh:5d6e70e37f5dd226fe728a1ed1c331f82e6088c9c16e9a344a09c95c2cc58345",
+    "zh:75f4b0f52d7e6c634c52b8f88b2e32de72eb8164d70a2018dae5fe4a0019435f",
+    "zh:7ce2086e5d94b5e7b048cf6f59e0e1eed0fd55e4bffa5f793afc3432e6a548c7",
+    "zh:978bd5f28cd1adf6e0e430f3cc1a4bd66269c5b21e95af4826bb88aff03fa2b0",
+    "zh:a722b772101717abe279ed6dcfe45a7e6f15b6668df0efa05cc6b3acc0ccff6e",
+    "zh:a952a9d16623ef738ee7049257a5ef84940b02f9de18eabfe034a8e28f7a11da",
+    "zh:d28a351bb58a67708abecf2321a798ee26697af7b2d04b67c09774ad531eff72",
+    "zh:d2eb372da98244a60569ddf4b853494fb452fe6073ae1c4d989d23b0389986f9",
+    "zh:d5f8102e80f546900ad15149dc9d9bb0550c59f7356938b6a27af8dc79da0e57",
+    "zh:d72097456069462f4a20d508b66efec63370bb3de06e2d88bae7933e372cee43",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.63.0"
-  constraints = ">= 3.29.0, >= 3.72.0, >= 3.73.0, ~> 4.0, >= 4.17.0, >= 4.45.0, >= 4.47.0"
+  constraints = ">= 3.29.0, >= 3.72.0, >= 3.73.0, ~> 4.0, >= 4.45.0, >= 4.47.0"
   hashes = [
+    "h1:dN7hK7srLB0ZScbsoqEP25/3yXX9kauF3elbEQ0yXFM=",
     "h1:rYAzJXE8nZcDQfHBa/1CCmOeWco5opIzfWDPgOhgsY8=",
     "zh:0162a9b61f45deed9fcc4a3c4a90341904b0c1c864b2226c8c6df14a87671d86",
     "zh:230db13f43ced8e9dcb7966c32a2b11cff0708b639083cfc92bdb6cb92902c86",
@@ -68,6 +94,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   constraints = ">= 2.0.0"
   hashes = [
     "h1:Vl0aixAYTV/bjathX7VArC5TVNkxBCsi3Vq7R4z1uvc=",
+    "h1:ocyv0lvfyvzW4krenxV5CL4Jq5DiA3EUfoy8DR6zFMw=",
     "zh:2487e498736ed90f53de8f66fe2b8c05665b9f8ff1506f751c5ee227c7f457d1",
     "zh:3d8627d142942336cf65eea6eb6403692f47e9072ff3fa11c3f774a3b93130b3",
     "zh:434b643054aeafb5df28d5529b72acc20c6f5ded24decad73b98657af2b53f4f",
@@ -88,6 +115,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "~> 2.5"
   hashes = [
     "h1:D5BLFN82WndhQZQleXE5rO0hUDnlyqb60XeUJKDhuo4=",
+    "h1:fEDID5J/9ret/sLpOSNAu98F/ZBEZhOmL0Leut7m5JU=",
     "zh:1471cb45908b426104687c962007b2980cfde294fa3530fabc4798ce9fb6c20c",
     "zh:1572e9cec20591ec08ece797b3630802be816a5adde36ca91a93359f2430b130",
     "zh:1b10ae03cf5ab1ae21ffaac2251de99797294ae4242b156b3b0beebbdbcb7e0f",
@@ -107,6 +135,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.19.0"
   constraints = ">= 2.10.0"
   hashes = [
+    "h1:ID/u9YOv00w+Z8iG+592oyuV7HcqRmPiZpEC9hnyTMY=",
     "h1:soxnBBEH2yLFS0xyALi7J8KQ4u7eQzEYIGvkDyyYCcU=",
     "zh:028d346460de2d1d19b4c863dfc36be51c7bcd97d372b54a3a946bcb19f3f613",
     "zh:391d0b38c455437d0a2ab1beb6ce6e1230aa4160bbae11c58b2810b258b44280",
@@ -127,6 +156,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = ">= 3.1.0"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
@@ -147,6 +177,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.0.4"
   constraints = ">= 3.0.0"
   hashes = [
+    "h1:GZcFizg5ZT2VrpwvxGBHQ/hO9r6g0vYdQqx3bFD3anY=",
     "h1:pe9vq86dZZKCm+8k1RhzARwENslF3SXb9ErHbQfgjXU=",
     "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
     "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
@@ -167,6 +198,7 @@ provider "registry.terraform.io/integrations/github" {
   version     = "5.13.0"
   constraints = "~> 5.13.0"
   hashes = [
+    "h1:7qNLigMnEVD5QsdSudzruJ4LGRUuc+yISbfZZyx12i0=",
     "h1:h5m2rgps7szJcS58Qw8zVIA0sbzZy0zJz/6brTMKxMk=",
     "zh:037bb9526d87b06b8077ebc1965b6705a8f5cb1c1eb7289a292ab37e90ba825d",
     "zh:25c21880806817cd3090797504843b5052f935024935e2b20103e0b89e610ba3",

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -30,6 +30,10 @@ terraform {
       source  = "integrations/github"
       version = "~> 5.13.0"
     }
+    gitlab = {
+      source = "gitlabhq/gitlab"
+      version = "16.3.0"
+    }
   }
 }
 
@@ -91,6 +95,22 @@ provider "kubernetes" {
 provider "github" {
   owner = "spack"
   token = jsondecode(data.aws_secretsmanager_secret_version.flux_github_token.secret_string).flux_github_token
+}
+
+data "kubernetes_ingress_v1" "gitlab_webservice" {
+  metadata {
+    name      = "gitlab-webservice-default"
+    namespace = "gitlab"
+  }
+}
+
+locals {
+  gitlab_url = "https://${data.kubernetes_ingress_v1.gitlab_webservice.spec[0].rule[0].host}"
+}
+
+provider "gitlab" {
+  base_url = local.gitlab_url
+  token = jsondecode(data.aws_secretsmanager_secret_version.gitlab_token.secret_string).gitlab_terraform_provider_access_token
 }
 
 module "production_cluster" {

--- a/terraform/production/secrets.tf
+++ b/terraform/production/secrets.tf
@@ -1,3 +1,7 @@
 data "aws_secretsmanager_secret_version" "flux_github_token" {
   secret_id = "flux_github_token"
 }
+
+data "aws_secretsmanager_secret_version" "gitlab_token" {
+  secret_id = "gitlab-terraform-provider-access-token"
+}

--- a/terraform/staging/.terraform.lock.hcl
+++ b/terraform/staging/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/fluxcd/flux" {
   constraints = "~> 0.22.2"
   hashes = [
     "h1:CXJxJQ/rHO2E4l1KTFo+WL854S/zZltaH5POd5XFL6s=",
+    "h1:cIZibxKmCJy0uQprGwkMtow3XjPjWoX8V0StDGKE+gM=",
     "zh:1aabb23cf485f658ef36b44219dc36821a917441892777c95a1d9bc5e3d88bd0",
     "zh:208073c9d67b536d992f0845f0e2ef0229566d9722b88d95d730b7b72edcd406",
     "zh:45c0139bfd03263365172e18cf9ac3bc495b1175ec7556412971c4032625c333",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/gavinbunney/kubectl" {
   version     = "1.14.0"
   constraints = "~> 1.14"
   hashes = [
+    "h1:ItrWfCZMzM2JmvDncihBMalNLutsAk7kyyxVRaipftY=",
     "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
     "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
     "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
@@ -45,6 +47,7 @@ provider "registry.terraform.io/gitlabhq/gitlab" {
   constraints = "16.3.0"
   hashes = [
     "h1:8ajRmpdh9zkemCteHyzcWoznYWAKsvvdQWX5lIg9L9A=",
+    "h1:Cbbpz1Wh8ThCtfpuDqmxO1UJ0uEZrm51cTEfHhpWzsg=",
     "zh:0f608005570dd7c5aaf4c5f9eb0fc0d46cc89ec37bd70fdabdc2a0f2894567cc",
     "zh:18281ce018fc3a0cf28574defc033023731b2c5b504956864a5be9a39867144d",
     "zh:19e210711ace72aa832ac51d962c67af3f7e6757ee660aef898aa9a7adb0daa5",
@@ -67,6 +70,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.67.0"
   constraints = ">= 3.29.0, >= 3.72.0, >= 3.73.0, ~> 4.0, >= 4.45.0, >= 4.47.0"
   hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
     "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
     "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
     "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
@@ -91,6 +95,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   constraints = ">= 2.0.0"
   hashes = [
     "h1:Vl0aixAYTV/bjathX7VArC5TVNkxBCsi3Vq7R4z1uvc=",
+    "h1:ocyv0lvfyvzW4krenxV5CL4Jq5DiA3EUfoy8DR6zFMw=",
     "zh:2487e498736ed90f53de8f66fe2b8c05665b9f8ff1506f751c5ee227c7f457d1",
     "zh:3d8627d142942336cf65eea6eb6403692f47e9072ff3fa11c3f774a3b93130b3",
     "zh:434b643054aeafb5df28d5529b72acc20c6f5ded24decad73b98657af2b53f4f",
@@ -110,6 +115,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.11.0"
   constraints = "~> 2.5"
   hashes = [
+    "h1:AOp9vXIM4uT1c/PVwsWTPiLVGlO2SSYrfiirV5rjCMQ=",
     "h1:zxfRtgpWrVZwjkIBuI+7jc52+u1QBA/k7LQZiCiq3Z8=",
     "zh:013857c88f3e19a4b162344e21dc51891c4ac8b600da8391f7fb2b6d234961e1",
     "zh:044fffa233a93cdcf8384afbe9e1ab6c9d0b5b176cbae56ff465eb9611302975",
@@ -130,6 +136,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.23.0"
   constraints = ">= 2.10.0"
   hashes = [
+    "h1:arTzD0XG/DswGCAx9JEttkSKe9RyyFW9W7UWcXF13dU=",
     "h1:xyFc77aYkPoU4Xt1i5t0B1IaS8TbTtp9aCSuQKDayII=",
     "zh:10488a12525ed674359585f83e3ee5e74818b5c98e033798351678b21b2f7d89",
     "zh:1102ba5ca1a595f880e67102bbf999cc8b60203272a078a5b1e896d173f3f34b",
@@ -150,6 +157,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = ">= 3.1.0"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
@@ -170,6 +178,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.0.4"
   constraints = ">= 3.0.0"
   hashes = [
+    "h1:GZcFizg5ZT2VrpwvxGBHQ/hO9r6g0vYdQqx3bFD3anY=",
     "h1:pe9vq86dZZKCm+8k1RhzARwENslF3SXb9ErHbQfgjXU=",
     "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
     "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
@@ -190,6 +199,7 @@ provider "registry.terraform.io/integrations/github" {
   version     = "5.13.0"
   constraints = "~> 5.13.0"
   hashes = [
+    "h1:7qNLigMnEVD5QsdSudzruJ4LGRUuc+yISbfZZyx12i0=",
     "h1:h5m2rgps7szJcS58Qw8zVIA0sbzZy0zJz/6brTMKxMk=",
     "zh:037bb9526d87b06b8077ebc1965b6705a8f5cb1c1eb7289a292ab37e90ba825d",
     "zh:25c21880806817cd3090797504843b5052f935024935e2b20103e0b89e610ba3",


### PR DESCRIPTION
Requires #601

This adds a GitLab OIDC provider to the spack module.

It also creates multiple resources for the protected and PR binary buckets*. The roles can only be assumed when the JWT matches the claims in `conditions`. This means that when a GitLab ID Token with `aud: protected_binary_mirror` is provided, it must also match the conditions here to be granted access.

This is a good illustration of how the overall flow works: https://docs.gitlab.com/ee/ci/cloud_services/index.html#authorization-workflow.

*The production bucket policies/roles aren't yet modularized in Terraform, so there's some logic to use the existing ones for production and create new ones for staging.