### PR TITLE
Align gitlab staging resource limits with production

### DIFF
--- a/k8s/staging/gitlab/kustomization.yaml
+++ b/k8s/staging/gitlab/kustomization.yaml
@@ -37,15 +37,6 @@ patches:
         path: /spec/values/gitlab/webservice/minReplicas
         value: 1
       - op: replace
-        path: /spec/values/gitlab/webservice/maxReplicas
-        value: 3
-      - op: replace
-        path: /spec/values/gitlab/webservice/resources/requests/cpu
-        value: 550m
-      - op: replace
-        path: /spec/values/gitlab/webservice/resources/requests/memory
-        value: 2G
-      - op: replace
         path: /spec/values/gitlab/toolbox/replicas
         value: 1
 


### PR DESCRIPTION
Currently, the resource allocation for the gitlab web server is as follows:
- Production: we always run a minimum of 4 web server pods, and autoscale up to 16 pods when needed
- Staging: we always run a minimum of 1 web server pod, and do not allow any autoscaling. Additionally, we set reduced CPU/memory requests as compared to prod

This PR updates staging to
- Allow it to scale up to the same amount of pods allowed in prod
- Remove the smaller CPU/memory requests and align it with those in prod instead

I left the minimum number of pods set to 1, since there's not really a need to run 4 pods at _all_ times in staging.


This should help alleviate some of the issues @johnwparent observed while testing windows CI in staging.