### PR TITLE
Add retries to pre_build.py

### DIFF
--- a/scripts/gitlab_runner_pre_build/pre_build.py
+++ b/scripts/gitlab_runner_pre_build/pre_build.py
@@ -6,7 +6,7 @@ sourced by the gitlab runner in its pre_build configuration option.
 In the case of a PR build, the temporary credentials are scoped down to only allow access to the
 S3 bucket prefix for the relevant PR.
 """
-import os, sys, json, base64
+import os, sys, json, base64, time
 import urllib.request, urllib.parse, urllib.error
 
 TEMPORARY_CREDENTIALS_DURATION = 3600 * 6  # 6 hours
@@ -48,6 +48,42 @@ def _token_to_sts_request(raw_jwt, decoded_jwt):
     return assume_role_kwargs
 
 
+def _durable_assume_role_request(assume_role_kwargs):
+    attempts = 0
+    max_attempts = 6
+
+    while attempts < max_attempts:
+        try:
+            req = urllib.request.Request(
+                "https://sts.amazonaws.com/?Action=AssumeRoleWithWebIdentity&Version=2011-06-15&"
+                + urllib.parse.urlencode(assume_role_kwargs),
+                headers={"Accept": "application/json"},
+            )
+
+            with urllib.request.urlopen(req) as response:
+                if response.getcode() == 200:
+                    response = json.loads(response.read().decode("utf-8"))
+                    return response
+                else:
+                    raise ValueError(
+                        f"Unexpected response code from assume role request: {response.getcode()}"
+                    )
+        except urllib.error.HTTPError as e:
+            print(e.read().decode("utf-8"), file=sys.stderr)
+
+            if e.code == 400:
+                attempts += 1
+                print(
+                    f"Assume role request failed with 400, retrying ({attempts}/{max_attempts})",
+                    file=sys.stderr,
+                )
+                time.sleep(2 ** (1 + attempts))
+            else:
+                raise e
+
+    raise Exception(f"Failed to assume role after {max_attempts} attempts")
+
+
 def _gitlab_token_to_credentials(gitlab_token):
     token = gitlab_token.split(".")[1]
     token += "=" * ((4 - len(token) % 4) % 4)
@@ -56,21 +92,12 @@ def _gitlab_token_to_credentials(gitlab_token):
     assume_role_kwargs = _token_to_sts_request(gitlab_token, token)
 
     print(
-        f"Assuming role {assume_role_kwargs['RoleArn']} with session name {assume_role_kwargs['RoleSessionName']}",
+        f"Assuming role {assume_role_kwargs['RoleArn']} with session name {assume_role_kwargs['RoleSessionName']}... ",
         file=sys.stderr,
+        end="",
     )
 
-    try:
-        req = urllib.request.Request(
-            "https://sts.amazonaws.com/?Action=AssumeRoleWithWebIdentity&Version=2011-06-15&"
-            + urllib.parse.urlencode(assume_role_kwargs),
-            headers={"Accept": "application/json"},
-        )
-        with urllib.request.urlopen(req) as response:
-            response = json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as e:
-        print(e.read().decode("utf-8"), file=sys.stderr)
-        raise e
+    response = _durable_assume_role_request(assume_role_kwargs)
 
     return response["AssumeRoleWithWebIdentityResponse"][
         "AssumeRoleWithWebIdentityResult"
@@ -88,3 +115,5 @@ if __name__ == "__main__":
     print(f'export AWS_ACCESS_KEY_ID="{response["AccessKeyId"]}"')
     print(f'export AWS_SECRET_ACCESS_KEY="{response["SecretAccessKey"]}"')
     print(f'export AWS_SESSION_TOKEN="{response["SessionToken"]}"')
+
+    print("done.", file=sys.stderr)


### PR DESCRIPTION
This adds retries to the OIDC assume role script in the event that a transient error occurs, or worse, gitlab.spack.io is down momentarily while AWS is fetching the identity information.

@scottwittenburg PTAL. In particular, I'm not sure how long we should be sleeping and retrying.