### PR TITLE
Increase memory request for nginx pods

### DIFF
--- a/k8s/production/ingress-nginx/release.yaml
+++ b/k8s/production/ingress-nginx/release.yaml
@@ -45,6 +45,10 @@ spec:
       nodeSelector:
         spack.io/node-pool: beefy
 
+      resources:
+        requests:
+          memory: 1Gi  # Request one gigabyte of memory
+
       replicaCount: 1
       minAvailable: 1
 


### PR DESCRIPTION
Increases the memory request for nginx from 100 MB to 1 GB.