### PR TITLE
Upgrade `kube-prometheus-stack` to the latest chart version

### DIFF
--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -24,6 +24,10 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kube-prometheus-stack
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
   values:
     defaultRules:
       create: false

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 43.1.1
+      version: 44.0.0
       sourceRef:
         kind: HelmRepository
         name: kube-prometheus-stack

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 51.0.0
+      version: 54.0.0
       sourceRef:
         kind: HelmRepository
         name: kube-prometheus-stack

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 44.0.0
+      version: 48.0.0
       sourceRef:
         kind: HelmRepository
         name: kube-prometheus-stack

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 48.0.0
+      version: 51.0.0
       sourceRef:
         kind: HelmRepository
         name: kube-prometheus-stack

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 57.0.0
+      version: 57.1.1
       sourceRef:
         kind: HelmRepository
         name: kube-prometheus-stack

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 56.0.0
+      version: 57.0.0
       sourceRef:
         kind: HelmRepository
         name: kube-prometheus-stack

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 54.0.0
+      version: 55.0.0
       sourceRef:
         kind: HelmRepository
         name: kube-prometheus-stack

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 55.0.0
+      version: 56.0.0
       sourceRef:
         kind: HelmRepository
         name: kube-prometheus-stack
@@ -77,8 +77,8 @@ spec:
           api_url: https://api.github.com/user
 #          team_ids:
           allowed_organizations: spack
-          client_id: DEADBEEF # Will be overriden by environment vars
-          client_secret: DEADBEEF # Will be overriden by environment vars
+          # client_id: DEADBEEF # Will be overriden by environment vars
+          # client_secret: DEADBEEF # Will be overriden by environment vars
 
       # https://github.com/grafana/helm-charts/blob/673566ba032c2df7108514ad8cb51500fdb48de3/charts/grafana/values.yaml#L501-L505
       plugins:


### PR DESCRIPTION
Luckily there were not changes to the Helm chart values.yaml, so this was relatively straightforward to do. 

The only other change I made in https://github.com/spack/spack-infrastructure/commit/7f3c5800a01a9fd0817d724ef3d98af0bfcaa543 is to tell Flux to automatically handle upgrading CRDs when the chart is upgraded, as opposed to me needing to run all these CRD upgrade commands on each version jump - https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/README.md#upgrading-an-existing-release-to-a-new-major-version