### PR TITLE
Increase gitlab max_yaml_size_limit

### DIFF
--- a/k8s/production/custom/gitlab-setting-updater/cronjobs.yaml
+++ b/k8s/production/custom/gitlab-setting-updater/cronjobs.yaml
@@ -37,7 +37,7 @@ spec:
                   "--",
                   "/srv/gitlab/bin/rails",
                   "runner",
-                  "ApplicationSetting.update(max_yaml_size_bytes: 10.megabytes)",
+                  "ApplicationSetting.update(max_yaml_size_bytes: 20.megabytes)",
                 ]
           nodeSelector:
             spack.io/node-pool: base


### PR DESCRIPTION
The size of the generated yaml for the E4S stack has grown beyond the current yaml size limit.  While we work on some optimization to decrease the size of the generated yaml, this PR makes sure we can still do a full rebuild of that stack.