### PR TITLE
Bump versions for build timing pods

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -46,9 +46,9 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./images/build-timing-processor
-            image-tags: ghcr.io/spack/build-timing-processor:0.0.2
+            image-tags: ghcr.io/spack/build-timing-processor:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/upload-build-timings:0.0.2
+            image-tags: ghcr.io/spack/upload-build-timings:0.0.3
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -72,7 +72,7 @@ jobs:
         with:
           context: ${{ matrix.docker-image }}
           file: ${{ matrix.docker-image }}/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}  # only publish image on push to main
+          push: ${{ github.ref == 'refs/heads/main' }} # only publish image on push to main
           tags: ${{ matrix.image-tags }}
           platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
Follow up to #635

The pod versions were already at `0.0.2`, which wasn't readily apparent in that PR, so bumping them from `0.0.1` to `0.0.2` did nothing. 