### PR TITLE
Fix issue with retrieving prometheus node labels in job processor

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -40,7 +40,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.5
+            image-tags: ghcr.io/spack/django:0.3.6
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/prometheus.py
+++ b/analytics/analytics/job_processor/prometheus.py
@@ -368,9 +368,11 @@ class PrometheusClient:
             )["metric"]["system_uuid"]
         )
 
-        # Get node labels
+        # Get node labels. Include the karpenter label to prevent the results being split up
+        # into two sets (one before this label was added and one after). This can occur if
+        # the job is scheduled on a newly created node
         node_labels = self.query_range(
-            f"kube_node_labels{{node='{node_name}'}}",
+            f"kube_node_labels{{node='{node_name}', label_karpenter_sh_initialized='true'}}",
             start=start,
             end=end,
             single_result=True,

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.5
+          image: ghcr.io/spack/django:0.3.6
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.5
+          image: ghcr.io/spack/django:0.3.6
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
When karpenter spins up a new node to accommodate a job, the prometheus query can return two series instead of one. The first one for a short period of time, while the node is still initializing. The second one, after the node is finished initializing, contains an extra karpenter label indcating so (`label_karpenter_sh_initialized='true'`), which "splits" up the data into two series. This PR adds a filter to only return results containing the karpenter label.