### PR TITLE
Add Sentry integration to sync script

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - docker-image: ./images/gh-gl-sync
-            image-tags: ghcr.io/spack/ci-bridge:0.0.37
+            image-tags: ghcr.io/spack/ci-bridge:0.0.38
           - docker-image: ./images/gitlab-api-scrape
             image-tags: ghcr.io/spack/gitlab-api-scrape:0.0.2
           - docker-image: ./images/ci-key-rotate

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -15,6 +15,14 @@ import tempfile
 import urllib.parse
 import urllib.request
 
+if 'SENTRY_DSN' in os.environ:
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=os.environ['SENTRY_DSN'],
+        traces_sample_rate=0.01,
+    )
+
 
 class SpackCIBridge(object):
 

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -15,13 +15,9 @@ import tempfile
 import urllib.parse
 import urllib.request
 
-if 'SENTRY_DSN' in os.environ:
-    import sentry_sdk
+import sentry_sdk
 
-    sentry_sdk.init(
-        dsn=os.environ['SENTRY_DSN'],
-        traces_sample_rate=0.01,
-    )
+sentry_sdk.init(traces_sample_rate=0.1)
 
 
 class SpackCIBridge(object):

--- a/images/gh-gl-sync/requirements.txt
+++ b/images/gh-gl-sync/requirements.txt
@@ -26,6 +26,7 @@ pytest-cov==3.0.0
 python-dateutil==2.8.2
 requests==2.26.0
 s3transfer==0.5.0
+sentry-sdk==1.32.0
 six==1.16.0
 toml==0.10.2
 tomli==1.2.1

--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.37
+            image: ghcr.io/spack/ci-bridge:0.0.38
             imagePullPolicy: IfNotPresent
             resources:
               requests:

--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -35,6 +35,9 @@ spec:
                 secretKeyRef:
                   name: gh-gl-sync
                   key: gitlab-ssh-key
+            envFrom:
+              - configMapRef:
+                  name: gh-gl-sync-sentry-config
             args:
               - "spack/spack"
               - "ssh://git@ssh.gitlab.spack.io/spack/spack"

--- a/terraform/modules/spack/sentry.tf
+++ b/terraform/modules/spack/sentry.tf
@@ -257,3 +257,31 @@ resource "kubectl_manifest" "gitlab_runner_sentry_config_map" {
         sentryDsn: ${data.sentry_key.gitlab_runner.dsn_public}
   YAML
 }
+
+resource "sentry_project" "gh_gl_sync" {
+  organization = data.sentry_organization.default.id
+
+  teams = [sentry_team.spack.id]
+  name  = "gh-gl-sync"
+  slug  = "gh-gl-sync"
+
+  platform = "python"
+}
+
+data "sentry_key" "gh_gl_sync" {
+  organization = data.sentry_organization.default.id
+  project      = sentry_project.gh_gl_sync.id
+}
+
+
+resource "kubectl_manifest" "gh_gl_sync_sentry_config_map" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: gh-gl-sync-sentry-config
+      namespace: custom
+    data:
+      SENTRY_DSN: ${data.sentry_key.gh_gl_sync.dsn_public}
+  YAML
+}


### PR DESCRIPTION
Adds Sentry to the sync script for error reporting. I've parameterized things such that if (1) the sentry sdk is not installed, or (2) there's no SENTRY_DSN environment variable set, then the sync script still works as usual.