### PR TITLE
Disable gitlab aws access key rotation

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -24,7 +24,7 @@ jobs:
           - docker-image: ./images/gitlab-api-scrape
             image-tags: ghcr.io/spack/gitlab-api-scrape:0.0.3
           - docker-image: ./images/ci-key-rotate
-            image-tags: ghcr.io/spack/ci-key-rotate:0.0.5
+            image-tags: ghcr.io/spack/ci-key-rotate:0.0.6
           - docker-image: ./images/ci-key-clear
             image-tags: ghcr.io/spack/ci-key-clear:0.0.2
           - docker-image: ./images/gitlab-stuckpods

--- a/images/ci-key-rotate/rotate_gitlab_aws_access_keys.py
+++ b/images/ci-key-rotate/rotate_gitlab_aws_access_keys.py
@@ -7,6 +7,10 @@ import urllib.request
 
 
 def update_gitlab_variable(k, v):
+    if os.environ.get('SKIP_GITLAB_VARIABLE_UPDATE', False):
+        print('Skipping GitLab variable update')
+        return
+
     DATA = urllib.parse.urlencode({'value': v}).encode()
     URL = 'https://gitlab.spack.io/api/v4/projects/2/variables/{0}'.format(k)
     request = urllib.request.Request(url=URL, data=DATA, method='PUT')

--- a/k8s/production/custom/rotate-keys/cron-jobs.yaml
+++ b/k8s/production/custom/rotate-keys/cron-jobs.yaml
@@ -15,7 +15,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: rotate-gitlab-aws-access-keys
-            image: ghcr.io/spack/ci-key-rotate:0.0.5
+            image: ghcr.io/spack/ci-key-rotate:0.0.6
             imagePullPolicy: IfNotPresent
             env:
             - name: GITLAB_TOKEN
@@ -23,6 +23,8 @@ spec:
                 secretKeyRef:
                   name: rotate-keys
                   key: gitlab-token
+            - name: SKIP_GITLAB_VARIABLE_UPDATE
+              value: "true"
           nodeSelector:
             spack.io/node-pool: base
 ---


### PR DESCRIPTION
All runners should now be using OIDC for authentication. I'm going to disable the secret updating and verify that nothing breaks. After a little while I'll remove all the associated key rotation code.