### PR TITLE
Upgrade TF `karpenter` module to 19.21.0

### DIFF
--- a/terraform/modules/spack/karpenter.tf
+++ b/terraform/modules/spack/karpenter.tf
@@ -4,7 +4,7 @@ locals {
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "18.31.0"
+  version = "19.21.0"
 
   cluster_name = module.eks.cluster_name
 


### PR DESCRIPTION
Upgrades the Terraform EKS karpenter module to 19.21.0. This just adds a few IAM permissions that are required for karpenter 0.32.0+.