### PR TITLE
Fix error handling in pruning script

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./analytics
             image-tags: ghcr.io/spack/django:0.3.5
           - docker-image: ./images/ci-prune-buildcache
-            image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.3
+            image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish
             image-tags: ghcr.io/spack/protected-publish:0.0.1
     steps:

--- a/k8s/production/custom/prune-buildcache/cron-jobs.yaml
+++ b/k8s/production/custom/prune-buildcache/cron-jobs.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: pruner
-            image: ghcr.io/spack/ci-prune-buildcache:0.0.3
+            image: ghcr.io/spack/ci-prune-buildcache:0.0.4
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
Add option to fail fast for local testing/usage. By default the script will attempt all mirrors and write errors/failures to a file

Fix bug where error/failures files were not being opened for write.