### PR TITLE
Increase retries for jobs that use opensearch

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -40,7 +40,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.2.5
+            image-tags: ghcr.io/spack/django:0.2.6
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/analytics/analytics/core/job_failure_classifier/__init__.py
+++ b/analytics/analytics/core/job_failure_classifier/__init__.py
@@ -172,8 +172,10 @@ def _collect_pod_status(job_input_data: dict[str, Any], job_trace: str):
     name="upload_job_failure_classification",
     soft_time_limit=60,
     autoretry_for=(ReadTimeoutError, ConnectionTimeout),
-    retry_backoff=5,
-    max_retries=5,
+    retry_backoff=30,
+    retry_backoff_max=3600,
+    max_retries=10,
+    retry_jitter=True,
 )
 def upload_job_failure_classification(job_input_data_json: str) -> None:
     gl = gitlab.Gitlab(settings.GITLAB_ENDPOINT, settings.GITLAB_TOKEN, retry_transient_errors=True)

--- a/analytics/analytics/core/job_log_uploader/__init__.py
+++ b/analytics/analytics/core/job_log_uploader/__init__.py
@@ -92,8 +92,10 @@ def _create_job_attempt(
     name="store_job_data",
     soft_time_limit=60,
     autoretry_for=(ReadTimeoutError, ConnectionTimeout),
-    retry_backoff=5,
-    max_retries=5,
+    retry_backoff=30,
+    retry_backoff_max=3600,
+    max_retries=10,
+    retry_jitter=True,
 )
 def store_job_data(job_input_data_json: str) -> None:
     job_input_data: dict[str, Any] = json.loads(job_input_data_json)

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.2.5
+          image: ghcr.io/spack/django:0.2.6
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.2.5
+          image: ghcr.io/spack/django:0.2.6
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
Given that opensearch seems to struggle during periods of high traffic, this increases the retry parameters to allow tasks to take a bit longer to settle. `retry_jitter` was already enabled, I just added it to make it a bit more explicit that we won't be subject to a thundering herd problem.