### PR TITLE
Speed up `spack` git clone in docker build

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -40,7 +40,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.2
+            image-tags: ghcr.io/spack/django:0.3.3
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.3
           - docker-image: ./images/protected-publish

--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -12,8 +12,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Install spack
-RUN git clone -c feature.manyFiles=true https://github.com/spack/spack.git /opt/spack
-RUN cd /opt/spack && git checkout v0.22.0
+RUN git clone -c feature.manyFiles=true --depth 1 --branch v0.22.0 https://github.com/spack/spack.git /opt/spack
 
 # Include spack import paths for python packages. Order is important
 ENV PYTHONPATH "/opt/spack/lib/spack:$PYTHONPATH"

--- a/analytics/analytics/job_processor/__init__.py
+++ b/analytics/analytics/job_processor/__init__.py
@@ -118,7 +118,10 @@ def process_job(job_input_data_json: str):
     # Retrieve project and job from gitlab API
     # TODO: Seems to be very slow and sometimes times out. Look into using shared session?
     gl = gitlab.Gitlab(
-        settings.GITLAB_ENDPOINT, settings.GITLAB_TOKEN, retry_transient_errors=True
+        settings.GITLAB_ENDPOINT,
+        settings.GITLAB_TOKEN,
+        retry_transient_errors=True,
+        timeout=15,
     )
     gl_project = gl.projects.get(job_input_data["project_id"])
     gl_job = gl_project.jobs.get(job_input_data["build_id"])

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.2
+          image: ghcr.io/spack/django:0.3.3
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.2
+          image: ghcr.io/spack/django:0.3.3
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
Instead of cloning the full repo and then checking out a specific tag, we can use `--depth 1` to only clone the desired tag.