### PR TITLE
Instrument other cluster python jobs with Sentry

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -40,7 +40,7 @@ jobs:
           - docker-image: ./images/upload-gitlab-failure-logs
             image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.1
           - docker-image: ./images/snapshot-release-tags
-            image-tags: ghcr.io/spack/snapshot-release-tags:0.0.2
+            image-tags: ghcr.io/spack/snapshot-release-tags:0.0.3
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./images/build-timing-processor

--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -44,9 +44,9 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./images/build-timing-processor
-            image-tags: ghcr.io/spack/build-timing-processor:0.0.1
+            image-tags: ghcr.io/spack/build-timing-processor:0.0.2
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/upload-build-timings:0.0.1
+            image-tags: ghcr.io/spack/upload-build-timings:0.0.2
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/snapshot-release-tags
             image-tags: ghcr.io/spack/snapshot-release-tags:0.0.2
           - docker-image: ./images/cache-indexer
-            image-tags: ghcr.io/spack/cache-indexer:0.0.2
+            image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./images/build-timing-processor
             image-tags: ghcr.io/spack/build-timing-processor:0.0.1
           - docker-image: ./analytics

--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -36,9 +36,9 @@ jobs:
           - docker-image: ./images/opensearch-index-build-logs
             image-tags: ghcr.io/spack/opensearch-index-build-logs:0.0.4
           - docker-image: ./images/gitlab-error-processor
-            image-tags: ghcr.io/spack/gitlab-error-processor:0.0.1
+            image-tags: ghcr.io/spack/gitlab-error-processor:0.0.2
           - docker-image: ./images/upload-gitlab-failure-logs
-            image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.1
+            image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.2
           - docker-image: ./images/snapshot-release-tags
             image-tags: ghcr.io/spack/snapshot-release-tags:0.0.3
           - docker-image: ./images/cache-indexer

--- a/analytics/requirements.txt
+++ b/analytics/requirements.txt
@@ -4,3 +4,4 @@ django-extensions==3.2.3
 kubernetes==26.1.0
 python-gitlab==3.11.0
 psycopg2-binary==2.9.5
+sentry-sdk[django]

--- a/analytics/settings.py
+++ b/analytics/settings.py
@@ -1,6 +1,13 @@
 import os
 from pathlib import Path
 
+import sentry_sdk
+
+sentry_sdk.init(
+    # Sample only 1% of transactions
+    traces_sample_rate=0.01,
+)
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/images/build-timing-processor/app.py
+++ b/images/build-timing-processor/app.py
@@ -3,9 +3,15 @@ import json
 import re
 from pathlib import Path
 
+import sentry_sdk
 import yaml
 from fastapi import FastAPI, HTTPException, Request, Response
 from kubernetes import client, config
+
+sentry_sdk.init(
+    # Sample only 1% of requests
+    traces_sample_rate=0.01,
+)
 
 config.load_incluster_config()
 v1 = client.CoreV1Api()

--- a/images/build-timing-processor/job-template.yaml
+++ b/images/build-timing-processor/job-template.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: build-timing-processing-job
-          image: ghcr.io/spack/upload-build-timings:0.0.1
+          image: ghcr.io/spack/upload-build-timings:0.0.2
           imagePullPolicy: Always
           env:
             - name: GITLAB_TOKEN

--- a/images/build-timing-processor/requirements.txt
+++ b/images/build-timing-processor/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.85.1
 kubernetes==25.3.0
 PyYAML==6.0
+sentry-sdk[fastapi]
 uvicorn==0.19.0

--- a/images/cache-indexer/Dockerfile
+++ b/images/cache-indexer/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3
 
 WORKDIR /scripts
-RUN pip install --upgrade boto3
+COPY requirements.txt ./
+RUN pip install --upgrade -r requirements.txt
 COPY cache_indexer.py ./
 
 ENTRYPOINT ["python", "./cache_indexer.py"]

--- a/images/cache-indexer/cache_indexer.py
+++ b/images/cache-indexer/cache_indexer.py
@@ -5,7 +5,13 @@ import re
 import os
 
 import boto3
+import sentry_sdk
 
+sentry_sdk.init(
+    # This cron job only runs once a day,
+    # so just record all transactions.
+    traces_sample_rate=1.0,
+)
 
 # Describe the spack refs to include in the cache.spack.io website
 REF_REGEXES = [

--- a/images/cache-indexer/requirements.txt
+++ b/images/cache-indexer/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+sentry-sdk

--- a/images/gitlab-error-processor/app.py
+++ b/images/gitlab-error-processor/app.py
@@ -1,9 +1,15 @@
 import json
 from pathlib import Path
 
+import sentry_sdk
 import yaml
 from fastapi import FastAPI, HTTPException, Request, Response
 from kubernetes import client, config
+
+sentry_sdk.init(
+    # Sample only 1% of jobs
+    traces_sample_rate=0.01,
+)
 
 config.load_incluster_config()
 

--- a/images/gitlab-error-processor/job-template.yaml
+++ b/images/gitlab-error-processor/job-template.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: gitlab-error-processing-job
-        image: ghcr.io/spack/upload-gitlab-failure-logs:0.0.1
+        image: ghcr.io/spack/upload-gitlab-failure-logs:0.0.2
         imagePullPolicy: Always
         env:
           - name: GITLAB_TOKEN
@@ -56,5 +56,8 @@ spec:
               secretKeyRef:
                 name: gitlab-error-processor
                 key: opensearch-password
+        envFrom:
+          - configMapRef:
+              name: python-scripts-sentry-config
       nodeSelector:
         spack.io/node-pool: base

--- a/images/gitlab-error-processor/requirements.txt
+++ b/images/gitlab-error-processor/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.85.1
 kubernetes==25.3.0
 PyYAML==6.0
+sentry-sdk[fastapi]
 uvicorn==0.19.0

--- a/images/gitlab-skipped-pipelines/requirements.txt
+++ b/images/gitlab-skipped-pipelines/requirements.txt
@@ -1,1 +1,2 @@
 requests
+sentry-sdk

--- a/images/gitlab-skipped-pipelines/skipped_pipelines.py
+++ b/images/gitlab-skipped-pipelines/skipped_pipelines.py
@@ -7,6 +7,13 @@ import urllib.parse
 from datetime import datetime, timedelta, timezone
 
 import requests
+import sentry_sdk
+
+sentry_sdk.init(
+    # This cron job only runs every 30 mins,
+    # so just record all transactions.
+    traces_sample_rate=1.0,
+)
 
 
 GITLAB_API_URL = "https://gitlab.spack.io/api/v4/projects/2"

--- a/images/snapshot-release-tags/requirements.txt
+++ b/images/snapshot-release-tags/requirements.txt
@@ -9,5 +9,6 @@ PyGithub==1.58.2
 PyJWT==2.7.0
 PyNaCl==1.5.0
 requests==2.30.0
+sentry-sdk
 urllib3==2.0.2
 wrapt==1.15.0

--- a/images/snapshot-release-tags/snapshot_release_tags.py
+++ b/images/snapshot-release-tags/snapshot_release_tags.py
@@ -5,9 +5,17 @@ from github import Github, InputGitAuthor
 import json
 import os
 import re
+import sentry_sdk
 import subprocess
 import tempfile
 import urllib.request
+
+sentry_sdk.init(
+    # This cron job only runs once weekly,
+    # so just record all transactions.
+    traces_sample_rate=1.0,
+)
+
 
 if __name__ == "__main__":
     if "GITHUB_TOKEN" not in os.environ:

--- a/images/upload-gitlab-failure-logs/requirements.txt
+++ b/images/upload-gitlab-failure-logs/requirements.txt
@@ -3,3 +3,4 @@ opensearch-dsl==2.0.1
 python-gitlab==3.11.0
 PyYAML==6.0
 psycopg2-binary==2.9.5
+sentry-sdk

--- a/images/upload-gitlab-failure-logs/upload_gitlab_failure_logs.py
+++ b/images/upload-gitlab-failure-logs/upload_gitlab_failure_logs.py
@@ -8,12 +8,19 @@ from typing import Any
 
 import gitlab
 import psycopg2
+import sentry_sdk
 import yaml
 from kubernetes import client, config
 from kubernetes.client.exceptions import ApiException
 from kubernetes.client.models.v1_pod import V1Pod
 from kubernetes.client.models.v1_pod_status import V1PodStatus
 from opensearch_dsl import Date, Document, connections
+
+
+sentry_sdk.init(
+    # Sample only 1% of jobs
+    traces_sample_rate=0.01,
+)
 
 config.load_config()
 v1_client = client.CoreV1Api()

--- a/k8s/production/custom/build-timing-processor/deployments.yaml
+++ b/k8s/production/custom/build-timing-processor/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: build-timing-processor
       containers:
         - name: build-timing-processor
-          image: ghcr.io/spack/build-timing-processor:0.0.1
+          image: ghcr.io/spack/build-timing-processor:0.0.2
           imagePullPolicy: Always
           resources:
             requests:

--- a/k8s/production/custom/cache-indexer/cron-jobs.yaml
+++ b/k8s/production/custom/cache-indexer/cron-jobs.yaml
@@ -14,7 +14,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: index-binary-caches
-            image: ghcr.io/spack/cache-indexer:0.0.2
+            image: ghcr.io/spack/cache-indexer:0.0.3
             imagePullPolicy: IfNotPresent
             env:
               - name: BUCKET_NAME
@@ -22,5 +22,8 @@ spec:
                   configMapKeyRef:
                     name: cache-indexer-config
                     key: bucket_name
+            envFrom:
+              - configMapRef:
+                  name: python-scripts-sentry-config
           nodeSelector:
             spack.io/node-pool: base

--- a/k8s/production/custom/gitlab-error-processor/deployments.yaml
+++ b/k8s/production/custom/gitlab-error-processor/deployments.yaml
@@ -23,8 +23,11 @@ spec:
       serviceAccountName: gitlab-error-processor
       containers:
       - name: gitlab-error-processor
-        image: ghcr.io/spack/gitlab-error-processor:0.0.1
+        image: ghcr.io/spack/gitlab-error-processor:0.0.2
         imagePullPolicy: Always
+        envFrom:
+          - configMapRef:
+              name: python-scripts-sentry-config
         resources:
           requests:
             cpu: 350m

--- a/k8s/production/custom/skipped-pipelines/cron-jobs.yaml
+++ b/k8s/production/custom/skipped-pipelines/cron-jobs.yaml
@@ -22,5 +22,8 @@ spec:
                 secretKeyRef:
                   name: gitlab-clear-pipelines
                   key: gitlab-token
+            envFrom:
+              - configMapRef:
+                  name: python-scripts-sentry-config
           nodeSelector:
             spack.io/node-pool: base

--- a/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
+++ b/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: snapshot-release-tags
-            image: ghcr.io/spack/snapshot-release-tags:0.0.2
+            image: ghcr.io/spack/snapshot-release-tags:0.0.3
             imagePullPolicy: IfNotPresent
             resources:
               requests:
@@ -28,5 +28,8 @@ spec:
                 secretKeyRef:
                   name: gh-gl-sync
                   key: github-public-repo-token
+            envFrom:
+              - configMapRef:
+                  name: python-scripts-sentry-config
           nodeSelector:
             spack.io/node-pool: base

--- a/terraform/modules/spack/sentry.tf
+++ b/terraform/modules/spack/sentry.tf
@@ -285,3 +285,31 @@ resource "kubectl_manifest" "gh_gl_sync_sentry_config_map" {
       SENTRY_DSN: ${data.sentry_key.gh_gl_sync.dsn_public}
   YAML
 }
+
+
+resource "sentry_project" "python_scripts" {
+  organization = data.sentry_organization.default.id
+
+  teams = [sentry_team.spack.id]
+  name  = "Spack Python Scripts"
+  slug  = "spack-python-scripts"
+
+  platform = "python"
+}
+
+data "sentry_key" "python_scripts" {
+  organization = data.sentry_organization.default.id
+  project      = sentry_project.python_scripts.id
+}
+
+resource "kubectl_manifest" "python_scripts_sentry_config_map" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: python-scripts-sentry-config
+      namespace: custom
+    data:
+      SENTRY_DSN: ${data.sentry_key.python_scripts.dsn_public}
+  YAML
+}


### PR DESCRIPTION
Adds Sentry integration to the rest of the custom Python jobs that run in the cluster.

I didn't instrument any of the build time processor stuff in this PR because I'm not as familiar with how that one works. I'll make a follow up PR for that and consult with @AlmightyYakob on the best way to do that.