### PR TITLE
Match gantry selectors to fix deployment

### DIFF
--- a/k8s/production/spack/gantry-spack-io/stateful-sets.yaml
+++ b/k8s/production/spack/gantry-spack-io/stateful-sets.yaml
@@ -6,6 +6,9 @@ kind: StatefulSet
 metadata:
   name: spack-gantry
   namespace: spack
+  labels:
+    app: spack-gantry
+    svc: web
 spec:
   selector:
     matchLabels:
@@ -31,6 +34,7 @@ spec:
     metadata:
       labels:
         app: spack-gantry
+        svc: web
     spec:
 
       # Grants permission to access S3 bucket for Litestream


### PR DESCRIPTION
At the moment, gantry isn't working correctly in the cluster:

```
$ kubectl exec -it spack-gantry-0 -c litestream -- sh                                                          
/ # wget spack-gantry.default.svc.cluster.local
Connecting to spack-gantry.default.svc.cluster.local (10.96.254.66:80)
wget: can't connect to remote host (10.96.254.66): Connection refused
/ # 
command terminated with exit code 1
$ kubectl describe svc spack-gantry
Name:              spack-gantry
Namespace:         default
Labels:            app=spack-gantry
                   svc=web
Annotations:       <none>
Selector:          app=spack-gantry,svc=web
...
Endpoints:         <none>
```

No endpoints are created for the service, meaning that the selector could be off.

Now, everything works fine (tested locally):

```
$ kubectl exec -it spack-gantry-0 -c litestream -- sh                                                           
/ # wget spack-gantry.default.svc.cluster.local
Connecting to spack-gantry.default.svc.cluster.local (10.96.201.218:80)
wget: server returned error: HTTP/1.1 404 Not Found
/ # 
command terminated with exit code 1
$ kubectl describe svc spack-gantry                                                                             
Name:              spack-gantry
Namespace:         default
Labels:            app=spack-gantry
                   svc=web
Annotations:       <none>
Selector:          app=spack-gantry,svc=web
...
Endpoints:         10.244.0.24:8080
```