### PR TITLE
Add new regex for `spack_error` taxonomy

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.13
+            image-tags: ghcr.io/spack/django:0.3.14
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
+++ b/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
@@ -162,6 +162,7 @@ taxonomy:
         - 'Error: No version for .+ satisfies'
         - 'Error: errors occurred during concretization of the environment'
         - 'cannot load package .+ from the .builtin. repository'
+        - 'must have a default provider in /builds/spack/spack/etc/spack/defaults/packages.yaml'
 
     invalid_pipeline_yaml:
       grep_for:

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.13
+          image: ghcr.io/spack/django:0.3.14
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.13
+          image: ghcr.io/spack/django:0.3.14
           command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
           imagePullPolicy: Always
           resources:


### PR DESCRIPTION
Catches jobs like these, which were labeled as `other`:
https://gitlab.spack.io/spack/spack/-/jobs/12024871
https://gitlab.spack.io/spack/spack/-/jobs/12024740
https://gitlab.spack.io/spack/spack/-/jobs/12024707