### PR TITLE
Run gitaly by itself on a m5.4xlarge instance (take 2)

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -175,9 +175,13 @@ spec:
             app: "gitaly"
 
       gitaly:
+        resources:
+          requests:
+            cpu: 15000m
+            memory: 58Gi
         nodeSelector:
           spack.io/node-pool: gitlab
-          node.kubernetes.io/instance-type: m5.xlarge
+          node.kubernetes.io/instance-type: m5.4xlarge
 
       migrations:
         nodeSelector:

--- a/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
@@ -14,7 +14,7 @@ spec:
   requirements:
     - key: "node.kubernetes.io/instance-type"
       operator: In
-      values: ["t3.xlarge", "m5.xlarge"]
+      values: ["t3.xlarge", "m5.xlarge", "m5.4xlarge"]
 
     # Always use on-demand
     - key: "karpenter.sh/capacity-type"


### PR DESCRIPTION
Resource request values came from here:

https://karpenter.sh/docs/concepts/instance-types/#m54xlarge

They were selected so that gitaly would get the whole m5.4xlarge node to itself.

Note that karpenter is telling us that our daemonsets add approximately 5 GB RAM in overhead.