### PR TITLE
Encode Grafana build timing dashboard in k8s

### DIFF
--- a/k8s/production/prometheus/custom/build-timing-dashboard.yaml
+++ b/k8s/production/prometheus/custom/build-timing-dashboard.yaml
@@ -584,7 +584,7 @@ data:
           },
           "gridPos": {
             "h": 11,
-            "w": 17,
+            "w": 18,
             "x": 0,
             "y": 22
           },
@@ -650,152 +650,6 @@ data:
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "fixed"
-              },
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              },
-              "mappings": []
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "pr11_ci-refactor-mirror-usage-uo-s3"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "yellow",
-                      "mode": "fixed"
-                    }
-                  },
-                  {
-                    "id": "displayName",
-                    "value": "UO/S3"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "pr12_ci-refactor-mirror-usage-uo-https"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "green",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "pr21_ci-refactor-mirror-usage-aws-s3"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "blue",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "pr22_ci-refactor-mirror-usage-aws-https"
-                },
-                "properties": [
-                  {
-                    "id": "color",
-                    "value": {
-                      "fixedColor": "purple",
-                      "mode": "fixed"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 16,
-            "w": 7,
-            "x": 17,
-            "y": 22
-          },
-          "id": 9,
-          "options": {
-            "displayLabels": [],
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "pieType": "pie",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "postgres",
-                "uid": "XCh6DDkSz"
-              },
-              "editorMode": "code",
-              "format": "table",
-              "rawQuery": true,
-              "rawSql": "SELECT SUM(\"public\".\"analytics_timerphase\".\"seconds\") / (COUNT(*) * 1.0) AS \"seconds\", \"public\".\"analytics_job\".\"ref\" as \"ref_name\"\nFROM \"public\".\"analytics_timerphase\"\nJOIN \"public\".\"analytics_timer\" ON \"public\".\"analytics_timerphase\".\"timer_id\" = \"public\".\"analytics_timer\".\"id\"\nJOIN \"public\".\"analytics_job\" ON \"public\".\"analytics_timer\".\"job_id\" = \"public\".\"analytics_job\".\"job_id\"\nWHERE\n  \"public\".\"analytics_timer\".\"cache\" IS true\n  AND \"public\".\"analytics_timerphase\".\"name\" LIKE 'fetch'\n  -- AND \"public\".\"analytics_job\".\"project_id\" = 23\n  AND \"public\".\"analytics_job\".\"ref\" LIKE '%ci-refactor-mirror-usage%'\nGROUP BY \"ref_name\"",
-              "refId": "A",
-              "sql": {
-                "columns": [
-                  {
-                    "parameters": [],
-                    "type": "function"
-                  }
-                ],
-                "groupBy": [
-                  {
-                    "property": {
-                      "type": "string"
-                    },
-                    "type": "groupBy"
-                  }
-                ],
-                "limit": 50
-              }
-            }
-          ],
-          "title": "Fetch from cache times (summary)",
-          "type": "piechart"
-        },
-        {
-          "datasource": {
-            "type": "postgres",
-            "uid": "XCh6DDkSz"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
                 "mode": "palette-classic"
               },
               "custom": {
@@ -818,29 +672,7 @@ data:
                   "mode": "off"
                 }
               },
-              "mappings": [
-                {
-                  "options": {
-                    "pr11_ci-refactor-mirror-usage-uo-s3": {
-                      "color": "yellow",
-                      "index": 0
-                    },
-                    "pr12_ci-refactor-mirror-usage-uo-https": {
-                      "color": "green",
-                      "index": 1
-                    },
-                    "pr21_ci-refactor-mirror-usage-aws-s3": {
-                      "color": "blue",
-                      "index": 2
-                    },
-                    "pr22_ci-refactor-mirror-usage-aws-https": {
-                      "color": "purple",
-                      "index": 3
-                    }
-                  },
-                  "type": "value"
-                }
-              ],
+              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -855,8 +687,8 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 16,
-            "w": 17,
+            "h": 11,
+            "w": 18,
             "x": 0,
             "y": 33
           },
@@ -864,13 +696,12 @@ data:
           "options": {
             "barRadius": 0,
             "barWidth": 0.97,
-            "colorByField": "ref",
             "groupWidth": 0.7,
             "legend": {
               "calcs": [],
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "orientation": "auto",
             "showValue": "auto",
@@ -894,7 +725,7 @@ data:
               "editorMode": "code",
               "format": "table",
               "rawQuery": true,
-              "rawSql": "SELECT AVG(\"public\".\"analytics_timerphase\".\"seconds\") AS \"avg time\", COUNT(*) as \"count\", \"public\".\"analytics_timer\".\"name\" as \"package\", \"public\".\"analytics_job\".\"ref\" as \"ref\"\nFROM \"public\".\"analytics_timerphase\"\nJOIN \"public\".\"analytics_timer\" ON \"public\".\"analytics_timerphase\".\"timer_id\" = \"public\".\"analytics_timer\".\"id\"\nJOIN \"public\".\"analytics_job\" ON \"public\".\"analytics_timer\".\"job_id\" = \"public\".\"analytics_job\".\"job_id\"\nWHERE\n  \"public\".\"analytics_timer\".\"cache\" IS true\n  AND \"public\".\"analytics_timerphase\".\"name\" LIKE 'fetch'\n  -- AND \"public\".\"analytics_job\".\"project_id\" = 23\n  AND \"public\".\"analytics_job\".\"ref\" LIKE '%ci-refactor-mirror-usage%'\nGROUP BY \"public\".\"analytics_timer\".\"name\", \"ref\"\nORDER BY \"avg time\" DESC\nLIMIT 20\n;",
+              "rawSql": "SELECT AVG(\"public\".\"analytics_timerphase\".\"seconds\") AS \"avg time\", \"public\".\"analytics_timer\".\"name\" as \"package\"\nFROM \"public\".\"analytics_timerphase\"\nJOIN \"public\".\"analytics_timer\" ON \"public\".\"analytics_timerphase\".\"timer_id\" = \"public\".\"analytics_timer\".\"id\"\nJOIN \"public\".\"analytics_job\" ON \"public\".\"analytics_timer\".\"job_id\" = \"public\".\"analytics_job\".\"job_id\"\nWHERE\n  \"public\".\"analytics_timer\".\"cache\" IS true\n  AND \"public\".\"analytics_timerphase\".\"name\" LIKE 'fetch'\n  AND \"public\".\"analytics_job\".\"project_id\" = 2\nGROUP BY \"public\".\"analytics_timer\".\"name\"\nORDER BY \"avg time\" DESC\nLIMIT 20\n;",
               "refId": "A",
               "sql": {
                 "columns": [
@@ -927,13 +758,13 @@ data:
         "list": []
       },
       "time": {
-        "from": "now-30d",
+        "from": "now-7d",
         "to": "now"
       },
       "timepicker": {},
       "timezone": "",
       "title": "Build Timing Dashboard",
       "uid": "XaY45DkIk",
-      "version": 8,
+      "version": 10,
       "weekStart": ""
     }

--- a/k8s/production/prometheus/custom/build-timing-dashboard.yaml
+++ b/k8s/production/prometheus/custom/build-timing-dashboard.yaml
@@ -1,0 +1,939 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: monitoring
+  name: kube-prometheus-stack-build-timing-dashboard
+  labels:
+    grafana_dashboard: "1"
+    app: kube-prometheus-stack-grafana
+    release: "kube-prometheus-stack"
+data:
+  build-timing-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 36,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 15,
+          "panels": [],
+          "title": "Phase Timings",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "XCh6DDkSz"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisWidth": 0,
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "stages_total"
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 18,
+            "x": 0,
+            "y": 1
+          },
+          "id": 17,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "orientation": "auto",
+            "showValue": "never",
+            "stacking": "normal",
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "xTickLabelRotation": -15,
+            "xTickLabelSpacing": 0
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "postgres",
+                "uid": "XCh6DDkSz"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "WITH T as (\n    SELECT\n        analytics_job.package_name as package_name,\n        analytics_timerphase.name as name,\n        SUM(analytics_timerphase.seconds) as total\n    FROM analytics_timerphase\n    LEFT JOIN analytics_timer ON analytics_timerphase.timer_id = analytics_timer.id\n    LEFT JOIN analytics_job ON analytics_timer.job_id = analytics_job.job_id\n    WHERE\n        $__timeFilter(analytics_job.started_at)\n        AND analytics_timer.cache IS FALSE\n    GROUP BY\n        analytics_job.package_name,\n        analytics_timerphase.name\n    ORDER BY analytics_job.package_name\n)\n\nSELECT\n    package_name,\n    SUM(total) filter (WHERE T.name = 'autoreconf') as autoreconf,\n    SUM(total) filter (WHERE T.name = 'bootstrap') as bootstrap,\n    SUM(total) filter (WHERE T.name = 'build') as build,\n    SUM(total) filter (WHERE T.name = 'cmake') as cmake,\n    SUM(total) filter (WHERE T.name = 'configure') as configure,\n    SUM(total) filter (WHERE T.name = 'edit') as edit,\n    SUM(total) filter (WHERE T.name = 'generate_luarocks_config') as generate_luarocks_config,\n    SUM(total) filter (WHERE T.name = 'hostconfig') as hostconfig,\n    SUM(total) filter (WHERE T.name = 'initconfig') as initconfig,\n    SUM(total) filter (WHERE T.name = 'install') as install,\n    SUM(total) filter (WHERE T.name = 'meson') as meson,\n    SUM(total) filter (WHERE T.name = 'post-install') as post_install,\n    SUM(total) filter (WHERE T.name = 'preprocess') as preprocess,\n    SUM(total) filter (WHERE T.name = 'qmake') as qmake,\n    SUM(total) filter (WHERE T.name = 'stage') as stage,\n    SUM(total) as stages_total\nFROM T\nGROUP BY T.package_name\nORDER BY stages_total DESC\nLIMIT 20\n;",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Non-Cache Stage Timings by Package",
+          "type": "barchart"
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "XCh6DDkSz"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "/^total_sum$/",
+              "values": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "postgres",
+                "uid": "XCh6DDkSz"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "WITH T as (\n    SELECT\n        ROW_NUMBER() OVER (ORDER BY total_sum DESC) as id,\n        name,\n        total_sum\n    FROM (\n        SELECT\n            analytics_timer.name as name,\n            sum(time_total) as total_sum\n            FROM analytics_timer\n            LEFT JOIN analytics_job on analytics_timer.job_id = analytics_job.job_id\n            WHERE $__timeFilter(analytics_job.started_at)\n            GROUP BY analytics_timer.name\n    ) s\n    GROUP BY s.name, s.total_sum\n    ORDER BY s.total_sum DESC\n)\n\n\n-- Select top N, and then sum remaining into \"other\" category\n(\n    SELECT name, total_sum FROM T WHERE id <= 20\n) UNION (\n    SELECT 'other' as name, SUM(total_sum) as total_sum FROM T WHERE id > 20\n)\n\nORDER BY total_sum DESC\n\n;",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Build Duration By Package with Percentages",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "XCh6DDkSz"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisWidth": 0,
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "stages_total"
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 18,
+            "x": 0,
+            "y": 11
+          },
+          "id": 19,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "orientation": "auto",
+            "showValue": "never",
+            "stacking": "normal",
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "xTickLabelRotation": -15,
+            "xTickLabelSpacing": 0
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "postgres",
+                "uid": "XCh6DDkSz"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "WITH T as (\n    SELECT\n        analytics_job.package_name as package_name,\n        analytics_timerphase.name as name,\n        SUM(analytics_timerphase.seconds) as total\n    FROM analytics_timerphase\n    LEFT JOIN analytics_timer ON analytics_timerphase.timer_id = analytics_timer.id\n    LEFT JOIN analytics_job ON analytics_timer.job_id = analytics_job.job_id\n    WHERE\n        -- analytics_job.started_at >= CAST((CAST(now() AS timestamp) + (INTERVAL '-7 day')) AS date)\n        $__timeFilter(analytics_job.started_at)\n        AND analytics_timer.cache IS TRUE\n    GROUP BY\n        analytics_job.package_name,\n        analytics_timerphase.name\n    ORDER BY analytics_job.package_name\n)\n\nSELECT\n    package_name,\n    SUM(total) filter (WHERE T.name = 'extract') as extract,\n    SUM(total) filter (WHERE T.name = 'fetch') as fetch,\n    SUM(total) filter (WHERE T.name = 'install') as install,\n    SUM(total) filter (WHERE T.name = 'relocate') as relocate,\n    SUM(total) filter (WHERE T.name = 'search') as search,\n    SUM(total) as stages_total\nFROM T\nGROUP BY T.package_name\nORDER BY stages_total DESC\nLIMIT 20\n;",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Cache Stage Timings by Package",
+          "type": "barchart"
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "XCh6DDkSz"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 6,
+            "x": 18,
+            "y": 11
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "postgres",
+                "uid": "XCh6DDkSz"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT name, SUM(seconds) as seconds from analytics_timerphase\n  WHERE is_subphase = false\nGROUP BY name\nORDER BY seconds DESC\n;",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Time by Stage",
+          "type": "piechart"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "id": 13,
+          "panels": [],
+          "title": "Cache Timings",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "XCh6DDkSz"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisWidth": 0,
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "absolute_total"
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "cache_false"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "cache_true"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 17,
+            "x": 0,
+            "y": 22
+          },
+          "id": 18,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "orientation": "auto",
+            "showValue": "never",
+            "stacking": "normal",
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            },
+            "xTickLabelRotation": -15,
+            "xTickLabelSpacing": 0
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "postgres",
+                "uid": "XCh6DDkSz"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "WITH\npackage_total_table AS (\n    SELECT\n        analytics_job.package_name,\n        analytics_timer.cache,\n        SUM(analytics_timer.time_total) as total\n    FROM analytics_timer\n    INNER JOIN analytics_job ON analytics_timer.job_id = analytics_job.job_id\n    WHERE $__timeFilter(analytics_job.started_at) \n    GROUP BY\n        analytics_job.package_name,\n        analytics_timer.cache\n    ORDER BY total DESC\n)\n\nSELECT\n    cache_true_t.package_name,\n    -- Do SUM here so that there's no GROUP BY needed on these two fields\n    SUM(cache_false_t.total) as cache_false,\n    SUM(cache_true_t.total) as cache_true,\n    SUM(cache_false_t.total) + SUM(cache_true_t.total) as absolute_total\nFROM (\n    SELECT package_name, total\n    FROM package_total_table\n    WHERE package_total_table.cache is TRUE\n) cache_true_t\nLEFT JOIN (\n    SELECT package_name, total\n    FROM package_total_table\n    WHERE package_total_table.cache is FALSE\n) cache_false_t\nON cache_true_t.package_name = cache_false_t.package_name\nGROUP BY\n    cache_true_t.package_name\nORDER BY\n    absolute_total DESC\nLIMIT 20\n;",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Cache vs. Non-Cache Build Times by Package",
+          "type": "barchart"
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "XCh6DDkSz"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "fixed"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": []
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pr11_ci-refactor-mirror-usage-uo-s3"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "UO/S3"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pr12_ci-refactor-mirror-usage-uo-https"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pr21_ci-refactor-mirror-usage-aws-s3"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pr22_ci-refactor-mirror-usage-aws-https"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 16,
+            "w": 7,
+            "x": 17,
+            "y": 22
+          },
+          "id": 9,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "postgres",
+                "uid": "XCh6DDkSz"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT SUM(\"public\".\"analytics_timerphase\".\"seconds\") / (COUNT(*) * 1.0) AS \"seconds\", \"public\".\"analytics_job\".\"ref\" as \"ref_name\"\nFROM \"public\".\"analytics_timerphase\"\nJOIN \"public\".\"analytics_timer\" ON \"public\".\"analytics_timerphase\".\"timer_id\" = \"public\".\"analytics_timer\".\"id\"\nJOIN \"public\".\"analytics_job\" ON \"public\".\"analytics_timer\".\"job_id\" = \"public\".\"analytics_job\".\"job_id\"\nWHERE\n  \"public\".\"analytics_timer\".\"cache\" IS true\n  AND \"public\".\"analytics_timerphase\".\"name\" LIKE 'fetch'\n  -- AND \"public\".\"analytics_job\".\"project_id\" = 23\n  AND \"public\".\"analytics_job\".\"ref\" LIKE '%ci-refactor-mirror-usage%'\nGROUP BY \"ref_name\"",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Fetch from cache times (summary)",
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "XCh6DDkSz"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Time in seconds",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "pr11_ci-refactor-mirror-usage-uo-s3": {
+                      "color": "yellow",
+                      "index": 0
+                    },
+                    "pr12_ci-refactor-mirror-usage-uo-https": {
+                      "color": "green",
+                      "index": 1
+                    },
+                    "pr21_ci-refactor-mirror-usage-aws-s3": {
+                      "color": "blue",
+                      "index": 2
+                    },
+                    "pr22_ci-refactor-mirror-usage-aws-https": {
+                      "color": "purple",
+                      "index": 3
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 16,
+            "w": 17,
+            "x": 0,
+            "y": 33
+          },
+          "id": 11,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.97,
+            "colorByField": "ref",
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "orientation": "auto",
+            "showValue": "auto",
+            "stacking": "none",
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            },
+            "xField": "package",
+            "xTickLabelMaxLength": 0,
+            "xTickLabelRotation": -45,
+            "xTickLabelSpacing": 0
+          },
+          "pluginVersion": "9.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "postgres",
+                "uid": "XCh6DDkSz"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT AVG(\"public\".\"analytics_timerphase\".\"seconds\") AS \"avg time\", COUNT(*) as \"count\", \"public\".\"analytics_timer\".\"name\" as \"package\", \"public\".\"analytics_job\".\"ref\" as \"ref\"\nFROM \"public\".\"analytics_timerphase\"\nJOIN \"public\".\"analytics_timer\" ON \"public\".\"analytics_timerphase\".\"timer_id\" = \"public\".\"analytics_timer\".\"id\"\nJOIN \"public\".\"analytics_job\" ON \"public\".\"analytics_timer\".\"job_id\" = \"public\".\"analytics_job\".\"job_id\"\nWHERE\n  \"public\".\"analytics_timer\".\"cache\" IS true\n  AND \"public\".\"analytics_timerphase\".\"name\" LIKE 'fetch'\n  -- AND \"public\".\"analytics_job\".\"project_id\" = 23\n  AND \"public\".\"analytics_job\".\"ref\" LIKE '%ci-refactor-mirror-usage%'\nGROUP BY \"public\".\"analytics_timer\".\"name\", \"ref\"\nORDER BY \"avg time\" DESC\nLIMIT 20\n;",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Avg per-pkg fetch from cache time",
+          "type": "barchart"
+        }
+      ],
+      "refresh": "5m",
+      "schemaVersion": 37,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-30d",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Build Timing Dashboard",
+      "uid": "XaY45DkIk",
+      "version": 8,
+      "weekStart": ""
+    }


### PR DESCRIPTION
Add a dashboard with panels showing top offenders for:

- per-pkg phase times summary for:
  * installs from cache
  * installs from source
- per-pkg times for installing from source vs installing all dependencies
- per-pkg fetch from cache times 

![build_timings_dashboard](https://github.com/spack/spack-infrastructure/assets/6527504/000207bc-a544-42c4-a219-a5fb6ba4759e)
