### PR TITLE
Point Flux at `spack/spack-infrastructure@main`

### DIFF
--- a/terraform/modules/spack_aws_k8s/versions.tf
+++ b/terraform/modules/spack_aws_k8s/versions.tf
@@ -59,12 +59,11 @@ provider "flux" {
     }
   }
   git = {
-    url = "https://github.com/mvandenburgh/spack-infrastructure" # TODO: update this
+    url = "https://github.com/spack/spack-infrastructure"
     http = {
-      username = "mvandenburgh" # TODO: update this
+      username = "spackbot"
       password = jsondecode(data.aws_secretsmanager_secret_version.flux_github_token.secret_string).flux_github_token
     }
-    branch = "alt-tf-module" # TODO: update this
   }
 }
 


### PR DESCRIPTION
This updates Flux to watch the `main` branch of `spack/spack-infrastructure` instead of the temporary branch from #954.