### PR TITLE
gitlab-error-processor: Process successful jobs as well as failures

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -36,9 +36,9 @@ jobs:
           - docker-image: ./images/opensearch-index-build-logs
             image-tags: ghcr.io/spack/opensearch-index-build-logs:0.0.4
           - docker-image: ./images/gitlab-error-processor
-            image-tags: ghcr.io/spack/gitlab-error-processor:0.0.1
+            image-tags: ghcr.io/spack/gitlab-error-processor:0.0.2
           - docker-image: ./images/upload-gitlab-failure-logs
-            image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.1
+            image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.2
           - docker-image: ./images/snapshot-release-tags
             image-tags: ghcr.io/spack/snapshot-release-tags:0.0.2
           - docker-image: ./images/cache-indexer

--- a/images/gitlab-error-processor/app.py
+++ b/images/gitlab-error-processor/app.py
@@ -23,9 +23,6 @@ async def gitlab_webhook_consumer(request: Request):
     if job_input_data.get("object_kind", "") != "build":
         raise HTTPException(status_code=400, detail="Invalid request")
 
-    if job_input_data["build_status"] != "failed":
-        return Response("Not a failed job, no action needed.", status_code=200)
-
     with open(Path(__file__).parent / "job-template.yaml") as f:
         job_template = yaml.safe_load(f)
 

--- a/images/gitlab-error-processor/job-template.yaml
+++ b/images/gitlab-error-processor/job-template.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: gitlab-error-processing-job
-        image: ghcr.io/spack/upload-gitlab-failure-logs:0.0.1
+        image: ghcr.io/spack/upload-gitlab-failure-logs:0.0.2
         imagePullPolicy: Always
         env:
           - name: GITLAB_TOKEN
@@ -39,7 +39,7 @@ spec:
               secretKeyRef:
                 name: gitlab-error-processor
                 key: postgresql-gitlab-ro-user-password
-          
+
           # opensearch credentials
           - name: OPENSEARCH_ENDPOINT
             valueFrom:

--- a/k8s/production/custom/gitlab-error-processor/deployments.yaml
+++ b/k8s/production/custom/gitlab-error-processor/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: gitlab-error-processor
       containers:
       - name: gitlab-error-processor
-        image: ghcr.io/spack/gitlab-error-processor:0.0.1
+        image: ghcr.io/spack/gitlab-error-processor:0.0.2
         imagePullPolicy: Always
         resources:
           requests:


### PR DESCRIPTION
Trigger the upload_failure_logs module on successes as well as failures, allowing it to notice and upload records about jobs that were incorrectly scheduled, i.e. jobs which ultimately found there was nothing to rebuild.