### PR TITLE
add additional job labels to all build job pods

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -145,6 +145,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
 
             [[runners.kubernetes.volumes.secret]]

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -130,6 +130,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
 
             [[runners.kubernetes.volumes.secret]]

--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -117,6 +117,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "spack.io/node-pool" = "pcluster-amzn2-glr-graviton3"

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -149,6 +149,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
 
             [[runners.kubernetes.volumes.secret]]

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -143,6 +143,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
 
             [[runners.kubernetes.volumes.secret]]

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -129,6 +129,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
 
             [[runners.kubernetes.volumes.secret]]

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -145,6 +145,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
 
       # default image

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -130,6 +130,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
 
       # default image

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -118,6 +118,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "spack.io/node-pool" = "pcluster-amzn2-glr-graviton3"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -150,6 +150,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
 
       # default image

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -143,6 +143,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
 
       # default image

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -129,6 +129,11 @@ spec:
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
               "metrics/spack_job_spec_pkg_name" = "$SPACK_JOB_SPEC_PKG_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
 
       # default image

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -151,11 +151,6 @@ spec:
               "metrics/gitlab_ci_project_name" = "$CI_PROJECT_NAME"
               "metrics/gitlab_ci_job_stage" = "$CI_JOB_STAGE"
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
-              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
-              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
-              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
-              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
-              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "amd64"

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -151,6 +151,11 @@ spec:
               "metrics/gitlab_ci_project_name" = "$CI_PROJECT_NAME"
               "metrics/gitlab_ci_job_stage" = "$CI_JOB_STAGE"
               "metrics/gitlab_ci_commit_ref_name" = "$CI_COMMIT_REF_NAME"
+              "metrics/spack_job_spec_pkg_version" = "$SPACK_JOB_SPEC_PKG_VERSION"
+              "metrics/spack_job_spec_compiler_name" = "$SPACK_JOB_SPEC_COMPILER_NAME"
+              "metrics/spack_job_spec_compiler_version" = "$SPACK_JOB_SPEC_COMPILER_VERSION"
+              "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
+              "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.node_selector]
               "kubernetes.io/arch" = "amd64"


### PR DESCRIPTION
This change adds the following information to the job metadata:
- package version
- compiler name
- compiler version
- arch
- package variants

These labels were added to the environment in https://github.com/spack/spack/pull/39905 (pending merge).

let me know if i'm missing anything

cc: @alecbcs @scottwittenburg 