### PR TITLE
Fix IAM policy attachemnts for EBS/EFS drivers

### DIFF
--- a/terraform/modules/spack_aws_k8s/eks.tf
+++ b/terraform/modules/spack_aws_k8s/eks.tf
@@ -183,9 +183,8 @@ resource "aws_iam_role" "ebs_csi_driver" {
   })
 }
 
-resource "aws_iam_policy_attachment" "ebs_csi_driver" {
-  name       = "AmazonEKS_EBS_CSI_Driver-${var.deployment_name}"
-  roles      = [aws_iam_role.ebs_csi_driver.name]
+resource "aws_iam_role_policy_attachment" "ebs_csi_driver" {
+  role       = aws_iam_role.ebs_csi_driver.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy" # AWS managed policy
 }
 
@@ -211,9 +210,8 @@ resource "aws_iam_role" "efs_csi_driver" {
   })
 }
 
-resource "aws_iam_policy_attachment" "efs_csi_driver" {
-  name       = "AmazonEKS_EFS_CSI_Driver-${var.deployment_name}"
-  roles      = [aws_iam_role.efs_csi_driver.name]
+resource "aws_iam_role_policy_attachment" "efs_csi_driver" {
+  role       = aws_iam_role.efs_csi_driver.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy" # AWS managed policy
 }
 


### PR DESCRIPTION
The `iam_policy_attachment` resource is for creating exclusive attachments of IAM policies to IAM roles. This prevented both staging and production from attaching their respective EBS/EFS roles to the same managed policy. See docs
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment

You can observe the behavior by trying to run `terraform plan` against staging on the current `main` branch. It will attempt to modify the `iam_policy_attachment` resources of the production cluster, since they are already attached.