### PR TITLE
Increase `maxReplicas` for ingress-nginx controller

### DIFF
--- a/k8s/production/ingress-nginx/release.yaml
+++ b/k8s/production/ingress-nginx/release.yaml
@@ -51,7 +51,7 @@ spec:
       autoscaling:
         enabled: true
         minReplicas: 1
-        maxReplicas: 40
+        maxReplicas: 80
         targetCPUUtilizationPercentage: 50
         targetMemoryUtilizationPercentage: 50
 


### PR DESCRIPTION
The nginx autoscaler is still scaling up the max number of pods, even after #640 and #641, so this PR doubles it again. After this is merged, we should keep an eye on the "NGINX Ingress Controller" grafana dashboard to see what effect it has.