### PR TITLE
Remove `c6a.8xlarge` from gitlab provisioner

### DIFF
--- a/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
@@ -17,14 +17,10 @@ spec:
       values:
       # Instance types are partly based on gitlab's recommendations
       # https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology
-      #
-      # The c6a.8xlarge is needed so that the webservice pod (requests 16 vCPUs) can be scheduled
-      # in the cluster alongside the necessary DaemonSet pods.
         - "t3.xlarge"
         - "m5.xlarge"
         - "m5.4xlarge"
         - "c5.4xlarge"
-        - "c6a.8xlarge"
 
     # Always use on-demand
     - key: "karpenter.sh/capacity-type"


### PR DESCRIPTION
This is no longer needed now that we've lowered gitlab webservice resource requests #838. I disabled flux and removed this in the cluster, and the pods were still schedulable.