### PR TITLE
Add service account to spack-gantry statefulset

### DIFF
--- a/k8s/production/spack/gantry-spack-io/stateful-sets.yaml
+++ b/k8s/production/spack/gantry-spack-io/stateful-sets.yaml
@@ -33,6 +33,9 @@ spec:
         app: spack-gantry
     spec:
 
+      # Grants permission to access S3 bucket for Litestream
+      serviceAccountName: spack-gantry
+
       # The config map is used to pass in our Litestream configuration file.
       volumes:
       - name: configmap


### PR DESCRIPTION
This was missing in #826/#827