### PR TITLE
Enable karpenter prometheus metrics

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.16
+            image-tags: ghcr.io/spack/django:0.3.17
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/prometheus.py
+++ b/analytics/analytics/job_processor/prometheus.py
@@ -409,7 +409,7 @@ class PrometheusClient:
         # lifetime, we return all values from this query and average them.
         zone = node_labels["label_topology_kubernetes_io_zone"]
         price_query = f"""
-            karpenter_cloudprovider_instance_type_price_estimate{{
+            karpenter_cloudprovider_instance_type_offering_price_estimate{{
                 capacity_type='{capacity_type}',
                 instance_type='{instance_type}',
                 zone='{zone}'

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.16
+          image: ghcr.io/spack/django:0.3.17
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,8 +146,18 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.16
-          command: ["celery", "-A", "analytics.celery", "worker", "-l", "info", "-Q", "celery"]
+          image: ghcr.io/spack/django:0.3.17
+          command:
+            [
+              "celery",
+              "-A",
+              "analytics.celery",
+              "worker",
+              "-l",
+              "info",
+              "-Q",
+              "celery",
+            ]
           imagePullPolicy: Always
           resources:
             requests:

--- a/terraform/modules/spack_aws_k8s/karpenter.tf
+++ b/terraform/modules/spack_aws_k8s/karpenter.tf
@@ -46,6 +46,8 @@ resource "helm_release" "karpenter" {
       clusterName: ${module.eks.cluster_name}
       clusterEndpoint: ${module.eks.cluster_endpoint}
       interruptionQueueName: ${module.karpenter.queue_name}
+    serviceMonitor:
+      enabled: true
     EOT
   ]
 


### PR DESCRIPTION
Re-enables Karpenter prometheus metrics that were inadvertently disabled in #954 