### PR TITLE
Drop unused service account

### DIFF
--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -13,7 +13,6 @@ spec:
       backoffLimit: 0
       template:
         spec:
-          serviceAccountName: gh-gl-sync
           restartPolicy: Never
           containers:
           - name: sync

--- a/k8s/production/custom/gh-gl-sync/service-accounts.yaml
+++ b/k8s/production/custom/gh-gl-sync/service-accounts.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: gh-gl-sync
-  namespace: custom
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::588562868276:role/DeleteObjectsFromBucketSpackBinariesPRs


### PR DESCRIPTION
After moving the PR branch cleanup to the spack bot this service account is not longer needed for the sync script.