### PR TITLE
Add missing public runners to staging

### DIFF
--- a/k8s/staging/runners/kustomization.yaml
+++ b/k8s/staging/runners/kustomization.yaml
@@ -5,8 +5,11 @@ resources:
 - ../../production/runners/service-accounts.yaml
 - ../../production/runners/namespace.yaml
 - ../../production/runners/public/graviton/2/release.yaml
+- ../../production/runners/public/graviton/3/release.yaml
 - ../../production/runners/public/pcluster/graviton/3/release.yaml
 - ../../production/runners/public/x86_64/v2/release.yaml
+- ../../production/runners/public/x86_64/v3/release.yaml
+- ../../production/runners/public/x86_64/v4/release.yaml
 
 patchesStrategicMerge:
   - rm-secrets.yaml
@@ -36,7 +39,34 @@ patches:
 
   - target:
       kind: HelmRelease
+      name: runner-graviton3-pub
+      namespace: gitlab
+    patch: |-
+      - op: replace
+        path: /spec/values/gitlabUrl
+        value: https://gitlab.staging.spack.io/
+
+  - target:
+      kind: HelmRelease
       name: runner-x86-v2-pub
+      namespace: gitlab
+    patch: |-
+      - op: replace
+        path: /spec/values/gitlabUrl
+        value: https://gitlab.staging.spack.io/
+
+  - target:
+      kind: HelmRelease
+      name: runner-x86-v3-pub
+      namespace: gitlab
+    patch: |-
+      - op: replace
+        path: /spec/values/gitlabUrl
+        value: https://gitlab.staging.spack.io/
+
+  - target:
+      kind: HelmRelease
+      name: runner-x86-v4-pub
       namespace: gitlab
     patch: |-
       - op: replace


### PR DESCRIPTION
Currently, we only include a subset of our AWS runners in our staging gitlab setup. This PR adds the rest of the public runners to staging to bring it closer to parity with production.