### PR TITLE
Add dependencies to production helm releases

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -23,6 +23,11 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: gitlab
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+    - name: ingress-nginx
+      namespace: ingress-nginx
 
   valuesFrom:
     - kind: Secret

--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-graviton2-prot
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-prot
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -24,6 +24,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-prot-windows
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-prot
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v3-prot
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v4-prot
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-graviton2-pub
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-pub
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -24,6 +24,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-pub-windows
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-pub
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v3-pub
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v4-pub
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -23,6 +23,9 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: runner-spack-package-signing
+  dependsOn:
+    - name: gitlab
+      namespace: gitlab
 
   valuesFrom:
     # See terraform/modules/sentry/sentry.tf


### PR DESCRIPTION
This makes spinning up a cluster from scratch slightly less messy, since Flux will wait and provision things in the proper order instead of doing everything at once and causing a bunch of `CrashLoopBackoff` errors (that eventually resolve themselves).

Cherry picked out of #954 