### PR TITLE
Add CloudFront distributions for binary mirrors

### DIFF
--- a/terraform/modules/spack/binary_mirrors.tf
+++ b/terraform/modules/spack/binary_mirrors.tf
@@ -3,6 +3,32 @@ locals {
   binary_mirror_name_suffix = var.deployment_name == "prod" ? "" : "-${var.deployment_name}"
 }
 
+# This is a cache policy that gets used by both binary mirror CDNs.
+resource "aws_cloudfront_cache_policy" "min_ttl_zero" {
+  name        = "CachingAllowNoCache${local.binary_mirror_name_suffix}"
+  comment     = "Same as Managed - Caching Optimized, but min TTL=0"
+  default_ttl = 86400
+  max_ttl     = 31536000
+  min_ttl     = 0
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+
+    headers_config {
+      header_behavior = "none"
+    }
+
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+
+    enable_accept_encoding_gzip   = true
+    enable_accept_encoding_brotli = true
+  }
+}
+
 module "pr_binary_mirror" {
   source = "./modules/binary_mirror"
 
@@ -11,6 +37,9 @@ module "pr_binary_mirror" {
 
   enable_logging      = true
   logging_bucket_name = "spack-logs${local.binary_mirror_name_suffix}"
+
+  cdn_domain      = "binaries-prs.${var.deployment_name == "prod" ? "" : "${var.deployment_name}."}spack.io"
+  cache_policy_id = aws_cloudfront_cache_policy.min_ttl_zero.id
 }
 
 module "protected_binary_mirror" {
@@ -20,6 +49,9 @@ module "protected_binary_mirror" {
   bucket_name         = "spack-binaries${local.binary_mirror_name_suffix}"
 
   enable_logging = false
+
+  cdn_domain      = "binaries.${var.deployment_name == "prod" ? "" : "${var.deployment_name}."}spack.io"
+  cache_policy_id = aws_cloudfront_cache_policy.min_ttl_zero.id
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "pr_binary_mirror" {

--- a/terraform/modules/spack/modules/binary_mirror/cloudfront.tf
+++ b/terraform/modules/spack/modules/binary_mirror/cloudfront.tf
@@ -1,0 +1,89 @@
+data "aws_route53_zone" "spack_io" {
+  name         = "spack.io"
+  private_zone = false
+}
+
+# ACM Certificates created for CloudFront distributions must be in us-east-1
+# See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html#https-requirements-certificate-issuer
+provider "aws" {
+  alias  = "acm"
+  region = "us-east-1"
+}
+
+resource "aws_acm_certificate" "binary_mirror" {
+  domain_name       = var.cdn_domain
+  validation_method = "DNS"
+
+  provider = aws.acm
+}
+
+resource "aws_route53_record" "acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.binary_mirror.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  name    = each.value.name
+  records = [each.value.record]
+  ttl     = 300
+  type    = each.value.type
+  zone_id = data.aws_route53_zone.spack_io.zone_id
+}
+
+resource "aws_acm_certificate_validation" "binary_mirror" {
+  certificate_arn         = aws_acm_certificate.binary_mirror.arn
+  validation_record_fqdns = [for record in aws_route53_record.acm_validation : record.fqdn]
+
+  provider = aws.acm
+}
+
+resource "aws_route53_record" "binary_mirror" {
+  zone_id = data.aws_route53_zone.spack_io.zone_id
+  name    = var.cdn_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.binary_mirror.domain_name
+    zone_id                = aws_cloudfront_distribution.binary_mirror.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_cloudfront_distribution" "binary_mirror" {
+  enabled = true
+
+  aliases = [var.cdn_domain]
+
+  is_ipv6_enabled = true
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cache_policy_id        = var.cache_policy_id
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    target_origin_id       = aws_s3_bucket.binary_mirror.bucket_regional_domain_name
+    viewer_protocol_policy = "https-only"
+  }
+
+  origin {
+    domain_name = aws_s3_bucket.binary_mirror.bucket_regional_domain_name
+    origin_id   = aws_s3_bucket.binary_mirror.bucket_regional_domain_name
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.binary_mirror.arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
+  }
+
+  wait_for_deployment = true
+}

--- a/terraform/modules/spack/modules/binary_mirror/variables.tf
+++ b/terraform/modules/spack/modules/binary_mirror/variables.tf
@@ -18,3 +18,13 @@ variable "logging_bucket_name" {
   type        = string
   default     = null
 }
+
+variable "cdn_domain" {
+  description = "The domain name of the CDN that points to the bucket."
+  type        = string
+}
+
+variable "cache_policy_id" {
+  description = "The ID of the cache policy to use for this bucket."
+  type        = string
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -31,11 +31,11 @@ terraform {
       version = "~> 5.13.0"
     }
     gitlab = {
-      source = "gitlabhq/gitlab"
+      source  = "gitlabhq/gitlab"
       version = "16.3.0"
     }
     sentry = {
-      source = "jianyuan/sentry"
+      source  = "jianyuan/sentry"
       version = "0.11.2"
     }
   }
@@ -114,7 +114,7 @@ locals {
 
 provider "gitlab" {
   base_url = local.gitlab_url
-  token = jsondecode(data.aws_secretsmanager_secret_version.gitlab_token.secret_string).gitlab_terraform_provider_access_token
+  token    = jsondecode(data.aws_secretsmanager_secret_version.gitlab_token.secret_string).gitlab_terraform_provider_access_token
 }
 
 module "production_cluster" {
@@ -159,4 +159,49 @@ module "production_cluster" {
   provision_opensearch_cluster = true
 
   ses_email_domain = "spack.io"
+}
+
+import {
+  to = module.production_cluster.aws_cloudfront_cache_policy.min_ttl_zero
+  id = "81c0f2a0-054d-433c-8331-af5bd0999d1e"
+}
+
+import {
+  to = module.production_cluster.module.pr_binary_mirror.aws_cloudfront_distribution.binary_mirror
+  id = "E3DYSQ5D87PXM6"
+}
+
+import {
+  to = module.production_cluster.module.protected_binary_mirror.aws_cloudfront_distribution.binary_mirror
+  id = "E226DDMH1YK40I"
+}
+
+import {
+  to = module.production_cluster.module.protected_binary_mirror.aws_acm_certificate.binary_mirror
+  id = "arn:aws:acm:us-east-1:588562868276:certificate/789b7d28-3c2d-455f-8e4e-3436c9f63e91"
+}
+
+import {
+  to = module.production_cluster.module.pr_binary_mirror.aws_acm_certificate.binary_mirror
+  id = "arn:aws:acm:us-east-1:588562868276:certificate/8b4daf8a-23c8-493a-88e6-a8af4567c1f7"
+}
+
+import {
+  to = module.production_cluster.module.pr_binary_mirror.aws_route53_record.acm_validation["binaries-prs.spack.io"]
+  id = "Z10308771IP3CUGATOPMY__e18450e3136396809b710e47cc969cf5.binaries-prs.spack.io_CNAME"
+}
+
+import {
+  to = module.production_cluster.module.protected_binary_mirror.aws_route53_record.acm_validation["binaries.spack.io"]
+  id = "Z10308771IP3CUGATOPMY__8239b041bf4676156a63bce18737c2f3.binaries.spack.io_CNAME"
+}
+
+import {
+  to = module.production_cluster.module.protected_binary_mirror.aws_route53_record.binary_mirror
+  id = "Z10308771IP3CUGATOPMY_binaries.spack.io_A"
+}
+
+import {
+  to = module.production_cluster.module.pr_binary_mirror.aws_route53_record.binary_mirror
+  id = "Z10308771IP3CUGATOPMY_binaries-prs.spack.io_A"
 }


### PR DESCRIPTION
This codifies the state of the cloudfront deployment on production now. The diff against production has a couple of rough patches, so applying this will have to be done carefully.

@mvandenburgh FYI:
1. ACM certs for CF have to be created in us-east-1
2. The cache policy can't be encapsulated in the binary mirror module since it has to be used by both instances