### PR TITLE
Add S3 lifecycle rule for non-current versions

### DIFF
--- a/terraform/modules/spack/modules/binary_mirror/binary_mirror_bucket.tf
+++ b/terraform/modules/spack/modules/binary_mirror/binary_mirror_bucket.tf
@@ -40,6 +40,22 @@ resource "aws_s3_bucket_versioning" "binary_mirror" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "binary_mirror" {
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.binary_mirror]
+
+  bucket = aws_s3_bucket.binary_mirror.id
+
+  rule {
+    id = "DeleteNonCurrentAfter30Days"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    status = "Enabled"
+  }
+}
 
 resource "aws_s3_bucket_acl" "binary_mirror" {
   bucket = aws_s3_bucket.binary_mirror.id


### PR DESCRIPTION
Following this [example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#creating-a-lifecycle-configuration-for-a-bucket-with-versioning), encode our existing lifecycle rule expiring objects 30 days after they become non-current.