### PR TITLE
Fix crash in error taxonomy upload script

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -38,9 +38,9 @@ jobs:
           - docker-image: ./images/python-aws-bash
             image-tags: ghcr.io/spack/python-aws-bash:0.0.2
           - docker-image: ./images/gitlab-error-processor
-            image-tags: ghcr.io/spack/gitlab-error-processor:0.0.3
+            image-tags: ghcr.io/spack/gitlab-error-processor:0.0.4
           - docker-image: ./images/upload-gitlab-failure-logs
-            image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.3
+            image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.4
           - docker-image: ./images/snapshot-release-tags
             image-tags: ghcr.io/spack/snapshot-release-tags:0.0.4
           - docker-image: ./images/cache-indexer

--- a/images/gitlab-error-processor/job-template.yaml
+++ b/images/gitlab-error-processor/job-template.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: gitlab-error-processing-job
-        image: ghcr.io/spack/upload-gitlab-failure-logs:0.0.3
+        image: ghcr.io/spack/upload-gitlab-failure-logs:0.0.4
         imagePullPolicy: Always
         env:
           - name: GITLAB_TOKEN

--- a/images/upload-gitlab-failure-logs/upload_gitlab_failure_logs.py
+++ b/images/upload-gitlab-failure-logs/upload_gitlab_failure_logs.py
@@ -141,9 +141,10 @@ def collect_pod_status(job_input_data: dict[str, Any], job_trace: str):
     if not job_input_data["kubernetes_job"]:
         return
 
-    # Jobs sometimes don't have a `runner` field if the job failed du
-    # to a runner system failure
-    if 'runner' not in job_input_data:
+    # Jobs sometimes don't have a `runner` field if the job failed due
+    # to a runner system failure.
+    # In some cases they *do* have a `runner` field, but it is None.
+    if job_input_data.get("runner") is None:
         return
 
     # Scan job logs to infer the name of the pod this job was executed on

--- a/k8s/production/custom/gitlab-error-processor/deployments.yaml
+++ b/k8s/production/custom/gitlab-error-processor/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: gitlab-error-processor
       containers:
       - name: gitlab-error-processor
-        image: ghcr.io/spack/gitlab-error-processor:0.0.3
+        image: ghcr.io/spack/gitlab-error-processor:0.0.4
         imagePullPolicy: Always
         envFrom:
           - configMapRef:


### PR DESCRIPTION
In certain error scenarios, we were trying to index a `None` value.