### PR TITLE
Add GitLab runner pre_build_script for temporary credentials request

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -45,6 +45,22 @@ spec:
     runners:
       config: |
         [[runners]]
+          pre_build_script = """
+          echo 'Executing Spack pre-build setup script'
+
+          python -m venv pre_build_venv
+          source pre_build_venv/bin/activate
+          python -m pip install -qr https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/requirements.txt
+          python -c "import requests;f=open('pre_build.py','w');f.write(requests.get('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py').text);f.close()"
+          python pre_build.py > envvars
+
+          deactivate
+
+          source envvars
+          rm -rf pre_build_venv envvars
+          unset GITLAB_OIDC_TOKEN
+          """
+
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]

--- a/scripts/gitlab_runner_pre_build/pre_build.py
+++ b/scripts/gitlab_runner_pre_build/pre_build.py
@@ -1,0 +1,70 @@
+"""
+This script is responsible for taking the GITLAB_OIDC_TOKEN from the environment and
+exchanging it for temporary AWS credentials. These credentials are then printed to stdout to be
+sourced by the gitlab runner in its pre_build configuration option.
+
+In the case of a PR build, the temporary credentials are scoped down to only allow access to the
+S3 bucket prefix for the relevant PR.
+"""
+import boto3, os, sys, jwt, json
+
+TEMPORARY_CREDENTIALS_DURATION = 3600 * 6  # 6 hours
+
+if __name__ == "__main__":
+    if not os.environ.get("GITLAB_OIDC_TOKEN"):
+        print("GITLAB_OIDC_TOKEN not in the environment", file=sys.stderr)
+        sys.exit(0)  # this isn't an error yet.
+
+    token = jwt.decode(
+        os.environ["GITLAB_OIDC_TOKEN"],
+        algorithms=["RS256"],
+        # it's unnecessary to verify the signature here since this is running before any
+        # untrusted code. it's also useful to avoid having to install the crypto libraries
+        # in diverse environments.
+        options={"verify_signature": False},
+    )
+
+    # assemble aws sts temporary credential request
+    sts = boto3.client("sts")
+
+    assume_role_kwargs = {
+        "RoleArn": os.environ[
+            "PR_BINARY_MIRROR_ROLE_ARN"
+            if token["aud"] == "pr_binary_mirror"
+            else "PROTECTED_BINARY_MIRROR_ROLE_ARN"
+        ],
+        "RoleSessionName": (
+            f'GitLabRunner-{os.environ["CI_JOB_ID"]}-{os.environ["CI_COMMIT_SHORT_SHA"]}'
+        ),
+        "WebIdentityToken": os.environ["GITLAB_OIDC_TOKEN"],
+        "DurationSeconds": TEMPORARY_CREDENTIALS_DURATION,
+    }
+
+    # if this is a PR build, narrow down the permissions to only allow access to the PR build prefix
+    if token["aud"] == "pr_binary_mirror":
+        assume_role_kwargs["Policy"] = json.dumps(
+            {
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        # allow every action the broader RoleArn allows
+                        "Action": "*",
+                        # scope the actions down the pr prefix
+                        "Resource": f"{os.environ['PR_BINARY_MIRROR_BUCKET_ARN']}/{os.environ['CI_COMMIT_REF_NAME']}/*",
+                    }
+                ]
+            }
+        )
+
+    print(
+        f"Assuming role {assume_role_kwargs['RoleArn']} with session name {assume_role_kwargs['RoleSessionName']}",
+        file=sys.stderr,
+    )
+    response = sts.assume_role_with_web_identity(**assume_role_kwargs)
+
+    # print credentials to stdout
+    print(f'export AWS_ACCESS_KEY_ID="{response["Credentials"]["AccessKeyId"]}"')
+    print(
+        f'export AWS_SECRET_ACCESS_KEY="{response["Credentials"]["SecretAccessKey"]}"'
+    )
+    print(f'export AWS_SESSION_TOKEN="{response["Credentials"]["SessionToken"]}"')

--- a/scripts/gitlab_runner_pre_build/requirements.txt
+++ b/scripts/gitlab_runner_pre_build/requirements.txt
@@ -1,0 +1,3 @@
+boto3
+pyjwt
+requests

--- a/terraform/modules/spack/gitlab_runner_iam.tf
+++ b/terraform/modules/spack/gitlab_runner_iam.tf
@@ -106,6 +106,13 @@ resource "gitlab_project_variable" "binary_mirror_role_arn" {
   value   = each.value.arn
 }
 
+# pre_build.py needs access to this to request PR prefix scoped permissions
+resource "gitlab_project_variable" "pr_binary_mirror_bucket_arn" {
+  project = data.gitlab_project.spack.id
+  key     = "PR_BINARY_MIRROR_BUCKET_ARN"
+  value   = module.pr_binary_mirror.bucket_arn
+}
+
 # attachments for the pre-existing hardcoded policies in production
 resource "aws_iam_role_policy_attachment" "legacy_gitlab_runner_pr_binary_mirror" {
   for_each = var.deployment_name == "prod" ? toset(["arn:aws:iam::588562868276:policy/DeleteObjectsFromBucketSpackBinariesPRs",


### PR DESCRIPTION
Requires #602 

This adds a script for converting a GitLab JWT to AWS temporary credentials. It also adds runner-side configuration for bootstrapping and running the script before every job executes (see https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runners-section). The URL for bootstrapping will change before merging to reference main.