### PR TITLE
New cron job to restart gitlab-webservice once a day

### DIFF
--- a/k8s/production/custom/gitlab-restart-webservice/cronjobs.yaml
+++ b/k8s/production/custom/gitlab-restart-webservice/cronjobs.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: gitlab-restart-webservice
+  namespace: gitlab
+spec:
+  # Run daily at 12:30am UTC.
+  schedule: "30 0 * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  # Only save the most recent run to avoid overpopulating the pod list in the gitlab namespace.
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      labels:
+        app: gitlab-restart-webservice
+    spec:
+      template:
+        metadata:
+          name: gitlab-restart-webservice
+          namespace: gitlab
+          labels:
+            app: gitlab-restart-webservice
+        spec:
+          serviceAccountName: gitlab-restart-webservice
+          restartPolicy: Never
+          containers:
+            - name: restarter
+              image: bitnami/kubectl
+              imagePullPolicy: IfNotPresent
+              command: ["kubectl"]
+              args:
+                [
+                  "-n",
+                  "gitlab",
+                  "rollout",
+                  "restart",
+                  "deployment",
+                  "gitlab-webservice-default",
+                ]
+          nodeSelector:
+            spack.io/node-pool: base

--- a/k8s/production/custom/gitlab-restart-webservice/serviceaccounts.yaml
+++ b/k8s/production/custom/gitlab-restart-webservice/serviceaccounts.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gitlab-restart-webservice
+  namespace: gitlab
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitlab-restart-webservice
+  namespace: gitlab
+rules:
+  - apiGroups: ["", "extensions", "apps"]
+    resources: ["deployments", "replicasets", "pods", "pods/exec"]
+    verbs: ["get", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitlab-restart-webservice
+  namespace: gitlab
+subjects:
+  - kind: ServiceAccount
+    name: gitlab-restart-webservice
+roleRef:
+  kind: Role
+  name: gitlab-restart-webservice
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This will help mitigate the issue we've seen where the GitLab webservice consumes more and more memory as time goes on, which eventually results in spurious CI job failures.

The relevant upstream issue appears to be:
https://gitlab.com/gitlab-org/gitlab/-/issues/432847