### PR TITLE
Align gitlab webservice/sidekiq resource requests with recommended values

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -139,12 +139,14 @@ spec:
         minReplicas: 4
         maxReplicas: 16
         resources:
+          # Based on webservice resources here
+          # https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology
           limits:
-            cpu: 1500m
-            memory: 3.5G
+            cpu: 48
+            memory: 32G
           requests:
-            cpu: 300m
-            memory: 2.5G
+            cpu: 16
+            memory: 14.4G
         nodeSelector:
           spack.io/node-pool: gitlab
       gitlab-exporter:
@@ -158,6 +160,12 @@ spec:
           spack.io/node-pool: gitlab
 
       sidekiq:
+        resources:
+          # Based on sidekiq resources here
+          # https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology
+          requests:
+            cpu: 4
+            memory: 15G
         nodeSelector:
           spack.io/node-pool: gitlab
 


### PR DESCRIPTION
See https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology

The 3k users tier is the minimum requirements for a gitlab deployment to be considered "high-availability" and is what we followed when provisioning other AWS resources such as postgres in RDS and redis in elasticache.