### PR TITLE
Require at least two replicas for nginx controller

### DIFF
--- a/k8s/production/ingress-nginx/release.yaml
+++ b/k8s/production/ingress-nginx/release.yaml
@@ -55,7 +55,7 @@ spec:
 
       autoscaling:
         enabled: true
-        minReplicas: 1
+        minReplicas: 2
         maxReplicas: 40
         targetCPUUtilizationPercentage: 50
         targetMemoryUtilizationPercentage: 50


### PR DESCRIPTION
Since there's some evidence that the nginx controller pod is being killed with a `SIGTERM` periodically, requiring at least two to be up at all times could help mitigate this issue. 