### PR TITLE
Fix build timing script and image versions

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -46,9 +46,9 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./images/build-timing-processor
-            image-tags: ghcr.io/spack/build-timing-processor:0.0.3
+            image-tags: ghcr.io/spack/build-timing-processor:0.0.4
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/upload-build-timings:0.0.3
+            image-tags: ghcr.io/spack/upload-build-timings:0.0.4
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/analytics/analytics/management/commands/upload_build_timings.py
+++ b/analytics/analytics/management/commands/upload_build_timings.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import zipfile
+from contextlib import contextmanager
 
 import djclick as click
 import gitlab
@@ -25,6 +26,7 @@ class JobArtifactFileNotFound(Exception):
         super().__init__(message)
 
 
+@contextmanager
 def get_job_artifacts_file(job: ProjectJob, filename: str):
     """Yields a file IO, raises KeyError if the filename is not present"""
     with tempfile.NamedTemporaryFile(suffix=".zip") as temp:

--- a/images/build-timing-processor/job-template.yaml
+++ b/images/build-timing-processor/job-template.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: build-timing-processing-job
-          image: ghcr.io/spack/upload-build-timings:0.0.2
+          image: ghcr.io/spack/upload-build-timings:0.0.4
           imagePullPolicy: Always
           env:
             - name: GITLAB_TOKEN

--- a/k8s/production/custom/build-timing-processor/deployments.yaml
+++ b/k8s/production/custom/build-timing-processor/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: build-timing-processor
       containers:
         - name: build-timing-processor
-          image: ghcr.io/spack/build-timing-processor:0.0.2
+          image: ghcr.io/spack/build-timing-processor:0.0.4
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
There are a couple of things that are causing the analytics DB to not contain the added fields from #635 

1. I forgot to add the `@contextmanager` decorator to the `get_job_artifacts_file` function. The lack of this decorator _should_ have caused sentry errors that would point to the issue. However, that didn't happen because...
2. Due to the fallout of #635 regarding version collision, the hastily made follow-up PR #690 didn't actually bump the version of `upload-build-timings` that was used in the build timing webhook. So events that were being sent to the webhook were _still_ using the old version of the script, and not adding in those fields.