### PR TITLE
Include protocol in webhook handler prometheus url

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -44,7 +44,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.0.7
+            image-tags: ghcr.io/spack/django:0.0.8
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -90,7 +90,7 @@ spec:
                   name: webhook-secrets
                   key: celery-broker-url
             - name: PROMETHEUS_URL
-              value: kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+              value: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
       nodeSelector:
         spack.io/node-pool: base
 
@@ -185,6 +185,6 @@ spec:
                   name: webhook-secrets
                   key: celery-broker-url
             - name: PROMETHEUS_URL
-              value: kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+              value: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
       nodeSelector:
         spack.io/node-pool: base

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.0.7
+          image: ghcr.io/spack/django:0.0.8
           imagePullPolicy: Always
           resources:
             requests:
@@ -119,7 +119,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.0.7
+          image: ghcr.io/spack/django:0.0.8
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
Follow up to #723 

When I included the internal prometheus URL as an env var to the deployment, I forgot to include the protocol (`http`) on the front of it.