### PR TITLE
Add windows runners to gitlab.spack.io

### DIFF
--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -32,14 +32,10 @@ spec:
       valuesKey: values.yaml
 
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.7.0
     imagePullPolicy: IfNotPresent
-    replicas: 1
+    replicas: 6
 
-    # TODO: change to production when ready
-    gitlabUrl: "https://gitlab.staging.spack.io/"
+    gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
     concurrent: 20
@@ -80,36 +76,34 @@ spec:
 
           shell = "powershell"
           executor = "kubernetes"
-          output_limit = 4096
+          output_limit = 20480
 
           # Ensure windows paths are used
           [runners.feature_flags]
             FF_USE_POWERSHELL_PATH_RESOLVER = true
 
           [runners.kubernetes]
-            namespace = "pipeline"
-            service_account = "runner"
-            # Allow 30 minutes for the pod to be ready. This is necessary because
-            # the windows docker image can take a significantly long time to pull.
-            poll_timeout = 1800
             privileged = false
+            helper_memory_request = "1"
+
+            cpu_request = "750m"
+            cpu_request_overwrite_max_allowed = "12"
+
+            memory_request = "2G"
+            memory_request_overwrite_max_allowed = "64G"
+            memory_limit = "64G"
+            memory_limit_overwrite_max_allowed = "64G"
+
+            namespace = "pipeline"
+            # Allow 30 minutes for the pod to be ready. This is necessary because
+            # the windows docker image can take a significantly long time to pull/boot.
+            poll_timeout = 1800
+            service_account = "runner"
 
             # Image for windows 2022, runner helper
             image = "mcr.microsoft.com/windows/servercore:ltsc2022"
             helper_image = "gitlab/gitlab-runner-helper:x86_64-v16.11.1-servercore21H2"
 
-            # CPU requests/limits
-            cpu_request = "750m"
-            cpu_request_overwrite_max_allowed = "12"
-
-            # Memory requests/limits
-            helper_memory_request = "1"
-            memory_request = "2G"
-            memory_request_overwrite_max_allowed = "48G"
-            memory_limit = "48G"
-            memory_limit_overwrite_max_allowed = "48G"
-
-            # Storage requests/limits
             ephemeral_storage_request = "500M"
             helper_ephemeral_storage_request = "500M"
 
@@ -166,7 +160,9 @@ spec:
       runUntagged: false
 
       tags: "spack,protected,small,medium,win64,x86_64-win,x86_64_v2-win,aws"
-      secret: gitlab-gitlab-runner-secret # from gitlab release
+      secret: spack-project-runner-registration-token
+
+      serviceAccountName: runner
 
       cache: {}
 

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -151,6 +151,11 @@ spec:
               "spack.io/runner-taint=true" = "NoSchedule"
               "windows=true" = "NoSchedule"
 
+            [[runners.kubernetes.volumes.secret]]
+              name = "spack-intermediate-ci-signing-key"
+              mount_path = "C:\\key"
+              read_only = true
+
       # default image
       image: "mcr.microsoft.com/windows/servercore:ltsc2022"
       imagePullPolicy: "if-not-present"

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -32,14 +32,11 @@ spec:
       valuesKey: values.yaml
 
   values:
-    image:
-      image: gitlab-org/gitlab-runner
-      tag: alpine-v16.7.0
     imagePullPolicy: IfNotPresent
-    replicas: 1
+    replicas: 6
 
     # TODO: change to production when ready
-    gitlabUrl: "https://gitlab.staging.spack.io/"
+    gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true
     terminationGracePeriodSeconds: 21600 # six hours
     concurrent: 20
@@ -80,36 +77,34 @@ spec:
 
           shell = "powershell"
           executor = "kubernetes"
-          output_limit = 4096
+          output_limit = 20480
 
           # Ensure windows paths are used
           [runners.feature_flags]
             FF_USE_POWERSHELL_PATH_RESOLVER = true
 
           [runners.kubernetes]
-            namespace = "pipeline"
-            service_account = "runner"
-            # Allow 30 minutes for the pod to be ready. This is necessary because
-            # the windows docker image can take a significantly long time to pull.
-            poll_timeout = 1800
             privileged = false
+            helper_memory_request = "1"
 
-            # Image for windows 2022, runner helper
-            image = "mcr.microsoft.com/windows/servercore:ltsc2022"
-            helper_image = "gitlab/gitlab-runner-helper:x86_64-v16.11.1-servercore21H2"
-
-            # CPU requests/limits
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"
 
-            # Memory requests/limits
-            helper_memory_request = "1"
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "48G"
             memory_limit = "48G"
             memory_limit_overwrite_max_allowed = "48G"
 
-            # Storage requests/limits
+            namespace = "pipeline"
+            # Allow 30 minutes for the pod to be ready. This is necessary because
+            # the windows docker image can take a significantly long time to pull.
+            poll_timeout = 1800
+            service_account = "runner"
+
+            # Image for windows 2022, runner helper
+            image = "mcr.microsoft.com/windows/servercore:ltsc2022"
+            helper_image = "gitlab/gitlab-runner-helper:x86_64-v16.11.1-servercore21H2"
+
             ephemeral_storage_request = "500M"
             helper_ephemeral_storage_request = "500M"
 

--- a/k8s/staging/runners/kustomization.yaml
+++ b/k8s/staging/runners/kustomization.yaml
@@ -9,11 +9,13 @@ resources:
 - ../../production/runners/public/x86_64/v2/release.yaml
 - ../../production/runners/public/x86_64/v3/release.yaml
 - ../../production/runners/public/x86_64/v4/release.yaml
+- ../../production/runners/public/x86_64/v2-win/release.yaml
 - ../../production/runners/protected/graviton/2/release.yaml
 - ../../production/runners/protected/graviton/3/release.yaml
 - ../../production/runners/protected/x86_64/v2/release.yaml
 - ../../production/runners/protected/x86_64/v3/release.yaml
 - ../../production/runners/protected/x86_64/v4/release.yaml
+- ../../production/runners/protected/x86_64/v2-win/release.yaml
 - ../../production/runners/signing/release.yaml
 
 patchesStrategicMerge:
@@ -80,6 +82,15 @@ patches:
 
   - target:
       kind: HelmRelease
+      name: runner-x86-v2-pub-windows
+      namespace: gitlab
+    patch: |-
+      - op: replace
+        path: /spec/values/gitlabUrl
+        value: https://gitlab.staging.spack.io/
+
+  - target:
+      kind: HelmRelease
       name: runner-graviton2-prot
       namespace: gitlab
     patch: |-
@@ -117,6 +128,15 @@ patches:
   - target:
       kind: HelmRelease
       name: runner-x86-v4-prot
+      namespace: gitlab
+    patch: |-
+      - op: replace
+        path: /spec/values/gitlabUrl
+        value: https://gitlab.staging.spack.io/
+
+  - target:
+      kind: HelmRelease
+      name: runner-x86-v2-prot-windows
       namespace: gitlab
     patch: |-
       - op: replace


### PR DESCRIPTION
This PR makes the necessary changes to spin up Windows GitLab runners on gitlab.spack.io. All of the work needed to allow Karpenter/k8s to run windows nodes was already done and applied by #764; this PR just moves the existing staging runners to production.

I noticed a few inconsistencies in the runner config YAML when compared to the linux public/protected x86 v2 (likely due to changes in the latter since the staging windows runners were created), so I also updated that to be consistent.

attn @johnwparent @kwryankrattiger 