### PR TITLE
Add stack name to annotations

### DIFF
--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -149,7 +149,7 @@ spec:
         - pods=[*]
         - nodes=[*]
       metricAnnotationsAllowList:
-        - pods=[gitlab/ci_job_id,metrics/spack_job_spec_pkg_name,metrics/spack_job_spec_pkg_version,metrics/spack_job_spec_compiler_name,metrics/spack_job_spec_compiler_version,metrics/spack_job_spec_arch,metrics/spack_job_spec_variants,metrics/spack_job_build_jobs]
+        - pods=[gitlab/ci_job_id,metrics/spack_job_spec_pkg_name,metrics/spack_job_spec_pkg_version,metrics/spack_job_spec_compiler_name,metrics/spack_job_spec_compiler_version,metrics/spack_job_spec_arch,metrics/spack_job_spec_variants,metrics/spack_job_build_jobs,metrics/spack_ci_stack_name]
 
   # Configure OpenSearch datasource
   valuesFrom:

--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -152,6 +152,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -137,6 +137,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -124,6 +124,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -156,6 +156,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -150,6 +150,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -136,6 +136,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -152,6 +152,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -137,6 +137,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -125,6 +125,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -157,6 +157,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -150,6 +150,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -136,6 +136,7 @@ spec:
               "metrics/spack_job_spec_arch" = "$SPACK_JOB_SPEC_ARCH"
               "metrics/spack_job_spec_variants" = "$SPACK_JOB_SPEC_VARIANTS"
               "metrics/spack_job_build_jobs" = "$SPACK_BUILD_JOBS"
+              "metrics/spack_ci_stack_name" = "$SPACK_CI_STACK_NAME"
             [runners.kubernetes.pod_labels]
               "spack.io/runner" = "true"
               "gitlab/ci_job_id" = "$CI_JOB_ID"


### PR DESCRIPTION
This is a follow-up to #630. With the exception of stack name, all the information I need to retrieve for the dynamic allocation web hook is available in the annotations. Rather than add load to the Prometheus server with an extra request to the labels, it would be most convenient to have the stack name available here as well.

@jjnesbitt 