### PR TITLE
Allow "metrics/spack_job_spec_hash" annotation

### DIFF
--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -155,7 +155,7 @@ spec:
         - pods=[*]
         - nodes=[*]
       metricAnnotationsAllowList:
-        - pods=[gitlab/ci_job_id,metrics/spack_job_spec_pkg_name,metrics/spack_job_spec_pkg_version,metrics/spack_job_spec_compiler_name,metrics/spack_job_spec_compiler_version,metrics/spack_job_spec_arch,metrics/spack_job_spec_variants,metrics/spack_job_build_jobs,metrics/spack_ci_stack_name]
+        - pods=[gitlab/ci_job_id,metrics/spack_job_spec_pkg_name,metrics/spack_job_spec_hash,metrics/spack_job_spec_pkg_version,metrics/spack_job_spec_compiler_name,metrics/spack_job_spec_compiler_version,metrics/spack_job_spec_arch,metrics/spack_job_spec_variants,metrics/spack_job_build_jobs,metrics/spack_ci_stack_name]
 
   # Configure OpenSearch datasource
   valuesFrom:


### PR DESCRIPTION
This was added in #865 but never added to the prometheus annotation allow list, which means it's still not being reported by prometheus.