### PR TITLE
Increase memory request/limit for gitlab webservice

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -143,10 +143,10 @@ spec:
           # https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology
           limits:
             cpu: 12
-            memory: 7G
+            memory: 20G
           requests:
             cpu: 4
-            memory: 5G
+            memory: 14G
         nodeSelector:
           spack.io/node-pool: gitlab
       gitlab-exporter:


### PR DESCRIPTION
As of #838, we request 7GB for each gitlab webservice pod. We've been seeing sporadic downtime of a few seconds on gitlab.spack.io for the last week, and it looks like memory usage has been at about 14 GB for each gitlab webservice pod that period of time
https://grafana.spack.io/d/d249cc23-6930-403e-91f6-c9c30389b88d/kubernetes-deployment-cpu-and-memory-metrics

I verified that Karpenter can spin up necessary nodes to accomodate this without adding new instance types.