### PR TITLE
Misc bug fixes for job processor prometheus logic

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -44,7 +44,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.0.8
+            image-tags: ghcr.io/spack/django:0.0.9
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/analytics/analytics/job_processor/prometheus.py
+++ b/analytics/analytics/job_processor/prometheus.py
@@ -195,7 +195,7 @@ class PrometheusClient:
         pod_results = next(
             (res for res in results if res["metric"]["pod"] == pod), None
         )
-        if pod is None:
+        if pod_results is None:
             raise UnexpectedPrometheusResult(f"Pod {pod} not found in cpu usage query")
 
         job.pod.cpu_usage_seconds = float(pod_results["values"][-1][1])

--- a/analytics/analytics/models.py
+++ b/analytics/analytics/models.py
@@ -104,7 +104,7 @@ class Job(models.Model):
             self.node.save()
             return
         except IntegrityError as e:
-            if "unique-name-system-uuid" not in e:
+            if "unique-name-system-uuid" not in str(e):
                 raise
 
         # Node already exists, set node field to the existing node

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.0.8
+          image: ghcr.io/spack/django:0.0.9
           imagePullPolicy: Always
           resources:
             requests:
@@ -119,7 +119,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.0.8
+          image: ghcr.io/spack/django:0.0.9
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
We were seeing a few issues in sentry from the new job processor work (#723). This PR fixes the following issues:

1. A typo that was causing non-aws jobs to fail to be tracked correctly
2. A bug in handling node model creation
3. Issues resulting from static step sizes in range queries. This is because if a job is sufficiently short (a minute or less), the previous step size of 30 seconds could result in just one or even zero samples, depending on the start and end times used. Now, dynamic step sizes (based on the job duration) are used.