### PR TITLE
Upgrade EKS clusters to 1.29, fix scheduling issue with bootstrap pods

### DIFF
--- a/k8s/production/sealed-secrets/release.yaml
+++ b/k8s/production/sealed-secrets/release.yaml
@@ -26,3 +26,7 @@ spec:
   values:
     nodeSelector:
       spack.io/node-pool: base
+    tolerations:
+      - key: SpackBootstrap
+        operator: Equal
+        effect: NoSchedule

--- a/terraform/modules/spack/eks.tf
+++ b/terraform/modules/spack/eks.tf
@@ -84,6 +84,13 @@ module "eks" {
 
       create_iam_role = false
       iam_role_arn    = aws_iam_role.managed_node_group.arn
+
+      taints = {
+        spack-bootstrap = {
+          key    = "SpackBootstrap"
+          effect = "NO_SCHEDULE"
+        }
+      }
     }
   }
 

--- a/terraform/modules/spack/karpenter.tf
+++ b/terraform/modules/spack/karpenter.tf
@@ -70,6 +70,11 @@ resource "helm_release" "karpenter" {
     value = "1Gi"
   }
 
+  set {
+    name = "tolerations[0].key"
+    value = "SpackBootstrap"
+  }
+
   # Enable service monitor for prometheus metrics
   set {
     name  = "serviceMonitor.enabled"

--- a/terraform/modules/spack/karpenter.tf
+++ b/terraform/modules/spack/karpenter.tf
@@ -71,7 +71,7 @@ resource "helm_release" "karpenter" {
   }
 
   set {
-    name = "tolerations[0].key"
+    name  = "tolerations[0].key"
     value = "SpackBootstrap"
   }
 

--- a/terraform/production/flux.tf
+++ b/terraform/production/flux.tf
@@ -24,5 +24,6 @@ provider "flux" {
 }
 
 resource "flux_bootstrap_git" "this" {
-  path = "k8s/production/"
+  path            = "k8s/production/"
+  toleration_keys = ["SpackBootstrap"]
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -130,7 +130,7 @@ module "production_cluster" {
 
   gitlab_url = local.gitlab_url
 
-  kubernetes_version = "1.28"
+  kubernetes_version = "1.29"
 
   availability_zones = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d"]
 

--- a/terraform/staging/flux.tf
+++ b/terraform/staging/flux.tf
@@ -24,5 +24,6 @@ provider "flux" {
 }
 
 resource "flux_bootstrap_git" "this" {
-  path = "k8s/staging/"
+  path            = "k8s/staging/"
+  toleration_keys = ["SpackBootstrap"]
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -130,7 +130,7 @@ module "staging_cluster" {
 
   gitlab_url = local.gitlab_url
 
-  kubernetes_version = "1.28"
+  kubernetes_version = "1.29"
 
   availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
 


### PR DESCRIPTION
I've already applied the updates in the AWS console, this PR just syncs up the Terraform with it. 

I also discovered a bug in the way we schedule "bootstrapping" pods, i.e. pods that must come up first before any others (most notably, Karpenter). We provision an initial managed node group to allow Karpenter pods to be scheduled, and then they are responsible for provisioning any other needed compute capacity. But because we don't taint the nodes in that node group, it's possible for other nodes to fill it up and block Karpenter from ever getting scheduled. 
As part of this PR, I added a taints and tolerations for those nodes such that Karpenter, Flux, and the sealed-secrets controller are the only pods allowed to be scheduled on them; all other pods must wait for a Karpenter-provisioned node.