### PR TITLE
Enable stesachs@amazon.com to run `s3 sync` on a sub-bucket

### DIFF
--- a/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
+++ b/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
@@ -36,9 +36,12 @@ resource "aws_s3_bucket_policy" "bootstrap" {
           "AWS" : "arn:aws:iam::679174810898:root"
         },
         "Action" : [
+          "s3:CopyObject*",
+          "s3:DeleteObject*",
           "s3:GetObject*",
-          "s3:PutObject*",
-          "s3:DeleteObject*"
+          "s3:ListBucket*"
+          "s3:ListObjects*",
+          "s3:PutObject*"
         ],
         "Resource" : "arn:aws:s3:::${aws_s3_bucket.bootstrap.bucket}/pcluster/*"
       }

--- a/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
+++ b/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
@@ -39,7 +39,7 @@ resource "aws_s3_bucket_policy" "bootstrap" {
           "s3:CopyObject*",
           "s3:DeleteObject*",
           "s3:GetObject*",
-          "s3:ListBucket*"
+          "s3:ListBucket*",
           "s3:ListObjects*",
           "s3:PutObject*"
         ],


### PR DESCRIPTION
I want to add to the existing buildcache location and run `spack buildcache
update-index` in order to merge the content. Spack needs to be able to list the
content (or use `aws s3 sync`) to run `buildcache update-index`.

This is an extension of #731 to enable `aws s3 sync` additionally to `aws s3 cp`.