### PR TITLE
Improve functionality of sealed secrets update script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ terraform.rc
 # Python Byte-compiled / optimized files
 __pycache__/
 *.py[cod]
+
+# Spack secret files
+private.key

--- a/scripts/secrets/update.py
+++ b/scripts/secrets/update.py
@@ -335,6 +335,9 @@ def main(secrets_file: str, value: str, raw: bool):
             "Argument SECRETS_FILE must be supplied when --raw is not specified"
         )
 
+    if os.environ.get("KUBECONFIG") is None:
+        raise click.ClickException("Environment variable KUBECONFIG must be set")
+
     # Display info about which cluster is being acted on
     print_cluster_info()
 

--- a/scripts/secrets/update.py
+++ b/scripts/secrets/update.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 
+import base64
 import curses
+import functools
+import json
 import os
 import subprocess
 import tempfile
 import typing
-from pathlib import Path
 from subprocess import PIPE, Popen
 
 import click
+import kubernetes
+from kubernetes.client.models.v1_secret_list import V1SecretList
 from ruamel.yaml import YAML
 
 if typing.TYPE_CHECKING:
@@ -95,39 +99,100 @@ def get_yaml_reader():
         return self.represent_scalar("tag:yaml.org,2002:null", "null")
 
     yl = YAML()
-    yl.preserve_quotes = True
+    yl.preserve_quotes = True  # type: ignore
     yl.representer.add_representer(type(None), represent_none)
 
     return yl
 
 
-def sealed_secret_cert_path(staging: bool) -> str:
-    env = "staging" if staging else "production"
-    default_cert = (
-        Path(__file__).parents[2] / "k8s" / env / "sealed-secrets" / "cert.pem"
-    )
+@functools.cache
+def fetch_key_pairs() -> list[tuple[str, str]]:
+    """
+    Fetches all sealed secrets key pairs found in the cluster, in order of ascending creation date
+    (most recent last).
+    """
+    kubernetes.config.load_config()
+    client = kubernetes.client.CoreV1Api()
 
-    cert_path = os.getenv("SEALED_SECRETS_CERT", default_cert)
-    if not Path(cert_path).exists():
-        raise click.ClickException(
-            f"Sealed Secrets Cert file not found: {cert_path.absolute()}"
+    # Fetch list of secrets
+    secrets: V1SecretList = client.list_namespaced_secret(
+        namespace="kube-system",
+        label_selector="sealedsecrets.bitnami.com/sealed-secrets-key=active",
+    )
+    if not secrets.items:
+        raise Exception(
+            "Could not find sealed-secret key pair in namespace kube-system"
         )
 
-    return cert_path
+    ordered_secrets = sorted(
+        secrets.items, key=lambda item: item.metadata.creation_timestamp
+    )
+    return [
+        (
+            base64.b64decode(secret.data["tls.crt"]).decode(),
+            base64.b64decode(secret.data["tls.key"]).decode(),
+        )
+        for secret in ordered_secrets
+    ]
 
 
-def get_secret_value():
+def latest_key_pair() -> tuple[str, str]:
+    return fetch_key_pairs()[-1]
+
+
+def get_secret_value(starting_value: bytes | None = None):
     """Open the user configured editor and retrieve the input value."""
     EDITOR = os.environ.get("EDITOR", "vim")
     with tempfile.NamedTemporaryFile() as tmp:
+        # Populate file with contents of existing secret, if applicable
+        if starting_value is not None:
+            tmp.write(starting_value)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+
+        # Open editor so user can change things
         retcode = subprocess.call([EDITOR, tmp.name])
         if retcode != 0:
             raise click.ClickException("Error retrieving secret value")
 
+        # Read value back out
         tmp.seek(0)
         val = tmp.read().decode("utf-8")
 
     return val
+
+
+def decrypt_sealed_secret(secret: dict) -> dict:
+    if secret.get("kind", None) != "SealedSecret":
+        raise Exception("Attempted to decrypt invalid resource.")
+
+    key_pairs = fetch_key_pairs()
+    for _, key in key_pairs:
+        with tempfile.NamedTemporaryFile() as private_key_file:
+            private_key_file.write(key.encode("utf-8"))
+            private_key_file.flush()
+            os.fsync(private_key_file.fileno())
+
+            # Seal value
+            p = Popen(
+                [
+                    "kubeseal",
+                    "--recovery-unseal",
+                    "--recovery-private-key",
+                    private_key_file.name,
+                ],
+                stdin=PIPE,
+                stdout=PIPE,
+                stderr=PIPE,
+            )
+            output, _ = p.communicate(input=json.dumps(secret).encode("utf-8"))
+            if p.returncode != 0:
+                continue
+
+            decrypted_secret = json.loads(output.decode("utf-8"))
+            return decrypted_secret
+
+    raise Exception(f"Could not decrypt secret {secret['metadata']['name']}")
 
 
 @click.command(help="Update an existing secret")
@@ -174,11 +239,25 @@ def main(secrets_file: str, staging: bool, value: str):
     key_to_update = keys[select_key(secret_name, keys)]
 
     # If last key, prompt for key name
+    adding_new_key = False
     if key_to_update == keys[-1]:
+        adding_new_key = True
         key_to_update = click.prompt("Please enter new secret name")
 
-    # Retrieve value
-    value = value or get_secret_value().strip()
+    # Retrieve value, if not already supplied
+    if not value:
+        starting_value = None
+
+        # Don't populate existing if a new key is being created
+        if not adding_new_key:
+            # Decrypt existing value for the secret that's being updated
+            decrypted_secret = decrypt_sealed_secret(secret)
+            starting_value = base64.b64decode(
+                decrypted_secret["data"][key_to_update] or ""
+            )
+
+        value = get_secret_value(starting_value=starting_value).strip()
+
     if value == "":
         answer = click.prompt(
             click.style(
@@ -189,23 +268,30 @@ def main(secrets_file: str, staging: bool, value: str):
             click.echo(click.style("Exiting...", fg="yellow"))
             exit(0)
 
-    # Seal value
-    p = Popen(
-        [
-            "kubeseal",
-            "--raw",
-            "--namespace",
-            secret_namespace,
-            "--name",
-            secret_name,
-            "--cert",
-            sealed_secret_cert_path(staging=staging),
-        ],
-        stdin=PIPE,
-        stdout=PIPE,
-    )
-    output, _ = p.communicate(value.encode("utf-8"))
-    encrypted_value = output.decode("utf-8")
+    # Write cert to temp file so that it can be passed to kubeseal
+    cert, _ = latest_key_pair()
+    with tempfile.NamedTemporaryFile() as cert_file:
+        cert_file.write(cert.encode("utf-8"))
+        cert_file.flush()
+        os.fsync(cert_file.fileno())
+
+        # Seal value
+        p = Popen(
+            [
+                "kubeseal",
+                "--raw",
+                "--namespace",
+                secret_namespace,
+                "--name",
+                secret_name,
+                "--cert",
+                cert_file.name,
+            ],
+            stdin=PIPE,
+            stdout=PIPE,
+        )
+        output, _ = p.communicate(value.encode("utf-8"))
+        encrypted_value = output.decode("utf-8")
 
     # Check return
     rc = p.returncode

--- a/scripts/secrets/update.py
+++ b/scripts/secrets/update.py
@@ -268,17 +268,11 @@ def seal_secret_value(secret: dict, value: str):
 @click.command(help="Update an existing secret")
 @click.argument("secrets_file", type=click.Path(exists=True, dir_okay=False))
 @click.option(
-    "--staging",
-    type=click.BOOL,
-    is_flag=True,
-    help="Use the staging cert file.",
-)
-@click.option(
     "--value",
     type=click.STRING,
     help="Supply the value for the selected secret as an argument.",
 )
-def main(secrets_file: str, staging: bool, value: str):
+def main(secrets_file: str, value: str):
     yl = get_yaml_reader()
     with open(secrets_file) as f:
         secret_docs = list(yl.load_all(f))


### PR DESCRIPTION
I experienced some frustration recently when using the secret update script. I've modified it to include the following behavior:

1. When updating a secret, if possible, the existing secret value is de-crypted and injected into the editor before being opened for the user. This makes it much easier to both update a _part_ of a secret, as well as fix any errors. Previously, to do this you had to go through the process of fetching a secret from the cluster, decoding it, copying that value and pasting it into the editor, and then finally changing what you needed. This has multiple times now caused me issues with character escaping, etc., which this new approach avoids.
2. Since there are actually multiple key pairs which can be used to encrypt/decrypt values (relevant [docs](https://github.com/bitnami-labs/sealed-secrets#sealing-key-renewal)), this PR updates the script to fetch these key pairs from the cluster, and as such, the hard-coded use of the certificates included in this repository is no longer necessary.
3. The `--staging` flag is no longer required, as the relevant certificates to seal/unseal secrets are fetched from the cluster. As such, setting the `KUBECONFIG` environment variable is all that's required to switch between prod/staging.
4. The `--raw` flag was added to support the use case of updating or adding a staging secret. Rather than add the complex behavior and edge cases associated with modifying kustomization files, I thought this approach was more straight foreward.

