### PR TITLE
Add timeout to gitlab requests in job classification task

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -40,7 +40,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.1
+            image-tags: ghcr.io/spack/django:0.3.2
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.3
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/core/job_failure_classifier/__init__.py
+++ b/analytics/analytics/core/job_failure_classifier/__init__.py
@@ -181,7 +181,10 @@ def _collect_pod_status(job_input_data: dict[str, Any], job_trace: str):
 )
 def upload_job_failure_classification(job_input_data_json: str) -> None:
     gl = gitlab.Gitlab(
-        settings.GITLAB_ENDPOINT, settings.GITLAB_TOKEN, retry_transient_errors=True
+        settings.GITLAB_ENDPOINT,
+        settings.GITLAB_TOKEN,
+        retry_transient_errors=True,
+        timeout=15,
     )
 
     # Read input data and extract params

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.1
+          image: ghcr.io/spack/django:0.3.2
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.1
+          image: ghcr.io/spack/django:0.3.2
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
The `Soft time limit (60s) exceeded for upload_job_failure_classification` sentry errors seem to be occuring due to the gitlab API requests hanging. The [default timeout for them is `60`](https://github.com/python-gitlab/python-gitlab/blob/main/gitlab/config.py#L108), so if a request hangs for that long, it will exceed the Soft time limit set in the celery task. 

Adding this timeout of 15 seconds will hopefully confirm this, as I don't see a way to see what's happening using just the sentry errors.