### PR TITLE
Move cache indexer resources to spack module

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -41,7 +41,7 @@ jobs:
           - docker-image: ./images/snapshot-release-tags
             image-tags: ghcr.io/spack/snapshot-release-tags:0.0.2
           - docker-image: ./images/cache-indexer
-            image-tags: ghcr.io/spack/cache-indexer:0.0.1
+            image-tags: ghcr.io/spack/cache-indexer:0.0.2
           - docker-image: ./images/build-timing-processor
             image-tags: ghcr.io/spack/build-timing-processor:0.0.1
           - docker-image: ./analytics

--- a/images/cache-indexer/cache_indexer.py
+++ b/images/cache-indexer/cache_indexer.py
@@ -2,7 +2,7 @@
 
 import json
 import re
-import subprocess
+import os
 
 import boto3
 
@@ -70,14 +70,10 @@ def query_bucket(bucket_name):
 
 
 if __name__ == "__main__":
-    bucket_name = "spack-binaries"
+    bucket_name = os.environ["BUCKET_NAME"]
 
     results = query_bucket(bucket_name)
     json_data = build_json(bucket_name, results)
-
-    # with open("results.txt") as fd:
-    #     results = [l.strip() for l in fd]
-    # json_data = build_json(root_url, results)
 
     with open("output.json", "w") as fd:
         fd.write(json.dumps(json_data))

--- a/k8s/production/custom/cache-indexer/cron-jobs.yaml
+++ b/k8s/production/custom/cache-indexer/cron-jobs.yaml
@@ -14,7 +14,13 @@ spec:
           restartPolicy: Never
           containers:
           - name: index-binary-caches
-            image: ghcr.io/spack/cache-indexer:0.0.1
+            image: ghcr.io/spack/cache-indexer:0.0.2
             imagePullPolicy: IfNotPresent
+            env:
+              - name: BUCKET_NAME
+                valueFrom:
+                  configMapKeyRef:
+                    name: cache-indexer-config
+                    key: bucket_name
           nodeSelector:
             spack.io/node-pool: base

--- a/k8s/staging/custom/cache-indexer/kustomization.yaml
+++ b/k8s/staging/custom/cache-indexer/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../production/custom/cache-indexer/cron-jobs.yaml

--- a/terraform/modules/spack/cache_indexer.tf
+++ b/terraform/modules/spack/cache_indexer.tf
@@ -1,0 +1,83 @@
+locals {
+  suffix = var.deployment_name == "prod" ? "" : "-${var.deployment_name}"
+}
+
+# IAM Role for granting read access to spack-binaries and write access to the cache index
+data "aws_iam_policy_document" "cache_indexer_assume_role_policy" {
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.eks.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+  }
+}
+
+resource "aws_iam_role" "cache_indexer" {
+  name               = "CacheIndexer${local.suffix}"
+  assume_role_policy = data.aws_iam_policy_document.cache_indexer_assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "cache_indexer_policy" {
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+
+    resources = [
+      "${module.protected_binary_mirror.bucket_arn}/*",
+    ]
+  }
+
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["s3:PutObject", "s3:DeleteObject"]
+
+    resources = [
+      "${module.protected_binary_mirror.bucket_arn}/cache_spack_io_index.json",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "cache_indexer_policy" {
+  name   = "CacheIndexerPolicy${local.suffix}"
+  role   = aws_iam_role.cache_indexer.id
+  policy = data.aws_iam_policy_document.cache_indexer_policy.json
+}
+
+resource "kubectl_manifest" "cache_indexer_service_account" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: index-binary-caches
+      namespace: custom
+      annotations:
+        eks.amazonaws.com/role-arn: ${aws_iam_role.cache_indexer.arn}
+  YAML
+  depends_on = [
+    aws_iam_role_policy.cache_indexer_policy
+  ]
+}
+
+resource "kubectl_manifest" "cache_indexer_config_map" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cache-indexer-config
+      namespace: custom
+    data:
+      bucket_name: ${module.protected_binary_mirror.bucket_name}
+  YAML
+}


### PR DESCRIPTION
This moves us closer towards having staging/prod parity by moving the cache_indexer into the spack terraform module. It also parameterizes the cron job so it can run in both environments.