### PR TITLE
Test docker image builds on PRs

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -1,4 +1,4 @@
-name: Publish Docker Images
+name: Build Docker Images
 
 on:
   push:
@@ -7,9 +7,13 @@ on:
     paths:
       - images/**
       - .github/workflows/custom_docker_builds.yml
+  pull_request:
+    paths:
+      - images/**
+      - .github/workflows/custom_docker_builds.yml
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -62,13 +66,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push ${{ matrix.docker-image }}
+      - name: Build ${{ (github.ref == 'refs/heads/main' && 'and push ') || '' }}${{ matrix.docker-image }}
         id: docker-build-push
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
         with:
           context: ${{ matrix.docker-image }}
           file: ${{ matrix.docker-image }}/Dockerfile
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}  # only publish image on push to main
           tags: ${{ matrix.image-tags }}
           platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
This will make it so a "test build" of docker images (i.e. they will get built but not published to GHCR) gets performed on any PR that makes changes to the `images/` directory. This will help catch image build failures before a merge to `main` happens.