### PR TITLE
Increase the job log limit to 20MB

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/pcluster/graviton/3/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/public/pcluster/graviton/3/release.yaml
+++ b/k8s/production/runners/public/pcluster/graviton/3/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "gitlab/gitlab-runner-helper:arm-latest"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -72,7 +72,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -74,7 +74,7 @@ spec:
           unset GITLAB_OIDC_TOKEN
           """
 
-          output_limit = 10240
+          output_limit = 20480
           environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false


### PR DESCRIPTION
This should allow larger job logs to get through and let us retrieve more detail about what went wrong. Assuming there's no stability issues after rollout, we might want to ask 3rd party runners to do the same.