### PR TITLE
Re-order resources in gitlab pod-cleanup

### DIFF
--- a/k8s/production/gitlab/pod-cleanup.yaml
+++ b/k8s/production/gitlab/pod-cleanup.yaml
@@ -1,3 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-cleanup-sa
+  namespace: gitlab
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -19,12 +25,6 @@ subjects:
   - kind: ServiceAccount
     name: pod-cleanup-sa
     namespace: gitlab
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: pod-cleanup-sa
-  namespace: gitlab
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Flux is failing to apply the added resources from #660, seemingly due to the order of listed resources.