### PR TITLE
Enhance retry metadata tracking

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -40,7 +40,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.1.7
+            image-tags: ghcr.io/spack/django:0.1.8
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.1.7
+          image: ghcr.io/spack/django:0.1.8
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.1.7
+          image: ghcr.io/spack/django:0.1.8
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
This removes the `retried` field and adds the following fields to opensearch:
```
    is_retry: bool
    is_manual_retry: bool
    attempt_number: int
    final_attempt: bool
```

Computing these is a little trickier than it ought to be but this should account for less common situations e.g.
1. Jobs with unique retry conditions unlike the regular rebuild job (like protected publish)
2. Multiple pipelines (`commit_id`s) executing the same named job multiple times
3. Webhooks being received/processed out of order

@mvandenburgh I know this is going to go in postgres soon but I wanted to get the logic committed so it can be ported when that happens.