### PR TITLE
Add pre_build_script to remaining runner configurations

### DIFF
--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -42,6 +42,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          pre_build_script = """
+          echo 'Executing Spack pre-build setup script'
+
+          for cmd in "${PY3:-}" python3 python; do
+            if command -v > /dev/null "$cmd"; then
+              export PY3="$(command -v "$cmd")"
+              break
+            fi
+          done
+
+          if [ -z "${PY3:-}" ]; then
+            echo "Unable to find python3 executable"
+            exit 1
+          fi
+
+          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+          $PY3 pre_build.py > envvars
+
+          . ./envvars
+          rm -f envvars
+          unset GITLAB_OIDC_TOKEN
+          """
+
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -42,6 +42,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          pre_build_script = """
+          echo 'Executing Spack pre-build setup script'
+
+          for cmd in "${PY3:-}" python3 python; do
+            if command -v > /dev/null "$cmd"; then
+              export PY3="$(command -v "$cmd")"
+              break
+            fi
+          done
+
+          if [ -z "${PY3:-}" ]; then
+            echo "Unable to find python3 executable"
+            exit 1
+          fi
+
+          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+          $PY3 pre_build.py > envvars
+
+          . ./envvars
+          rm -f envvars
+          unset GITLAB_OIDC_TOKEN
+          """
+
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -42,6 +42,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          pre_build_script = """
+          echo 'Executing Spack pre-build setup script'
+
+          for cmd in "${PY3:-}" python3 python; do
+            if command -v > /dev/null "$cmd"; then
+              export PY3="$(command -v "$cmd")"
+              break
+            fi
+          done
+
+          if [ -z "${PY3:-}" ]; then
+            echo "Unable to find python3 executable"
+            exit 1
+          fi
+
+          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+          $PY3 pre_build.py > envvars
+
+          . ./envvars
+          rm -f envvars
+          unset GITLAB_OIDC_TOKEN
+          """
+
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -42,6 +42,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          pre_build_script = """
+          echo 'Executing Spack pre-build setup script'
+
+          for cmd in "${PY3:-}" python3 python; do
+            if command -v > /dev/null "$cmd"; then
+              export PY3="$(command -v "$cmd")"
+              break
+            fi
+          done
+
+          if [ -z "${PY3:-}" ]; then
+            echo "Unable to find python3 executable"
+            exit 1
+          fi
+
+          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+          $PY3 pre_build.py > envvars
+
+          . ./envvars
+          rm -f envvars
+          unset GITLAB_OIDC_TOKEN
+          """
+
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -42,6 +42,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          pre_build_script = """
+          echo 'Executing Spack pre-build setup script'
+
+          for cmd in "${PY3:-}" python3 python; do
+            if command -v > /dev/null "$cmd"; then
+              export PY3="$(command -v "$cmd")"
+              break
+            fi
+          done
+
+          if [ -z "${PY3:-}" ]; then
+            echo "Unable to find python3 executable"
+            exit 1
+          fi
+
+          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+          $PY3 pre_build.py > envvars
+
+          . ./envvars
+          rm -f envvars
+          unset GITLAB_OIDC_TOKEN
+          """
+
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -42,6 +42,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          pre_build_script = """
+          echo 'Executing Spack pre-build setup script'
+
+          for cmd in "${PY3:-}" python3 python; do
+            if command -v > /dev/null "$cmd"; then
+              export PY3="$(command -v "$cmd")"
+              break
+            fi
+          done
+
+          if [ -z "${PY3:-}" ]; then
+            echo "Unable to find python3 executable"
+            exit 1
+          fi
+
+          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+          $PY3 pre_build.py > envvars
+
+          . ./envvars
+          rm -f envvars
+          unset GITLAB_OIDC_TOKEN
+          """
+
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -42,6 +42,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          pre_build_script = """
+          echo 'Executing Spack pre-build setup script'
+
+          for cmd in "${PY3:-}" python3 python; do
+            if command -v > /dev/null "$cmd"; then
+              export PY3="$(command -v "$cmd")"
+              break
+            fi
+          done
+
+          if [ -z "${PY3:-}" ]; then
+            echo "Unable to find python3 executable"
+            exit 1
+          fi
+
+          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+          $PY3 pre_build.py > envvars
+
+          . ./envvars
+          rm -f envvars
+          unset GITLAB_OIDC_TOKEN
+          """
+
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -42,6 +42,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          pre_build_script = """
+          echo 'Executing Spack pre-build setup script'
+
+          for cmd in "${PY3:-}" python3 python; do
+            if command -v > /dev/null "$cmd"; then
+              export PY3="$(command -v "$cmd")"
+              break
+            fi
+          done
+
+          if [ -z "${PY3:-}" ]; then
+            echo "Unable to find python3 executable"
+            exit 1
+          fi
+
+          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+          $PY3 pre_build.py > envvars
+
+          . ./envvars
+          rm -f envvars
+          unset GITLAB_OIDC_TOKEN
+          """
+
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -44,6 +44,29 @@ spec:
     runners:
       config: |
         [[runners]]
+          pre_build_script = """
+          echo 'Executing Spack pre-build setup script'
+
+          for cmd in "${PY3:-}" python3 python; do
+            if command -v > /dev/null "$cmd"; then
+              export PY3="$(command -v "$cmd")"
+              break
+            fi
+          done
+
+          if [ -z "${PY3:-}" ]; then
+            echo "Unable to find python3 executable"
+            exit 1
+          fi
+
+          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+          $PY3 pre_build.py > envvars
+
+          . ./envvars
+          rm -f envvars
+          unset GITLAB_OIDC_TOKEN
+          """
+
           output_limit = 10240
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]


### PR DESCRIPTION
@scottwittenburg I'm seeing PR builds succeed now. Example: `ctrl-f` for `pre-build` on the raw log of https://gitlab.spack.io/spack/spack/-/jobs/8215737.