### PR TITLE
Allow service tagged runners to define `CI_OIDC_REQUIRED`

### DIFF
--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -61,7 +61,7 @@ spec:
 
           if [ -z "${PY3:-}" ]; then
             echo "Unable to find python3 executable"
-            exit 1
+            exit ${CI_OIDC_REQUIRED:-1}
           fi
 
           $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -61,7 +61,7 @@ spec:
 
           if [ -z "${PY3:-}" ]; then
             echo "Unable to find python3 executable"
-            exit 1
+            exit ${CI_OIDC_REQUIRED:-1}
           fi
 
           $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"


### PR DESCRIPTION
This allows not erroring on OIDC setup for runners with service tag. Noop jobs use the service runners, but do not need access to S3 buckets. Jobs on these runners should not fail trying to find services they don't need.

If the variable `CI_OIDC_REQUIRED` is set in the job running on the runner, the value will be used. This will likely only be set on the `noop` jobs with a value of `0`.

If the variable `CI_OIDC_REQUIRED` is not set, the exit code will be `1`

ref. https://github.com/spack/spack/pull/46732