### PR TITLE
Add c6a.8xlarge to gitlab provisioner

### DIFF
--- a/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
@@ -15,10 +15,15 @@ spec:
     - key: "node.kubernetes.io/instance-type"
       operator: In
       values:
+      # Instance types are partly based on gitlab's recommendations
+      # https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology
+      #
+      # The c6a.8xlarge is needed so that the webservice pod (requests 16 vCPUs) can be scheduled
+      # in the cluster alongside the necessary DaemonSet pods.
         - "t3.xlarge"
         - "m5.xlarge"
         - "m5.4xlarge"
-        - "c5.4xlarge"  # recommended by gitlab - https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology
+        - "c5.4xlarge"
         - "c6a.8xlarge"
 
     # Always use on-demand

--- a/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
@@ -19,6 +19,7 @@ spec:
         - "m5.xlarge"
         - "m5.4xlarge"
         - "c5.4xlarge"  # recommended by gitlab - https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology
+        - "c6a.8xlarge"
 
     # Always use on-demand
     - key: "karpenter.sh/capacity-type"


### PR DESCRIPTION
As I mentioned here https://github.com/spack/spack-infrastructure/pull/819#issuecomment-2059910506, the gitlab webservice requires 16.4 vCPUs (so really, 17) to run, as [the recommended specs from gitlab](https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology) themselves is 16 vCPUs, but I didn't account for the approximately 0.4 vCPUs for daemonsets that must also run on the node. 

The `c6a.8xlarge` instance is the cheapest one I could find that has the required CPU and is also x86-based (gitlab web service does not have an ARM image), so I picked that one. https://instances.vantage.sh/?min_vcpus=17

Karpenter will hopefully be smart enough to schedule a bunch of other gitlab pods on this instance next to the webservice so that the increased instance cost doesn't affect us in the bigger picture.