### PR TITLE
Upgrade to Gitlab 16.3.2

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab
-      version: 7.3.0 # gitlab@16.3.0
+      version: 7.3.2 # gitlab@16.3.2
       sourceRef:
         kind: HelmRepository
         name: gitlab

--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-graviton2-prot
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 3
 

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-graviton3-prot
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 3
 

--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-graviton3-pcluster-prot
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 3
 

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-x86-v2-prot
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-x86-v3-prot
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-x86-v4-prot
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-graviton2-pub
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-graviton3-pub
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-graviton3-pcluster-pub
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 2
 

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-x86-v2-pub
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-x86-v3-pub
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-x86-v4-pub
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 6
 

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -24,9 +24,6 @@ spec:
         kind: HelmRepository
         name: runner-spack-package-signing
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.1.0
     imagePullPolicy: IfNotPresent
     replicas: 1
 


### PR DESCRIPTION
While performing this upgrade, we realized that the gitlab-runner helm chart images were pinned, which was causing the out-of-date runner versions we were seeing. 

@mvandenburgh According to the docs [here](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/blob/main/values.yaml?ref_type=heads#L3-4), the pin is unnecessary. Is that consistent with why the change was made in the first place?
