### PR TITLE
gh-gl-sync: fetch at max depth rather than unshallow

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - docker-image: ./images/gh-gl-sync
-            image-tags: ghcr.io/spack/ci-bridge:0.0.42
+            image-tags: ghcr.io/spack/ci-bridge:0.0.43
           - docker-image: ./images/ci-key-clear
             image-tags: ghcr.io/spack/ci-key-clear:0.0.2
           - docker-image: ./images/gitlab-stuckpods

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -206,7 +206,7 @@ class SpackCIBridge(object):
                         # Check if we should defer pushing/testing this PR because it is based on "too new" of a commit
                         # of the main branch.
                         tmp_pr_branch = f"temporary_{pr_string}"
-                        _durable_subprocess_run(["git", "fetch", "--unshallow", "github",
+                        _durable_subprocess_run(["git", "fetch", "--depth=2147483647", "github",
                                                 f"refs/pull/{pull.number}/head:{tmp_pr_branch}"])
                         # Get the merge base between this PR and the main branch.
                         try:
@@ -263,7 +263,7 @@ class SpackCIBridge(object):
                         # then we will push the merge commit that was automatically created by GitHub to GitLab
                         # where it will kick off a CI pipeline.
                         try:
-                            _durable_subprocess_run(["git", "fetch", "--unshallow", "github",
+                            _durable_subprocess_run(["git", "fetch", "--depth=2147483647", "github",
                                                     f"{pull.merge_commit_sha}:{pr_string}"])
                         except subprocess.CalledProcessError:
                             print("Failed to locally checkout PR {0} ({1}). Skipping"
@@ -343,7 +343,7 @@ class SpackCIBridge(object):
         self.gitlab_shallow_fetch()
 
         if self.main_branch:
-            _durable_subprocess_run(["git", "fetch", "--unshallow", "github", self.main_branch])
+            _durable_subprocess_run(["git", "fetch", "--depth=2147483647", "github", self.main_branch])
 
     def get_gitlab_pr_branches(self):
         """Query GitLab for branches that have already been copied over from GitHub PRs.
@@ -387,7 +387,7 @@ class SpackCIBridge(object):
     def fetch_github_branches(self, fetch_refspecs):
         """Perform `git fetch` for a given list of refspecs."""
         print("Fetching GitHub refs for open PRs")
-        fetch_args = ["git", "fetch", "-q", "--unshallow", "github"] + fetch_refspecs
+        fetch_args = ["git", "fetch", "-q", "--depth=2147483647", "github"] + fetch_refspecs
         _durable_subprocess_run(fetch_args)
 
     def build_local_branches(self, protected_branches):

--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.42
+            image: ghcr.io/spack/ci-bridge:0.0.43
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
While setting up a new copy of the sync script for Kokkos I encountered into the following error:

fatal: --unshallow on a complete repository does not make sense

I'm not 100% sure why git decided to do a full (rather than shallow) clone for this repository, but fetching at maximum depth instead seems to solve the issue.

https://stackoverflow.com/a/46477285