### PR TITLE
Increase resources available to protected-publish

### DIFF
--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -21,7 +21,7 @@ spec:
             resources:
               requests:
                 cpu: 1500m
-                memory: 6G
+                memory: 12G
                 ephemeral-storage: "50G"
             envFrom:
               - configMapRef:

--- a/k8s/production/karpenter/provisioners/base/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/base/provisioner.yaml
@@ -21,7 +21,7 @@ spec:
       values:
         - "t3.small"
         - "t3.medium"
-        - "m4.large"
+        - "m4.xlarge"
 
     # Always use on-demand
     - key: "karpenter.sh/capacity-type"


### PR DESCRIPTION
The protected-publish job is failing (albeit infrequently) when it uses more memory than requested and triggers the node to become low on memory, which results in eviction.

The two times I saw evictions, it was using just over 7GB, so this doubles the request from 6GB to 12GB.

To support this, we need to move up to the next instance size in karpenter, so from `m4.large` to `m4.xlarge` which doubles available cores and memory to 4vcpu and 16GB.