### PR TITLE
Fix kube permissions for github actions

### DIFF
--- a/.github/workflows/terraform-drift-detection.yaml
+++ b/.github/workflows/terraform-drift-detection.yaml
@@ -45,6 +45,7 @@ jobs:
         run: terraform plan -lock=false -detailed-exitcode -no-color -input=false -out=tfplan > tfplan_output.txt 2>&1
         env:
           TF_VAR_eks_cluster_role: "arn:aws:iam::588562868276:role/GitHubActionsReadonlyRole"
+          TF_VAR_gitlab_token: ${{ secrets.GITLAB_ACCESS_TOKEN }}
 
       - name: Send Slack alert on drift
         if: failure()

--- a/terraform/modules/spack_aws_k8s/variables.tf
+++ b/terraform/modules/spack_aws_k8s/variables.tf
@@ -39,3 +39,9 @@ variable "opensearch_volume_size" {
   description = "The size of the EBS volume for the OpenSearch domain."
   type        = number
 }
+
+variable "eks_cluster_role" {
+  description = "The IAM role to assume when interacting with EKS resources."
+  type        = string
+  default     = null
+}

--- a/terraform/modules/spack_aws_k8s/versions.tf
+++ b/terraform/modules/spack_aws_k8s/versions.tf
@@ -15,6 +15,10 @@ terraform {
   }
 }
 
+locals {
+  eks_cluster_role = coalesce(var.eks_cluster_role, aws_iam_role.eks_cluster_access.arn)
+}
+
 provider "aws" {
   region = var.region
 }
@@ -28,7 +32,13 @@ provider "kubectl" {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    args = [
+      "eks",
+      "get-token",
+      "--cluster-name",
+      module.eks.cluster_name,
+      "--role", local.eks_cluster_role,
+    ]
   }
 }
 
@@ -41,7 +51,13 @@ provider "helm" {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed
-      args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+      args = [
+        "eks",
+        "get-token",
+        "--cluster-name",
+        module.eks.cluster_name,
+        "--role", local.eks_cluster_role,
+      ]
     }
   }
 }
@@ -55,7 +71,13 @@ provider "flux" {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed
-      args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+      args = [
+        "eks",
+        "get-token",
+        "--cluster-name",
+        module.eks.cluster_name,
+        "--role", local.eks_cluster_role,
+      ]
     }
   }
   git = {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -4,7 +4,8 @@ module "spack_aws_k8s" {
   deployment_name  = "prod"
   deployment_stage = "blue"
 
-  region = "us-east-1"
+  region           = "us-east-1"
+  eks_cluster_role = var.eks_cluster_role
 
   flux_path = "k8s/production/"
 

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -3,3 +3,9 @@ variable "gitlab_token" {
   type        = string
   sensitive   = true
 }
+
+variable "eks_cluster_role" {
+  description = "The IAM role to assume when interacting with EKS resources."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This fixes the [Terraform drift detection job](https://github.com/spack/spack-infrastructure/blob/main/.github/workflows/terraform-drift-detection.yaml) that we stopped running before due to the TLS network timeout issues.