### PR TITLE
Add new regex for `concretization_error`

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.12
+            image-tags: ghcr.io/spack/django:0.3.13
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
+++ b/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
@@ -26,6 +26,7 @@ taxonomy:
         - "Spack concretizer internal error."
         - "failed to concretize .+ for the following reasons"
         - "variant .+ not found in package"
+        - "trying to set variant .+ in package .+, but the package has no such variant"
 
     job_log_missing:
         grep_for:

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.12
+          image: ghcr.io/spack/django:0.3.13
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.12
+          image: ghcr.io/spack/django:0.3.13
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
This regex will catch jobs like [this one](https://gitlab.spack.io/spack/spack/-/jobs/12007967), which currently gets categorized as `other`.