### PR TITLE
Enforce exit on failure of native commands on Windows

### DIFF
--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -65,6 +65,10 @@ spec:
           $wc.DownloadFile('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', $scriptPath)
 
           & python $scriptPath | Out-File -FilePath 'envvars.ps1' -Encoding utf8
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "Prebuild script pre_build.py failed with exit code $LASTEXITCODE. See error above for more info"
+            exit 1
+          }
 
           ./envvars.ps1
 

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -66,7 +66,10 @@ spec:
           $wc.DownloadFile('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', $scriptPath)
 
           & python $scriptPath | Out-File -FilePath 'envvars.ps1' -Encoding utf8
-
+          if ($LASTEXITCODE -ne 0) {
+            Write-Output "Prebuild script pre_build.py failed with exit code $LASTEXITCODE. See error above for more info"
+            exit 1
+          }
           ./envvars.ps1
 
           Remove-Item $scriptPath -Force


### PR DESCRIPTION
Native commands don't cause powershell to stop execution on failure because powershell's exception handling does not consider native command exit codes. 
Add deliberate handling for these cases (pretty much just the calls to the prebuild script).