### PR TITLE
Fix pod annotations

### DIFF
--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -149,16 +149,7 @@ spec:
         - pods=[*]
         - nodes=[*]
       metricAnnotationsAllowList:
-        - > pods=[
-                gitlab/ci_job_id,
-                metrics/spack_job_spec_pkg_name,
-                metrics/spack_job_spec_pkg_version,
-                metrics/spack_job_spec_compiler_name,
-                metrics/spack_job_spec_compiler_version,
-                metrics/spack_job_spec_arch,
-                metrics/spack_job_spec_variants,
-                metrics/spack_job_build_jobs
-            ]
+        - pods=[gitlab/ci_job_id,metrics/spack_job_spec_pkg_name,metrics/spack_job_spec_pkg_version,metrics/spack_job_spec_compiler_name,metrics/spack_job_spec_compiler_version,metrics/spack_job_spec_arch,metrics/spack_job_spec_variants,metrics/spack_job_build_jobs]
 
   # Configure OpenSearch datasource
   valuesFrom:

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -149,7 +149,7 @@ spec:
         - pods=[*]
         - nodes=[*]
       metricAnnotationsAllowList:
-        - pods=[gitlab/ci_job_id,metrics*]
+        - pods=[gitlab/ci_job_id,metrics/spack_job_spec_pkg_name,metrics/spack_job_spec_pkg_version,metrics/spack_job_spec_compiler_name,metrics/spack_job_spec_compiler_version,metrics/spack_job_spec_arch,metrics/spack_job_spec_variants,metrics/spack_job_build_jobs]
 
   # Configure OpenSearch datasource
   valuesFrom:

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -149,7 +149,16 @@ spec:
         - pods=[*]
         - nodes=[*]
       metricAnnotationsAllowList:
-        - pods=[gitlab/ci_job_id,metrics/spack_job_spec_pkg_name,metrics/spack_job_spec_pkg_version,metrics/spack_job_spec_compiler_name,metrics/spack_job_spec_compiler_version,metrics/spack_job_spec_arch,metrics/spack_job_spec_variants,metrics/spack_job_build_jobs]
+        - > pods=[
+                gitlab/ci_job_id,
+                metrics/spack_job_spec_pkg_name,
+                metrics/spack_job_spec_pkg_version,
+                metrics/spack_job_spec_compiler_name,
+                metrics/spack_job_spec_compiler_version,
+                metrics/spack_job_spec_arch,
+                metrics/spack_job_spec_variants,
+                metrics/spack_job_build_jobs
+            ]
 
   # Configure OpenSearch datasource
   valuesFrom:


### PR DESCRIPTION
#630 added some job information to be exposed through attributes. In that PR, I tried including the entire `metrics` section by doing this:

```
     metricAnnotationsAllowList:
        - pods=[gitlab/ci_job_id,metrics*]
```

However, I checked the [docs](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/cli-arguments.md#available-options) and it seems like the only options are specifying each annotation manually or including all (performance isn't great). See [this prometheus query](https://prometheus.spack.io/api/v1/query_range?query=kube_pod_annotations%7Bannotation_gitlab_ci_job_id=%279359381%27%7D&start=1701780555&end=1701800555&step=10) for an example of this not working.

This PR lists each annotation we would like to have available in prometheus.

Is there a way to test if this would work beforehand in a staging area before pushing to production? No worries if not