### PR TITLE
Add new error taxonomy for missing spec list

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.11
+            image-tags: ghcr.io/spack/django:0.3.12
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
+++ b/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
@@ -56,6 +56,10 @@ taxonomy:
       grep_for:
         - 'SpackError: No installed spec matches the hash'
 
+    failed_to_get_specs:
+      grep_for:
+        - 'Error: Unable to generate package index: Failed to get list of specs from'
+
     build_error:
       grep_for:
         - 'error found in build log:'
@@ -256,6 +260,7 @@ taxonomy:
     - 'db_match'
     - 'db_hash'
     - 'no_spec'
+    - 'failed_to_get_specs'
     - 'ref_not_found'
     - 'cmd_not_found'
     - 'module_not_found'

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.11
+          image: ghcr.io/spack/django:0.3.12
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.11
+          image: ghcr.io/spack/django:0.3.12
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
This correctly categorizes the error that occurs when a `rebuild-index` job fails due to a missing spec list, which happens when all dependent jobs fail. Currently, that error is getting labeled as `other`.

Example jobs:
https://gitlab.spack.io/spack/spack/-/jobs/11980518
https://gitlab.spack.io/spack/spack/-/jobs/11980519
https://gitlab.spack.io/spack/spack/-/jobs/11980551