### PR TITLE
Retry celery tasks on gitlab timeouts

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -40,7 +40,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.3
+            image-tags: ghcr.io/spack/django:0.3.4
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.3
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/core/job_failure_classifier/__init__.py
+++ b/analytics/analytics/core/job_failure_classifier/__init__.py
@@ -13,6 +13,7 @@ from celery import shared_task
 from django.conf import settings
 from django.db import connections
 from opensearchpy import ConnectionTimeout
+from requests.exceptions import ReadTimeout
 from urllib3.exceptions import ReadTimeoutError
 
 
@@ -173,7 +174,7 @@ def _collect_pod_status(job_input_data: dict[str, Any], job_trace: str):
 @shared_task(
     name="upload_job_failure_classification",
     soft_time_limit=60,
-    autoretry_for=(ReadTimeoutError, ConnectionTimeout),
+    autoretry_for=(ReadTimeoutError, ConnectionTimeout, ReadTimeout),
     retry_backoff=30,
     retry_backoff_max=3600,
     max_retries=10,

--- a/analytics/analytics/job_processor/__init__.py
+++ b/analytics/analytics/job_processor/__init__.py
@@ -113,6 +113,7 @@ def create_job_fact(
 @shared_task(
     name="process_job",
     autoretry_for=(ReadTimeout,),
+    max_retries=3,
 )
 def process_job(job_input_data_json: str):
     # Read input data and extract params

--- a/analytics/analytics/job_processor/__init__.py
+++ b/analytics/analytics/job_processor/__init__.py
@@ -7,6 +7,7 @@ from celery import shared_task
 from django.conf import settings
 from django.db import transaction
 from gitlab.v4.objects import ProjectJob
+from requests.exceptions import ReadTimeout
 
 from analytics import setup_gitlab_job_sentry_tags
 from analytics.core.models.facts import JobFact
@@ -109,7 +110,10 @@ def create_job_fact(
     )
 
 
-@shared_task(name="process_job")
+@shared_task(
+    name="process_job",
+    autoretry_for=(ReadTimeout,),
+)
 def process_job(job_input_data_json: str):
     # Read input data and extract params
     job_input_data = json.loads(job_input_data_json)

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.3
+          image: ghcr.io/spack/django:0.3.4
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.3
+          image: ghcr.io/spack/django:0.3.4
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
Adds retries to error classification and process_job celery tasks on `requests.exceptions.ReadTimeout` exceptions. These happen when a request to gitlab times out.