### PR TITLE
Fix gitlab helm chart TLS issue

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -68,6 +68,8 @@ spec:
         apiVersion: networking.k8s.io/v1
         configureCertmanager: false
         class: nginx
+        tls:
+          external: true
 
       gitlab:
         license: {}


### PR DESCRIPTION
This fixes an issue that occurs when performing a fresh install of the GitLab helm chart using an external cert-manager (i.e., using your own version of `cert-manager`, as we do, instead of relying on the gitlab helm chart to install and manage it).

This is the issue tracking the bug and the workaround that fixes it, which I have included in this PR.
https://gitlab.com/gitlab-org/charts/gitlab/-/issues/4907#note_1494311672

(note, this is already applied to the cluster)

Cherry picked from #954 