### PR TITLE
Upgrade to `v2beta2` of `HelmRelease` kind

### DIFF
--- a/k8s/production/aws-node-termination-handler/release.yaml
+++ b/k8s/production/aws-node-termination-handler/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://aws.github.io/eks-charts
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: aws-node-termination-handler

--- a/k8s/production/cert-manager/release.yaml
+++ b/k8s/production/cert-manager/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.jetstack.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cert-manager

--- a/k8s/production/efs-csi-driver/release.yaml
+++ b/k8s/production/efs-csi-driver/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://kubernetes-sigs.github.io/aws-efs-csi-driver
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: aws-efs-csi-driver

--- a/k8s/production/fluent-bit/release.yaml
+++ b/k8s/production/fluent-bit/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://fluent.github.io/helm-charts
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fluent-bit

--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: gitlab

--- a/k8s/production/ingress-nginx/release.yaml
+++ b/k8s/production/ingress-nginx/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://kubernetes.github.io/ingress-nginx
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ingress-nginx

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -10,7 +10,7 @@ spec:
 
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-graviton2-prot

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-graviton3-prot

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-x86-v2-prot

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-x86-v3-prot

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-x86-v4-prot

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-graviton2-pub

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-graviton3-pub

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-x86-v2-pub

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-x86-v3-pub

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-x86-v4-pub

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://charts.gitlab.io
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: runner-spack-package-signing

--- a/k8s/production/sealed-secrets/release.yaml
+++ b/k8s/production/sealed-secrets/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://bitnami-labs.github.io/sealed-secrets
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sealed-secrets-controller

--- a/k8s/production/sentry/release.yaml
+++ b/k8s/production/sentry/release.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://sentry-kubernetes.github.io/charts
 
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sentry


### PR DESCRIPTION
The Flux changelog mentions that `v2beta1` is deprecated and will soon be removed from Flux - https://github.com/fluxcd/flux2/releases/tag/v2.2.0. I'm also seeing a deprecation warning whenever I apply a HelmRelease YAML with kubectl.

Note: we're currently running Flux v2.2.2.