### PR TITLE
Karpenter Windows Runners: source envvars file

### DIFF
--- a/k8s/staging/runners/protected/windows/x86_64/v2/release.yaml
+++ b/k8s/staging/runners/protected/windows/x86_64/v2/release.yaml
@@ -57,27 +57,14 @@ spec:
           pre_build_script = """
           Write-Output 'Executing Spack pre-build setup script'
 
-          $PY3 = $null
-          $pythonCmds = @('python3', 'python')
-
-          foreach ($cmd in $pythonCmds) {
-              if (Get-Command -ErrorAction SilentlyContinue $cmd) {
-                  $PY3 = Get-Command $cmd
-                  break
-              }
-          }
-
-          if (-not $PY3) {
-              Write-Output "Unable to find python3 executable"
-              exit 1
-          }
-
           $scriptPath = Join-Path $PSScriptRoot 'pre_build.py'
 
           $wc = New-Object System.Net.WebClient
           $wc.DownloadFile('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', $scriptPath)
 
-          & $PY3 $scriptPath | Out-File -FilePath 'envvars' -Encoding utf8
+          & python $scriptPath | Out-File -FilePath 'envvars.ps1' -Encoding utf8
+
+          ./envvars.ps1
 
           Remove-Item $scriptPath -Force
           Remove-Item 'envvars' -Force

--- a/k8s/staging/runners/protected/windows/x86_64/v2/release.yaml
+++ b/k8s/staging/runners/protected/windows/x86_64/v2/release.yaml
@@ -63,6 +63,7 @@ spec:
               Python not available on system, please install or
               add to the PATH
               "@
+            exit 1
           }
 
           $scriptPath = Join-Path $PSScriptRoot 'pre_build.py'

--- a/k8s/staging/runners/protected/windows/x86_64/v2/release.yaml
+++ b/k8s/staging/runners/protected/windows/x86_64/v2/release.yaml
@@ -57,6 +57,14 @@ spec:
           pre_build_script = """
           Write-Output 'Executing Spack pre-build setup script'
 
+          $a=(get-command -ErrorAction SilentlyContinue fake)
+          if ( -not $a ) {
+            Write-Output @"
+              Python not available on system, please install or
+              add to the PATH
+              "@
+          }
+
           $scriptPath = Join-Path $PSScriptRoot 'pre_build.py'
 
           $wc = New-Object System.Net.WebClient

--- a/k8s/staging/runners/protected/windows/x86_64/v2/release.yaml
+++ b/k8s/staging/runners/protected/windows/x86_64/v2/release.yaml
@@ -57,8 +57,8 @@ spec:
           pre_build_script = """
           Write-Output 'Executing Spack pre-build setup script'
 
-          $a=(get-command -ErrorAction SilentlyContinue fake)
-          if ( -not $a ) {
+          $py=(get-command -ErrorAction SilentlyContinue python)
+          if ( -not $py ) {
             Write-Output @"
               Python not available on system, please install or
               add to the PATH

--- a/k8s/staging/runners/public/windows/x86_64/v2/release.yaml
+++ b/k8s/staging/runners/public/windows/x86_64/v2/release.yaml
@@ -63,6 +63,7 @@ spec:
               Python not available on system, please install or
               add to the PATH
               "@
+            exit 1
           }
 
           $scriptPath = Join-Path $PSScriptRoot 'pre_build.py'

--- a/k8s/staging/runners/public/windows/x86_64/v2/release.yaml
+++ b/k8s/staging/runners/public/windows/x86_64/v2/release.yaml
@@ -57,6 +57,14 @@ spec:
           pre_build_script = """
           Write-Output 'Executing Spack pre-build setup script'
 
+          $a=(get-command -ErrorAction SilentlyContinue fake)
+          if ( -not $a ) {
+            Write-Output @"
+              Python not available on system, please install or
+              add to the PATH
+              "@
+          }
+
           $scriptPath = Join-Path $PSScriptRoot 'pre_build.py'
 
           $wc = New-Object System.Net.WebClient

--- a/k8s/staging/runners/public/windows/x86_64/v2/release.yaml
+++ b/k8s/staging/runners/public/windows/x86_64/v2/release.yaml
@@ -57,8 +57,8 @@ spec:
           pre_build_script = """
           Write-Output 'Executing Spack pre-build setup script'
 
-          $a=(get-command -ErrorAction SilentlyContinue fake)
-          if ( -not $a ) {
+          $py=(get-command -ErrorAction SilentlyContinue python)
+          if ( -not $py ) {
             Write-Output @"
               Python not available on system, please install or
               add to the PATH

--- a/k8s/staging/runners/public/windows/x86_64/v2/release.yaml
+++ b/k8s/staging/runners/public/windows/x86_64/v2/release.yaml
@@ -57,30 +57,17 @@ spec:
           pre_build_script = """
           Write-Output 'Executing Spack pre-build setup script'
 
-          $PY3 = $null
-          $pythonCmds = @('python3', 'python')
-
-          foreach ($cmd in $pythonCmds) {
-              if (Get-Command -ErrorAction SilentlyContinue $cmd) {
-                  $PY3 = Get-Command $cmd
-                  break
-              }
-          }
-
-          if (-not $PY3) {
-              Write-Output "Unable to find python3 executable"
-              exit 1
-          }
-
           $scriptPath = Join-Path $PSScriptRoot 'pre_build.py'
 
           $wc = New-Object System.Net.WebClient
           $wc.DownloadFile('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', $scriptPath)
 
-          & $PY3 $scriptPath | Out-File -FilePath 'envvars' -Encoding utf8
+          & python $scriptPath | Out-File -FilePath 'envvars.ps1' -Encoding utf8
+
+          ./envvars.ps1
 
           Remove-Item $scriptPath -Force
-          Remove-Item 'envvars' -Force
+          Remove-Item 'envvars.ps1' -Force
 
           $env:GITLAB_OIDC_TOKEN = $null
           """

--- a/scripts/gitlab_runner_pre_build/pre_build.py
+++ b/scripts/gitlab_runner_pre_build/pre_build.py
@@ -111,9 +111,12 @@ if __name__ == "__main__":
 
     response = _gitlab_token_to_credentials(os.environ["GITLAB_OIDC_TOKEN"])
 
+    set_env_cmd = "export "
+    if sys.platform == "win32":
+        set_env_cmd = "$Env:"
     # print credentials to stdout
-    print(f'export AWS_ACCESS_KEY_ID="{response["AccessKeyId"]}"')
-    print(f'export AWS_SECRET_ACCESS_KEY="{response["SecretAccessKey"]}"')
-    print(f'export AWS_SESSION_TOKEN="{response["SessionToken"]}"')
+    print(f'{set_env_cmd}AWS_ACCESS_KEY_ID="{response["AccessKeyId"]}"')
+    print(f'{set_env_cmd}AWS_SECRET_ACCESS_KEY="{response["SecretAccessKey"]}"')
+    print(f'{set_env_cmd}AWS_SESSION_TOKEN="{response["SessionToken"]}"')
 
     print("done.", file=sys.stderr)


### PR DESCRIPTION
Updates Windows runner prescript to generate `envvars` as a `.ps1` file, source it with powershell, and refactors the pre build Python script to generate powershell compatible export commands

Removed the logic searching for Python at the beginning of the setup script, Python is just `python` on Windows.

CC @kwryankrattiger @mvandenburgh  
Please let me know if I need to update something else to be compatible with this.
