### PR TITLE
Switch to new `kubectl` Terraform provider

### DIFF
--- a/terraform/modules/spack/main.tf
+++ b/terraform/modules/spack/main.tf
@@ -9,8 +9,8 @@ terraform {
       version = "~> 2.5"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "~> 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.0"
     }
     flux = {
       source  = "fluxcd/flux"

--- a/terraform/production/.terraform.lock.hcl
+++ b/terraform/production/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.0.3"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:cupk6JdgjzqXsw/0GE8RmKNycf7yJLakzAMlQI4+bsk=",
+    "zh:0573cc46fcdf43410114ba42a3d5bee1b2074072a5d7774e90c7ebbf279a4d9a",
+    "zh:195a5bac71df2e962c5857916aae8b0546fa283b9644b81a5579d87456b3b268",
+    "zh:19cffc851e779e3715753a312fa0dc49c5429363de9f10466dab6f0c63ad5dc1",
+    "zh:1acd66873dd114b0a433e74c1971068f44ba327f549a9784565fd26a49b2511d",
+    "zh:2e043875a2ea09fef17d165a39c305c8fb5b80990efa8eb668d41de290531b5c",
+    "zh:4a129b540ca0e45ac9b7e5fe29413e88f5c4f6d356df069962e3c73673c5a439",
+    "zh:8ffec16848393a92a4b9ed577758b396db0d898718823f49c50ebe14fc426fc5",
+    "zh:aa933d3f7603b4bf411160f23b2f0ca9d564dae143cefa526b1012aebbe814e6",
+    "zh:ad1199152300687c40863c973050bff4fc031ebca6e9e19e59053c9154d3788f",
+    "zh:b72834b595be6eafcf04c8f01c2241d5939d6bd65949b8f5bca525ef38320129",
+    "zh:d18320d9a30aa8c6124f140b7cda41b3289adefdae88a2e096aba7854b9f6a25",
+    "zh:db391acb58b3362137518db81b7fd118a14732a06094f736ff286024531990cf",
+    "zh:e9b832fda20c79b2cfb216de9a535e30579d8a02eaafe2dbf4461e2f54fe4383",
+    "zh:fc51af1d63b8bbaba36d5ee10e3b19176836ebed4f0e61b58d8d372df98d3989",
+  ]
+}
+
 provider "registry.terraform.io/fluxcd/flux" {
   version     = "0.22.3"
   constraints = "~> 0.22.2"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -19,8 +19,8 @@ terraform {
       version = "~> 2.5"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "~> 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.0"
     }
     flux = {
       source  = "fluxcd/flux"

--- a/terraform/staging/.terraform.lock.hcl
+++ b/terraform/staging/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.0.3"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:cupk6JdgjzqXsw/0GE8RmKNycf7yJLakzAMlQI4+bsk=",
+    "zh:0573cc46fcdf43410114ba42a3d5bee1b2074072a5d7774e90c7ebbf279a4d9a",
+    "zh:195a5bac71df2e962c5857916aae8b0546fa283b9644b81a5579d87456b3b268",
+    "zh:19cffc851e779e3715753a312fa0dc49c5429363de9f10466dab6f0c63ad5dc1",
+    "zh:1acd66873dd114b0a433e74c1971068f44ba327f549a9784565fd26a49b2511d",
+    "zh:2e043875a2ea09fef17d165a39c305c8fb5b80990efa8eb668d41de290531b5c",
+    "zh:4a129b540ca0e45ac9b7e5fe29413e88f5c4f6d356df069962e3c73673c5a439",
+    "zh:8ffec16848393a92a4b9ed577758b396db0d898718823f49c50ebe14fc426fc5",
+    "zh:aa933d3f7603b4bf411160f23b2f0ca9d564dae143cefa526b1012aebbe814e6",
+    "zh:ad1199152300687c40863c973050bff4fc031ebca6e9e19e59053c9154d3788f",
+    "zh:b72834b595be6eafcf04c8f01c2241d5939d6bd65949b8f5bca525ef38320129",
+    "zh:d18320d9a30aa8c6124f140b7cda41b3289adefdae88a2e096aba7854b9f6a25",
+    "zh:db391acb58b3362137518db81b7fd118a14732a06094f736ff286024531990cf",
+    "zh:e9b832fda20c79b2cfb216de9a535e30579d8a02eaafe2dbf4461e2f54fe4383",
+    "zh:fc51af1d63b8bbaba36d5ee10e3b19176836ebed4f0e61b58d8d372df98d3989",
+  ]
+}
+
 provider "registry.terraform.io/fluxcd/flux" {
   version     = "0.22.3"
   constraints = "~> 0.22.2"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -19,8 +19,8 @@ terraform {
       version = "~> 2.5"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "~> 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.0"
     }
     flux = {
       source  = "fluxcd/flux"


### PR DESCRIPTION
The current provider we're using (https://github.com/gavinbunney/terraform-provider-kubectl/) is now unmaintained and contains some critical bugs. We should fix this by switching to the official k8s provider, but that will require a refactor of a significant part of our Terraform code base. To address the immediate issues being caused by the buggy provider, this PR switches us to [this fork](https://github.com/gavinbunney/terraform-provider-kubectl/), which is actively maintained and fixes the bugs we're seeing while being effectively a drop-in replacement.