### PR TITLE
Add AWS AccessDenied to the error taxonomy

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -36,9 +36,9 @@ jobs:
           - docker-image: ./images/python-aws-bash
             image-tags: ghcr.io/spack/python-aws-bash:0.0.2
           - docker-image: ./images/gitlab-error-processor
-            image-tags: ghcr.io/spack/gitlab-error-processor:0.0.4
+            image-tags: ghcr.io/spack/gitlab-error-processor:0.0.5
           - docker-image: ./images/upload-gitlab-failure-logs
-            image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.4
+            image-tags: ghcr.io/spack/upload-gitlab-failure-logs:0.0.5
           - docker-image: ./images/snapshot-release-tags
             image-tags: ghcr.io/spack/snapshot-release-tags:0.0.4
           - docker-image: ./images/cache-indexer

--- a/images/gitlab-error-processor/job-template.yaml
+++ b/images/gitlab-error-processor/job-template.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: gitlab-error-processing-job
-        image: ghcr.io/spack/upload-gitlab-failure-logs:0.0.4
+        image: ghcr.io/spack/upload-gitlab-failure-logs:0.0.5
         imagePullPolicy: Always
         env:
           - name: GITLAB_TOKEN

--- a/images/upload-gitlab-failure-logs/taxonomy.yaml
+++ b/images/upload-gitlab-failure-logs/taxonomy.yaml
@@ -63,9 +63,10 @@ taxonomy:
         - 'command terminated with exit code 137'
         - 'ERROR: Job failed: exit code 137'
 
-    invalid_access_key:
+    aws_access_denied:
       grep_for:
         - 'The AWS Access Key Id you provided does not exist in our records'
+        - 'An error occurred (AccessDenied)'
 
     gitlab_down:
       grep_for:
@@ -280,7 +281,7 @@ taxonomy:
     - '5XX'
     - 'dial_backend'
     - 'remote_disconnect'
-    - 'invalid_access_key'
+    - 'aws_access_denied'
     - 'nvidia_detection_error'
     # Other Errors
     - 'gpg_fail_open_files'

--- a/k8s/production/custom/gitlab-error-processor/deployments.yaml
+++ b/k8s/production/custom/gitlab-error-processor/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: gitlab-error-processor
       containers:
       - name: gitlab-error-processor
-        image: ghcr.io/spack/gitlab-error-processor:0.0.4
+        image: ghcr.io/spack/gitlab-error-processor:0.0.5
         imagePullPolicy: Always
         envFrom:
           - configMapRef:


### PR DESCRIPTION
This should help us track a broader set of AWS access errors seen in runners without OIDC configured.