### PR TITLE
Add retries/exp. backoff to TF init

### DIFF
--- a/.github/workflows/terraform-drift-detection.yaml
+++ b/.github/workflows/terraform-drift-detection.yaml
@@ -6,6 +6,7 @@ on:
     # so they recommend scheduling them at a random minute instead of
     # minute 0. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     - cron: '16 * * * *'
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/terraform-drift-detection.yaml
+++ b/.github/workflows/terraform-drift-detection.yaml
@@ -34,7 +34,11 @@ jobs:
           terraform_wrapper: false
 
       - name: Initialize Terraform
-        run: terraform init
+        uses: nick-invision/retry@7152eba30c6575329ac0576536151aca5a72780e  # v3.0.0
+        with:
+          command: cd terraform/production && terraform init
+          max_attempts: 5
+          timeout_minutes: 5
 
       - name: Run Terraform Plan
         run: terraform plan -lock=false -detailed-exitcode -no-color -input=false -out=tfplan > tfplan_output.txt 2>&1


### PR DESCRIPTION
Hopefully this cuts down on the amount of false positives we get from the drift detection job due to transient network failures on the `terraform init` step.