### PR TITLE
Configure fluent-bit to parse ingress-nginx logs format

### DIFF
--- a/k8s/production/ingress-nginx/release.yaml
+++ b/k8s/production/ingress-nginx/release.yaml
@@ -93,6 +93,10 @@ spec:
           type: ClusterIP
           servicePort: 9913
 
+      podAnnotations:
+        # fluent-bit has a built-in parser for the k8s-nginx-ingress log format
+        fluentbit.io/parser: k8s-nginx-ingress
+
     ## Default 404 backend
     defaultBackend:
       enabled: true


### PR DESCRIPTION
This configures fluent-bit to parse ingress-nginx logs and store them in a more structured format in opensearch. Currently, a log record from ingress-nginx looks like this:
```
{
  "log": "192.168.38.176 - - [19/Jun/2024:18:29:59 +0000] "POST /api/v4/runners/verify HTTP/1.1" 200 67 "-" "gitlab-runner 16.11.1 (16-11-stable; go1.21.9; linux/amd64)" 335 0.026 [gitlab-gitlab-webservice-default-8181] [] 10.100.182.194:8181 67 0.027 200 0fb16c52659a7c780187d4c1cfb7836c",
}
```

With this change, it will look like this:
```
{
  "log_processed.agent": "Go-http-client/2.0",
  "log_processed.code": 401,
  "log_processed.host": "192.168.211.104",
  "log_processed.method": "GET",
  "log_processed.path": "/api/v4/projects/2/jobs?per_page=100&page=25&scope[]=failed&scope[]=success&scope[]=canceled",
  "log_processed.proxy_upstream_name": "gitlab-gitlab-webservice-default-8181",
  "log_processed.referer": "-",
  "log_processed.reg_id": "32f6d4a0e459106f6cab058cbc403397",
  "log_processed.request_length": 7,
  "log_processed.request_time": 0.011,
  "log_processed.size": 118,
  "log_processed.upstream_addr": "10.100.182.194:8181",
  "log_processed.upstream_response_length": 118,
  "log_processed.upstream_response_time": 0.011,
  "log_processed.upstream_status": 401,
  "log_processed.user": "-",
}
```

Which makes querying for specific logs much easier.

- [Docs for the `fluentbit.io/parser` annotation](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#kubernetes-pod-annotations)
- [`k8s-nginx-ingress` parser definition](https://github.com/fluent/fluent-bit/blob/v1.1.2/conf/parsers.conf#L27-L32)