### PR TITLE
Reduce the frequency of gitlab tls certificate renewals

### DIFF
--- a/k8s/production/gitlab/certificates.yaml
+++ b/k8s/production/gitlab/certificates.yaml
@@ -11,3 +11,10 @@ spec:
     kind: ClusterIssuer
   dnsNames:
     - gitlab.spack.io
+
+  # Set the renewal very close to the expiration date as a last resort. The policy for renewing
+  # spack-gitlab certificates is to do so manually, as a regeneration of the OIDC thumbprint
+  # (via terraform apply) is required.
+  # Certificate renewals that don't coincide with a regeneration of the OIDC thumbprint will result
+  # in a broken OIDC configuration for all jobs.
+  renewBefore: 48h


### PR DESCRIPTION
This should effectively disable the automatic renewal of the gitlab certificates by cert-manager. Manual renewals are going to be done going forward to ensure that the OIDC configuration is updated in tandem.

See also:
- https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec 
- https://cert-manager.io/docs/reference/cmctl/#renew