### PR TITLE
Set CPU requests for nginx pods

### DIFF
--- a/k8s/production/ingress-nginx/release.yaml
+++ b/k8s/production/ingress-nginx/release.yaml
@@ -47,6 +47,7 @@ spec:
 
       resources:
         requests:
+          cpu: 500m  # request 0.5 CPU cores
           memory: 1Gi  # Request one gigabyte of memory
 
       replicaCount: 1


### PR DESCRIPTION
This raises the nginx CPU request from the default 0.1 cores to 0.5 cores. According to grafana, nginx uses between 0.2 - 0.5 cores generally.