### PR TITLE
[gh-gl-sync] instrument gitlab requests w/ retries

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - docker-image: ./images/gh-gl-sync
-            image-tags: ghcr.io/spack/ci-bridge:0.0.39
+            image-tags: ghcr.io/spack/ci-bridge:0.0.40
           - docker-image: ./images/ci-key-clear
             image-tags: ghcr.io/spack/ci-key-clear:0.0.2
           - docker-image: ./images/gitlab-stuckpods

--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.39
+            image: ghcr.io/spack/ci-bridge:0.0.40
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
GitLab's recent reliability issues have caused the sync script to fail fairly regularly. This change adds retries to the sync script to mitigate the impact of these failures. Hopefully this will improve things until we get to the bottom of this.