### PR TITLE
Taint pipeline nodes

### DIFF
--- a/k8s/production/karpenter/provisioners/runners/graviton/2/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/graviton/2/provisioners.yaml
@@ -11,6 +11,12 @@ spec:
   # Terminate nodes after 5 minutes of idle time
   ttlSecondsAfterEmpty: 300
 
+  # Taint these nodes so only pipeline pods will be scheduled on them.
+  taints:
+    - key: spack.io/runner-taint
+      value: "true"
+      effect: NoSchedule
+
   # Resource limits for this provisioner only
   limits:
     resources:

--- a/k8s/production/karpenter/provisioners/runners/graviton/3/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/graviton/3/provisioners.yaml
@@ -11,6 +11,12 @@ spec:
   # Terminate nodes after 5 minutes of idle time
   ttlSecondsAfterEmpty: 300
 
+  # Taint these nodes so only pipeline pods will be scheduled on them.
+  taints:
+    - key: spack.io/runner-taint
+      value: "true"
+      effect: NoSchedule
+
   # Resource limits for this provisioner only
   limits:
     resources:

--- a/k8s/production/karpenter/provisioners/runners/pcluster/graviton/3/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/pcluster/graviton/3/provisioners.yaml
@@ -1,5 +1,5 @@
 ---
-# Provisioner for graviton3 gitlab runners
+# Provisioner for pcluster graviton3 gitlab runners
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
@@ -10,6 +10,12 @@ spec:
 
   # Terminate nodes after 5 minutes of idle time
   ttlSecondsAfterEmpty: 300
+
+  # Taint these nodes so only pipeline pods will be scheduled on them.
+  taints:
+    - key: spack.io/runner-taint
+      value: "true"
+      effect: NoSchedule
 
   # Resource limits for this provisioner only
   limits:

--- a/k8s/production/karpenter/provisioners/runners/testing/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/testing/provisioners.yaml
@@ -11,6 +11,12 @@ spec:
   # Terminate nodes after 5 minutes of idle time
   ttlSecondsAfterEmpty: 300
 
+  # Taint these nodes so only pipeline pods will be scheduled on them.
+  taints:
+    - key: spack.io/runner-taint
+      value: "true"
+      effect: NoSchedule
+
   # Resource limits for this provisioner only
   limits:
     resources:

--- a/k8s/production/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
@@ -11,6 +11,12 @@ spec:
   # Terminate nodes after 5 minutes of idle time
   ttlSecondsAfterEmpty: 300
 
+  # Taint these nodes so only pipeline pods will be scheduled on them.
+  taints:
+    - key: spack.io/runner-taint
+      value: "true"
+      effect: NoSchedule
+
   # Resource limits for this provisioner only
   limits:
     resources:

--- a/k8s/production/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
@@ -11,6 +11,12 @@ spec:
   # Terminate nodes after 5 minutes of idle time
   ttlSecondsAfterEmpty: 300
 
+  # Taint these nodes so only pipeline pods will be scheduled on them.
+  taints:
+    - key: spack.io/runner-taint
+      value: "true"
+      effect: NoSchedule
+
   # Resource limits for this provisioner only
   limits:
     resources:

--- a/k8s/production/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
@@ -11,6 +11,12 @@ spec:
   # Terminate nodes after 5 minutes of idle time
   ttlSecondsAfterEmpty: 300
 
+  # Taint these nodes so only pipeline pods will be scheduled on them.
+  taints:
+    - key: spack.io/runner-taint
+      value: "true"
+      effect: NoSchedule
+
   # Resource limits for this provisioner only
   limits:
     resources:

--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -133,6 +133,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -118,6 +118,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -105,6 +105,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -137,6 +137,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -131,6 +131,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -117,6 +117,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -133,6 +133,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -118,6 +118,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -106,6 +106,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -138,6 +138,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -131,6 +131,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -117,6 +117,9 @@ spec:
                       operator = "In"
                       values = ["true"]
 
+            [runners.kubernetes.node_tolerations]
+              "spack.io/runner-taint=true" = "NoSchedule"
+
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"


### PR DESCRIPTION
Update our Karpenter provision to apply taints to our pipeline nodes. This will prevent other pods from being scheduled on them.

Also update our GitLab runner configuration to allow our pipeline pods to tolerate these taints.