### PR TITLE
Enable Prometheus metrics for Gitaly

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -182,6 +182,8 @@ spec:
         nodeSelector:
           spack.io/node-pool: gitlab
           node.kubernetes.io/instance-type: m5.4xlarge
+        metrics:
+          enabled: true
 
       migrations:
         nodeSelector:


### PR DESCRIPTION
I tested this on staging and confirmed that (1) this exposes metrics at the expected endpoint, and (2) the gitaly/gitlab helm chart adds the correct annotations to the gitaly pod for prometheus to auto discover it as a scrape target.