### PR TITLE
Bump memory request of protected-publish cron job

### DIFF
--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -21,7 +21,7 @@ spec:
             resources:
               requests:
                 cpu: 1500m
-                memory: 2G
+                memory: 3G
                 ephemeral-storage: "50G"
             envFrom:
               - configMapRef:


### PR DESCRIPTION
This pod may have run up against memory pressure recently, so request more memory in the hopes that kube will mostly give it a node of its own.