### PR TITLE
Update terraform state with reality, enable RDS performance insights

### DIFF
--- a/terraform/modules/spack/analytics_db.tf
+++ b/terraform/modules/spack/analytics_db.tf
@@ -34,6 +34,7 @@ module "analytics_db" {
   backup_window                   = "03:00-06:00"
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   create_cloudwatch_log_group     = true
+  performance_insights_enabled    = true
 
   backup_retention_period = 7
   skip_final_snapshot     = false

--- a/terraform/modules/spack/analytics_db.tf
+++ b/terraform/modules/spack/analytics_db.tf
@@ -17,7 +17,7 @@ module "analytics_db" {
   engine               = "postgres"
   family               = "postgres15"
   major_engine_version = "15"
-  engine_version       = "15.3"
+  engine_version       = "15.5"
   instance_class       = var.gitlab_db_instance_class
 
   # Credentials

--- a/terraform/modules/spack/cdash_db.tf
+++ b/terraform/modules/spack/cdash_db.tf
@@ -16,9 +16,10 @@ module "cdash_db" {
   publicly_accessible  = false
   db_subnet_group_name = aws_db_subnet_group.spack.name
 
-  maintenance_window          = "Sun:00:00-Sun:03:00"
-  backup_window               = "03:00-06:00"
-  create_cloudwatch_log_group = true
+  maintenance_window           = "Sun:00:00-Sun:03:00"
+  backup_window                = "03:00-06:00"
+  create_cloudwatch_log_group  = true
+  performance_insights_enabled = true
 
   backup_retention_period = 7
   skip_final_snapshot     = true

--- a/terraform/modules/spack/cdash_db.tf
+++ b/terraform/modules/spack/cdash_db.tf
@@ -5,7 +5,7 @@ module "cdash_db" {
   identifier = "cdash-${var.deployment_name}"
 
   engine               = "mysql"
-  engine_version       = "8.0.33"
+  engine_version       = "8.0.35"
   family               = "mysql8.0"
   major_engine_version = "8.0"
   instance_class       = var.cdash_db_instance_class

--- a/terraform/modules/spack/eks.tf
+++ b/terraform/modules/spack/eks.tf
@@ -152,7 +152,8 @@ resource "aws_iam_role" "eks_cluster_access" {
             "arn:aws:iam::588562868276:user/alecscott",
             "arn:aws:iam::588562868276:user/zack",
             "arn:aws:iam::588562868276:user/joesnyder",
-            "arn:aws:iam::588562868276:user/dan"
+            "arn:aws:iam::588562868276:user/dan",
+            "arn:aws:iam::588562868276:user/william",
           ]
         },
         "Action" : "sts:AssumeRole"

--- a/terraform/modules/spack/gitlab_db.tf
+++ b/terraform/modules/spack/gitlab_db.tf
@@ -74,7 +74,7 @@ module "gitlab_db" {
   identifier = "gitlab-${var.deployment_name}"
 
   engine               = "postgres"
-  engine_version       = "14.7"
+  engine_version       = "14.10"
   family               = "postgres14"
   major_engine_version = "14"
   instance_class       = var.gitlab_db_instance_class

--- a/terraform/modules/spack/gitlab_db.tf
+++ b/terraform/modules/spack/gitlab_db.tf
@@ -92,6 +92,7 @@ module "gitlab_db" {
   backup_window                   = "03:00-06:00"
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
   create_cloudwatch_log_group     = true
+  performance_insights_enabled    = true
 
   backup_retention_period = 7
   skip_final_snapshot     = false


### PR DESCRIPTION
Some AWS resources got changed out from under Terraform, some due to AWS upgrades and some due to some manual actions in the AWS console UI, so this is just bringing the Terraform state up to date with reality.

One exception to this is enabling performance insights for each RDS instance. I had enabled it a while back for the prod gitlab instance for debugging, and I think it's worth enabling for all of our instances since it's free (at least for the default retention rate of 7 days), and might be helpful someday.