### PR TITLE
Add (another) new regex to `concretizer_error` taxonomy

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -40,7 +40,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.9
+            image-tags: ghcr.io/spack/django:0.3.10
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
+++ b/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
@@ -25,6 +25,7 @@ taxonomy:
         - "Error: concretization failed for the following reasons"
         - "Spack concretizer internal error."
         - "failed to concretize .+ for the following reasons"
+        - "variant .+ not found in package"
 
     job_log_missing:
         grep_for:

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.9
+          image: ghcr.io/spack/django:0.3.10
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.9
+          image: ghcr.io/spack/django:0.3.10
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
Jobs like [this one](https://gitlab.spack.io/spack/spack/-/jobs/11966614) are getting categorized as `other`, when they should be
`concretizer_error`. This adds a new regex to the taxonomy fix this.

Hopefully this and #923 cover all the new job errors we've seen today