### PR TITLE
Only run TF validate workflow if PR touches terraform

### DIFF
--- a/.github/workflows/validate-terraform.yaml
+++ b/.github/workflows/validate-terraform.yaml
@@ -7,6 +7,9 @@ on:
       - 'terraform/**'
       - 'terraform-bootstrap/**'
   pull_request:
+    paths:
+      - 'terraform/**'
+      - 'terraform-bootstrap/**'
 
 jobs:
   lint:


### PR DESCRIPTION
I noticed this workflow was running on PRs that don't modify any TF code.