### PR TITLE
(docker compose) Expose gitlab container service internally

### DIFF
--- a/analytics/docker-compose.yml
+++ b/analytics/docker-compose.yml
@@ -50,6 +50,7 @@ services:
     environment:
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'http://gitlab'
+        registry_external_url 'http://gitlab:5050'
         gitlab_rails['db_host'] = 'gitlab-db'
         gitlab_rails['db_port'] = '5432'
         gitlab_rails['db_username'] = 'gitlab'


### PR DESCRIPTION
The GitLab Container Registry is enabled by default, but is currently inaccessible outside of the `gitlab` docker container. This PR exposes the registry internally on the docker compose network at `http://gitlab:5050`.

[Docs](https://docs.gitlab.com/ee/administration/packages/container_registry.html#configure-container-registry-under-an-existing-gitlab-domain)