### PR TITLE
Enable fluent-bit for pipeline pods

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -138,7 +138,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -123,7 +123,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -110,7 +110,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -142,7 +142,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -136,7 +136,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -122,7 +122,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -138,7 +138,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -123,7 +123,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -111,7 +111,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -143,7 +143,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -136,7 +136,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -122,7 +122,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -147,7 +147,6 @@ spec:
 
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
-              "fluentbit.io/exclude" = "true"
               "karpenter.sh/do-not-evict" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"


### PR DESCRIPTION
We're excluding pipeline pods from fluent-bit, so when a job pod fails, we don't have any logs to debug.