### PR TITLE
Add sentry_dsn for gitlab runners

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-graviton2-prot
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 3

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-prot
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 3

--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-pcluster-prot
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 3

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-prot
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v3-prot
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v4-prot
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-graviton2-pub
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-pub
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-pcluster-pub
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 2

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-pub
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v3-pub
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v4-pub
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -23,6 +23,13 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-spack-package-signing
+
+  valuesFrom:
+    # See terraform/modules/sentry/sentry.tf
+    - kind: ConfigMap
+      name: gitlab-runner-sentry-config
+      valuesKey: values.yaml
+
   values:
     imagePullPolicy: IfNotPresent
     replicas: 1

--- a/terraform/modules/spack/sentry.tf
+++ b/terraform/modules/spack/sentry.tf
@@ -239,3 +239,21 @@ resource "sentry_project" "gitlab_runner" {
 
   platform = "go"
 }
+
+data "sentry_key" "gitlab_runner" {
+  organization = data.sentry_organization.default.id
+  project      = sentry_project.gitlab_runner.id
+}
+
+resource "kubectl_manifest" "gitlab_runner_sentry_config_map" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: gitlab-runner-sentry-config
+      namespace: gitlab
+    data:
+      values.yaml: |
+        sentryDsn: ${data.sentry_key.gitlab_runner.dsn_public}
+  YAML
+}


### PR DESCRIPTION
This should catch any system errors on gitlab runners in sentry. @mvandenburgh It turns out this is a global config, not in the runners toml, so we can use a config map for it.