### PR TITLE
Add another filter to prometheus node label query

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -40,7 +40,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.6
+            image-tags: ghcr.io/spack/django:0.3.7
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/prometheus.py
+++ b/analytics/analytics/job_processor/prometheus.py
@@ -368,11 +368,11 @@ class PrometheusClient:
             )["metric"]["system_uuid"]
         )
 
-        # Get node labels. Include the karpenter label to prevent the results being split up
+        # Get node labels. Include extra labels to prevent the results being split up
         # into two sets (one before this label was added and one after). This can occur if
         # the job is scheduled on a newly created node
         node_labels = self.query_range(
-            f"kube_node_labels{{node='{node_name}', label_karpenter_sh_initialized='true'}}",
+            f"kube_node_labels{{node='{node_name}', label_karpenter_sh_initialized='true', label_topology_ebs_csi_aws_com_zone=~'.+'}}",
             start=start,
             end=end,
             single_result=True,

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.6
+          image: ghcr.io/spack/django:0.3.7
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.6
+          image: ghcr.io/spack/django:0.3.7
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
Follow up to #910 

Turns out there's yet another node label that is added after a node is initialized. This led to the same error cropping up in sentry for the same reason as before. This _seems_ to be the last instance of this problem, so merging this should finally resolve this issue.