### PR TITLE
Fix selectors for prometheus in staging kustomization

### DIFF
--- a/k8s/staging/prometheus/kustomization.yaml
+++ b/k8s/staging/prometheus/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 patches:
   - target:
       kind: Certificate
-      name: tls-prometheus-webservice
+      name: prometheus
       namespace: monitoring
     patch: |-
       - op: replace
@@ -19,7 +19,7 @@ patches:
 
   - target:
       kind: Certificate
-      name: tls-grafana-webservice
+      name: grafana
       namespace: monitoring
     patch: |-
       - op: replace
@@ -28,7 +28,7 @@ patches:
 
   - target:
       kind: Certificate
-      name: tls-alertmanager-webservice
+      name: alertmanager
       namespace: monitoring
     patch: |-
       - op: replace


### PR DESCRIPTION
This explains why https://grafana.staging.spack.io/ (and related URLs) return an invalid cert error.