### PR TITLE
Further prometheus job processor fixes

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -44,7 +44,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.1.1
+            image-tags: ghcr.io/spack/django:0.1.2
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/analytics/analytics/core/models.py
+++ b/analytics/analytics/core/models.py
@@ -1,5 +1,5 @@
 from django.contrib.postgres.fields import ArrayField
-from django.db import IntegrityError, models
+from django.db import IntegrityError, models, transaction
 
 
 class NodeCapacityType(models.TextChoices):
@@ -97,7 +97,8 @@ class Job(models.Model):
             return
 
         try:
-            self.node.save()
+            with transaction.atomic():
+                self.node.save()
             return
         except IntegrityError as e:
             if "unique-name-system-uuid" not in str(e):

--- a/analytics/analytics/job_processor/prometheus.py
+++ b/analytics/analytics/job_processor/prometheus.py
@@ -253,7 +253,7 @@ class PrometheusClient:
 
         # Use this query to get the node the pod was running on at the time
         node_name = self.query_range(
-            f"kube_pod_info{{pod='{pod}', node=~'.+'}}",
+            f"kube_pod_info{{pod='{pod}', node=~'.+', pod_ip=~'.+'}}",
             start=job.started_at,
             end=job.finished_at,
             step=step,

--- a/analytics/analytics/job_processor/prometheus.py
+++ b/analytics/analytics/job_processor/prometheus.py
@@ -175,8 +175,11 @@ class PrometheusClient:
         step = math.ceil(job.duration.total_seconds() / 100)
 
         # Get cpu seconds usage
+        cpu_seconds_query = (
+            f"container_cpu_usage_seconds_total{{container='build', node='{node}'}}"
+        )
         results = self.query_range(
-            f"container_cpu_usage_seconds_total{{container='build', node='{node}'}}",
+            cpu_seconds_query,
             start=job.started_at,
             end=job.finished_at,
             step=step,
@@ -188,7 +191,10 @@ class PrometheusClient:
             (res for res in results if res["metric"]["pod"] == pod), None
         )
         if pod_results is None:
-            raise UnexpectedPrometheusResult(f"Pod {pod} not found in cpu usage query")
+            raise UnexpectedPrometheusResult(
+                message=f"Pod {pod} not found in cpu usage query",
+                query=cpu_seconds_query,
+            )
 
         job.pod.cpu_usage_seconds = float(pod_results["values"][-1][1])
 

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.1.1
+          image: ghcr.io/spack/django:0.1.2
           imagePullPolicy: Always
           resources:
             requests:
@@ -121,7 +121,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.1.1
+          image: ghcr.io/spack/django:0.1.2
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
Follow up  to #740 

One of the fixes in that PR was to prevent duplicate results from prometheus queries when filtering by `pod`. That was accomplished by including a filter for a non-empty `node` field, which I _thought_ would guarantee we only get results for the pod once it's running on the node. However, that turns out not to be the case. It seems the pod can be present on the node _before_ the pod has an IP address, which results in two values for the same pod from the query.

To fix this, an additional filter for `pod_ip` has been added.

The following fixes have also been made:

1. A transaction has been added around node creation, to avoid a `TransactionManagementError` that was being raised.
2. Fix an incorrect raising of `UnexpectedPrometheusResult`
