### PR TITLE
Fix crash in gitlab error processor upload job

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -36,9 +36,9 @@ jobs:
           - docker-image: ./images/opensearch-index-build-logs
             image-tags: ghcr.io/spack/opensearch-index-build-logs:0.0.4
           - docker-image: ./images/gitlab-error-processor
-            image-tags: ghcr.io/spack/gitlab-error-processor:0.0.2
+            image-tags: ghcr.io/spack/gitlab-error-processor:0.0.3
           - docker-image: ./images/upload-gitlab-failure-logs
-            image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.2
+            image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.3
           - docker-image: ./images/snapshot-release-tags
             image-tags: ghcr.io/spack/snapshot-release-tags:0.0.3
           - docker-image: ./images/cache-indexer

--- a/images/gitlab-error-processor/job-template.yaml
+++ b/images/gitlab-error-processor/job-template.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: gitlab-error-processing-job
-        image: ghcr.io/spack/upload-gitlab-failure-logs:0.0.2
+        image: ghcr.io/spack/upload-gitlab-failure-logs:0.0.3
         imagePullPolicy: Always
         env:
           - name: GITLAB_TOKEN

--- a/images/upload-gitlab-failure-logs/upload_gitlab_failure_logs.py
+++ b/images/upload-gitlab-failure-logs/upload_gitlab_failure_logs.py
@@ -141,6 +141,11 @@ def collect_pod_status(job_input_data: dict[str, Any], job_trace: str):
     if not job_input_data["kubernetes_job"]:
         return
 
+    # Jobs sometimes don't have a `runner` field if the job failed du
+    # to a runner system failure
+    if 'runner' not in job_input_data:
+        return
+
     # Scan job logs to infer the name of the pod this job was executed on
     runner_name_matches = re.findall(
         rf"Running on (.+) via {job_input_data['runner']['description']}...",

--- a/k8s/production/custom/gitlab-error-processor/deployments.yaml
+++ b/k8s/production/custom/gitlab-error-processor/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: gitlab-error-processor
       containers:
       - name: gitlab-error-processor
-        image: ghcr.io/spack/gitlab-error-processor:0.0.2
+        image: ghcr.io/spack/gitlab-error-processor:0.0.3
         imagePullPolicy: Always
         envFrom:
           - configMapRef:


### PR DESCRIPTION
If the `runner` key is nonexistant in the job payload, the python script will crash and no record will be uploaded to opensearch. Since adding Sentry to this job last week, we've seen this happen several times. It seems the `runner` key may be missing when there is a "runner system failure", but unfortunately gitlab does not appear to provide an exact spec for the structure of this JSON blob.