### PR TITLE
Upgrade RDS instances

### DIFF
--- a/terraform/modules/spack/analytics_db.tf
+++ b/terraform/modules/spack/analytics_db.tf
@@ -17,7 +17,7 @@ module "analytics_db" {
   engine               = "postgres"
   family               = "postgres15"
   major_engine_version = "15"
-  engine_version       = "15.5"
+  engine_version       = "15.7"
   instance_class       = var.gitlab_db_instance_class
 
   # Credentials

--- a/terraform/modules/spack/gitlab_db.tf
+++ b/terraform/modules/spack/gitlab_db.tf
@@ -74,7 +74,7 @@ module "gitlab_db" {
   identifier = "gitlab-${var.deployment_name}"
 
   engine               = "postgres"
-  engine_version       = "14.10"
+  engine_version       = "14.12"
   family               = "postgres14"
   major_engine_version = "14"
   instance_class       = var.gitlab_db_instance_class

--- a/terraform/production/.terraform.lock.hcl
+++ b/terraform/production/.terraform.lock.hcl
@@ -151,6 +151,26 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.2"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.2"
   constraints = ">= 3.1.0"


### PR DESCRIPTION
This upgrades our RDS instances to the latest minor versions of Postgres/MySQL.  This has already happened for some of them across both production and staging, so this brings the terraform state up to sync and upgrades any instances that are still on an older version.