### PR TITLE
Upgrade Karpenter to 0.31.4

### DIFF
--- a/terraform/modules/spack/karpenter.tf
+++ b/terraform/modules/spack/karpenter.tf
@@ -1,5 +1,5 @@
 locals {
-  karpenter_version = "v0.31.0"
+  karpenter_version = "v0.31.4"
 }
 
 module "karpenter" {

--- a/terraform/modules/spack/karpenter.tf
+++ b/terraform/modules/spack/karpenter.tf
@@ -1,5 +1,5 @@
 locals {
-  karpenter_version = "v0.29.0"
+  karpenter_version = "v0.31.0"
 }
 
 module "karpenter" {


### PR DESCRIPTION
I applied this to staging, and tested it by deleting a bunch of nodes and Karpenter was able to spin them back up.

See https://karpenter.sh/v0.37/upgrading/upgrade-guide/#upgrading-to-0310 for the changelog - nothing impacts us, so this is a relatively straightforward upgrade. Upgrading to 0.32.0 does contain a fair amount of breaking changes, so I've left that for a follow up PR.