### PR TITLE
Add `c5.4xlarge` instance type to `gitlab` provisioner

### DIFF
--- a/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
@@ -14,7 +14,11 @@ spec:
   requirements:
     - key: "node.kubernetes.io/instance-type"
       operator: In
-      values: ["t3.xlarge", "m5.xlarge", "m5.4xlarge"]
+      values:
+        - "t3.xlarge"
+        - "m5.xlarge"
+        - "m5.4xlarge"
+        - "c5.4xlarge"  # recommended by gitlab - https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology
 
     # Always use on-demand
     - key: "karpenter.sh/capacity-type"


### PR DESCRIPTION
This is the instance type recommended by gitlab for the webservice. https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology

It seems Karpenter is having trouble scheduling the webservice pods after #817 . Giving it this instance type should fix that.