### PR TITLE
Deploy Sentry in staging

### DIFF
--- a/k8s/staging/sentry/namespace.yaml
+++ b/k8s/staging/sentry/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sentry

--- a/k8s/staging/sentry/release.yaml
+++ b/k8s/staging/sentry/release.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: sentry
+  namespace: sentry
+spec:
+  interval: 10m
+  url: https://sentry-kubernetes.github.io/charts
+
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: sentry
+  namespace: sentry
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: sentry
+      version: 20.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: sentry
+
+  values:
+    ingress:
+      enabled: true
+
+      annotations:
+        kubernetes.io/ingress.class: nginx
+
+      hostname: sentry.staging.spack.io
+
+      tls:
+      - secretName: tls-sentry
+        hosts: [sentry.staging.spack.io]


### PR DESCRIPTION
Deploys Sentry to staging using a `HelmRelease`. This doesn't instrument any code or add the `sentry-kubernetes` controller yet, it just gets an instance of Sentry running. Once all of that is sorted out, I'll move this into production and refactor this into a `Kustomization` manifest.