### PR TITLE
Upgrade to GitLab 16.3.4

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab
-      version: 7.3.2 # gitlab@16.3.2
+      version: 7.3.4 # gitlab@16.3.4
       sourceRef:
         kind: HelmRepository
         name: gitlab


### PR DESCRIPTION
This will resolve the security warning that gets displayed on gitlab.spack.io.