### PR TITLE
Add CI workflow to check for missing image version bumps

### DIFF
--- a/.github/scripts/check_docker_image_versions.sh
+++ b/.github/scripts/check_docker_image_versions.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+echoerr() { printf "%s\n" "$*" >&2; }
+
+WORKFLOW_FILE=./.github/workflows/custom_docker_builds.yml
+
+# Set to 1 if any of the checks fail
+FAILED=0
+
+GIT_DIFF='git diff origin/main HEAD'
+
+# What gets fed into the $image var is defined at the end of the loop
+while read image; do
+    DOCKER_IMAGE_DIR=$(echo $image | jq '."docker-image"' -r | sed 's/^\.\///')
+    IMAGE_TAG=$(echo $image | jq '."image-tags"' -r)
+
+    # Skip if the directory was not modified at all
+    if ! $GIT_DIFF --name-only | grep $DOCKER_IMAGE_DIR > /dev/null; then
+        continue
+    fi
+
+    # Is the found tag in the added lines of the diff? If so, don't error just yet.
+    # If not, error, as that means the tag we're looking at is the old tag
+    if ! $GIT_DIFF -- $WORKFLOW_FILE | grep "^+[^+].\+$IMAGE_TAG" > /dev/null; then
+        FAILED=1
+        echoerr "ERROR: Directory '$DOCKER_IMAGE_DIR' modified, but image tag $IMAGE_TAG not incremented!"
+        continue
+    fi
+
+    # Find the old tag from the diff and search for it. If it exists, error, as that means it hasn't been bumped
+    BASE_IMAGE_TAG=$(echo $IMAGE_TAG | cut -d ":" -f1)
+    BASE_IMAGE_TAG_PATTERN=$(echo $BASE_IMAGE_TAG | sed 's/[.\/]/\\&/g')
+    OLD_TAG=$($GIT_DIFF -- $WORKFLOW_FILE | sed -nr s"/^-[^-].+($BASE_IMAGE_TAG_PATTERN)/\1/p")
+
+    NEW_TAG_VERSION=$(echo $IMAGE_TAG | cut -d ":" -f2)
+    OLD_TAG_VERSION=$(echo $OLD_TAG | cut -d ":" -f2)
+
+    # Search for this old tag. If found error, as we should only find the new tag
+    if git grep $OLD_TAG > /dev/null; then
+        FAILED=1
+        echoerr "ERROR: Image $BASE_IMAGE_TAG incremented to $NEW_TAG_VERSION, found remaining occurances of $OLD_TAG_VERSION!"
+    fi
+
+# This is where the input to the while loop variable $image comes in. This is called a "here string" and
+# circumvents the issue with subshells setting global variables.
+# https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Here-Strings
+done <<< $(cat $WORKFLOW_FILE | yq ".jobs.build.strategy.matrix.include" -o json | jq -c ".[]")
+
+if [ "$FAILED" -eq "1" ]; then
+    exit 1
+fi

--- a/.github/workflows/check_docker_image_versions.yml
+++ b/.github/workflows/check_docker_image_versions.yml
@@ -1,0 +1,17 @@
+name: Check Docker Image Versions
+
+on:
+  pull_request:
+
+jobs:
+  check-image:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-image-bump') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - run: git fetch --no-tags --prune --depth=1 origin main
+
+      - name: Check for modified directories that need an image bump
+        run: ./.github/scripts/check_docker_image_versions.sh


### PR DESCRIPTION
(I accidentally closed #912 when playing around with git commands locally)

This PR adds a CI workflow that fails if it finds one of the following conditions:

1. A directory was modified, but the image version in `.github/workflows/custom_docker_builds.yml` was not incremented
2. A directory was modified, and the image version in the workflow file was bumped, but uses of the old image version still remain in the code base.

In cases where this check is either undesired or unhelpful, the `no-image-bump` tag can be applied to the pull request and the job will be skipped.