### PR TITLE
Enable dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[gh-actions]"
+      include: scope
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
We have these annoying warnings that pop up due to using deprecated github action versions (see https://github.com/spack/spack-infrastructure/actions/runs/8693442058 for example). 

This PR enables dependabot for GH Actions only. Dependabot can get really noisy if you're pinning python/application-level dependencies, but we've used it for keeping just github actions up to date on other projects and it's worked out well. 

https://github.com/dependabot/dependabot-core/issues/4691 indicates that it is compatible with the commit SHA pinning syntax we use, too.