### PR TITLE
Don't use multiline string or double quotes

### DIFF
--- a/k8s/staging/runners/protected/windows/x86_64/v2/release.yaml
+++ b/k8s/staging/runners/protected/windows/x86_64/v2/release.yaml
@@ -59,10 +59,7 @@ spec:
 
           $py=(get-command -ErrorAction SilentlyContinue python)
           if ( -not $py ) {
-            Write-Output @"
-              Python not available on system, please install or
-              add to the PATH
-              "@
+            Write-Output 'Python was not found on the system. Add it to the PATH or install.'
             exit 1
           }
 
@@ -76,7 +73,7 @@ spec:
           ./envvars.ps1
 
           Remove-Item $scriptPath -Force
-          Remove-Item 'envvars' -Force
+          Remove-Item 'envvars.ps1' -Force
 
           $env:GITLAB_OIDC_TOKEN = $null
           """

--- a/k8s/staging/runners/public/windows/x86_64/v2/release.yaml
+++ b/k8s/staging/runners/public/windows/x86_64/v2/release.yaml
@@ -59,10 +59,7 @@ spec:
 
           $py=(get-command -ErrorAction SilentlyContinue python)
           if ( -not $py ) {
-            Write-Output @"
-              Python not available on system, please install or
-              add to the PATH
-              "@
+            Write-Output 'Python not found on the system. Add it to the PATH or install.'
             exit 1
           }
 


### PR DESCRIPTION
Multiline strings and double quotes were functional when run from a script directly but seem to cause issues with the TOML and other parsing this attribute is passed through before being composed into the step script. 
Remove those elements.

CC @kwryankrattiger 