### PR TITLE
Allow Prometheus to scrape ServiceMonitors in any namespace, enable ServiceMonitor for gitaly

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -184,6 +184,8 @@ spec:
           node.kubernetes.io/instance-type: m5.4xlarge
         metrics:
           enabled: true
+          serviceMonitor:
+            enabled: true
 
       migrations:
         nodeSelector:

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -112,6 +112,14 @@ spec:
           requests:
             cpu: 2000m
             memory: 50G
+
+        # These three values allow prometheus to pick up ServiceMonitors from *any* namespace,
+        # not just the "monitoring" namespace.
+        serviceMonitorNamespaceSelector:
+          any: true
+        serviceMonitorSelector: {}
+        serviceMonitorSelectorNilUsesHelmValues: false
+
         additionalScrapeConfigs:
           - job_name: "gitlab-metrics"
             metrics_path: "/-/metrics"


### PR DESCRIPTION
Prometheus is supposed to discover and scrape service monitors automatically, but it only looks in the namespace it's deployed in by default. This configures it to search all namespaces in the cluster. The `kube-prometheus-stack` docs didn't go into detail on this, but [this issue](https://github.com/prometheus-community/helm-charts/issues/106#issuecomment-700847774) helped me get this working.

After merging #663 , I noticed it didn't work in production. When I was messing around in staging, I manually configured gitaly in the `additionalScrapeConfigs` block in the prometheus helm release before trying to figure out the auto-discovery thing. I think what happened is that it was still falling back on the `additionalScrapeConfigs` even after I removed it, and I wrongly assumed it was working. 

