### PR TITLE
Extend gitlab helm release timeout

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -16,6 +16,8 @@ metadata:
   namespace: gitlab
 spec:
   interval: 10m
+  # GitLab can take a while to start up for the first time, so give it up to 15 mins before deciding it failed.
+  timeout: 15m
   chart:
     spec:
       chart: gitlab


### PR DESCRIPTION
The GitLab helm chart can take a while to start up for the first time, so this updates the HelmRelease to give it up to 15 mins to install before deciding it failed.

Cherry picked from #954 