### PR TITLE
Change how `CI_OIDC_REQUIRED` works

### DIFF
--- a/k8s/production/runners/README.md
+++ b/k8s/production/runners/README.md
@@ -1,0 +1,29 @@
+# Gitlab runners
+
+There are three types of runners with increasing levels of access to cluster secrets.
+
+1. `public`
+2. `protected`
+3. `signing`
+
+## Public & Protected runners
+
+The `public` and `protected` runners provide multiple architectures and base OSs that run across a range of AWS nodes.
+
+* Windows
+  * `x86_64_v2`
+* Linux
+  * `x86_64_v2`
+  * `x86_64_v3`
+  * `x86_64_v4`
+  * `graviton2`
+  * `graviton3`
+
+### Special Variables
+
+* `CI_OIDC_REQUIRED`: available to be set for runners with the `service` tag.
+  This variable can be used to skip OIDC configuration.
+
+## Signing Runners
+
+The `signing` runners use either `x86_64_v3` or `x86_64_v4` Linux machines.

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -53,26 +53,29 @@ spec:
       config: |
         [[runners]]
           pre_build_script = """
-          echo 'Executing Spack pre-build setup script'
+          if [ ${CI_OIDC_REQUIRED:-1} == 1 ]; then
+            echo 'Executing Spack pre-build setup script'
 
-          for cmd in "${PY3:-}" python3 python; do
-            if command -v > /dev/null "$cmd"; then
-              export PY3="$(command -v "$cmd")"
-              break
+            for cmd in "${PY3:-}" python3 python; do
+              if command -v > /dev/null "$cmd"; then
+                export PY3="$(command -v "$cmd")"
+                break
+              fi
+            done
+
+
+            if [ -z "${PY3:-}" ]; then
+              echo "Unable to find python3 executable"
+              exit 1
             fi
-          done
 
-          if [ -z "${PY3:-}" ]; then
-            echo "Unable to find python3 executable"
-            exit ${CI_OIDC_REQUIRED:-1}
+            $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+            $PY3 pre_build.py > envvars
+
+            . ./envvars
+            rm -f envvars
+            unset GITLAB_OIDC_TOKEN
           fi
-
-          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
-          $PY3 pre_build.py > envvars
-
-          . ./envvars
-          rm -f envvars
-          unset GITLAB_OIDC_TOKEN
           """
 
           output_limit = 20480

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -53,26 +53,28 @@ spec:
       config: |
         [[runners]]
           pre_build_script = """
-          echo 'Executing Spack pre-build setup script'
+          if [ ${CI_OIDC_REQUIRED:-1} == 1 ]; then
+            echo 'Executing Spack pre-build setup script'
 
-          for cmd in "${PY3:-}" python3 python; do
-            if command -v > /dev/null "$cmd"; then
-              export PY3="$(command -v "$cmd")"
-              break
+            for cmd in "${PY3:-}" python3 python; do
+              if command -v > /dev/null "$cmd"; then
+                export PY3="$(command -v "$cmd")"
+                break
+              fi
+            done
+
+            if [ -z "${PY3:-}" ]; then
+              echo "Unable to find python3 executable"
+              exit 1
             fi
-          done
 
-          if [ -z "${PY3:-}" ]; then
-            echo "Unable to find python3 executable"
-            exit ${CI_OIDC_REQUIRED:-1}
+            $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+            $PY3 pre_build.py > envvars
+
+            . ./envvars
+            rm -f envvars
+            unset GITLAB_OIDC_TOKEN
           fi
-
-          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
-          $PY3 pre_build.py > envvars
-
-          . ./envvars
-          rm -f envvars
-          unset GITLAB_OIDC_TOKEN
           """
 
           output_limit = 20480


### PR DESCRIPTION
Add runner and variable documentation in README

This also fixes a problem with the previous approach where if you set `CI_OIDC_REQUIRED: 0` in your job config, then the `exit 0` here prevented any of your jobs `before_script` or `script` from running at all.  