### PR TITLE
Kill protected-publish if it takes too long

### DIFF
--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -9,6 +9,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 14400 # terminate any running job after 4 hours
       backoffLimit: 0
       template:
         spec:


### PR DESCRIPTION
4 hours limit for cron scheduled every 3 hours seems good