### PR TITLE
Add staging kustomization for spack-gantry

### DIFF
--- a/k8s/staging/spack/kustomization.yaml
+++ b/k8s/staging/spack/kustomization.yaml
@@ -3,3 +3,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../production/spack/namespace.yaml
+  - ../../production/spack/gantry-spack-io/services.yaml
+  - ../../production/spack/gantry-spack-io/stateful-sets.yaml
+
+patches:
+  - target:
+      kind: StatefulSet
+      name: spack-gantry
+      namespace: spack
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env/1/value
+        value: https://gitlab.staging.spack.io/api/v4/projects/8


### PR DESCRIPTION
@cmelone this will deploy spack-gantry to the staging cluster. I've configured it to point at the staging `spack/spack` project, but we could use another project if that makes more sense.