### PR TITLE
Increase resources for protected-publish again

### DIFF
--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -21,7 +21,7 @@ spec:
             resources:
               requests:
                 cpu: 1500m
-                memory: 2500M
+                memory: 6G
                 ephemeral-storage: "50G"
             envFrom:
               - configMapRef:

--- a/k8s/production/karpenter/provisioners/base/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/base/provisioner.yaml
@@ -18,7 +18,10 @@ spec:
   requirements:
     - key: "node.kubernetes.io/instance-type"
       operator: In
-      values: ["t3.small", "t3.medium"]
+      values:
+        - "t3.small"
+        - "t3.medium"
+        - "m4.large"
 
     # Always use on-demand
     - key: "karpenter.sh/capacity-type"


### PR DESCRIPTION
The `m4.large` instance type has 2 vCPU and 8 GB memory, so let's try that type and request most of that memory for this job.