### PR TITLE
 Enable stesachs@amazon.com to run `s3 sync` on a `pcluster/` sub-bucket

### DIFF
--- a/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
+++ b/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
@@ -36,9 +36,10 @@ resource "aws_s3_bucket_policy" "bootstrap" {
           "AWS" : "arn:aws:iam::679174810898:root"
         },
         "Action" : [
+          "s3:DeleteObject*",
           "s3:GetObject*",
-          "s3:PutObject*",
-          "s3:DeleteObject*"
+          "s3:ListBucket*",
+          "s3:PutObject*"
         ],
         "Resource" : "arn:aws:s3:::${aws_s3_bucket.bootstrap.bucket}/pcluster/*"
       }

--- a/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
+++ b/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
@@ -38,11 +38,20 @@ resource "aws_s3_bucket_policy" "bootstrap" {
         "Action" : [
           "s3:DeleteObject*",
           "s3:GetObject*",
-          "s3:ListBucket*",
           "s3:PutObject*"
         ],
         "Resource" : "arn:aws:s3:::${aws_s3_bucket.bootstrap.bucket}/pcluster/*"
+      },
+      {
+        "Sid" : "StephenSachsEnableSync",
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : "arn:aws:iam::679174810898:root"
+        },
+        "Action" : "s3:ListBucket*",
+        "Resource" : "arn:aws:s3:::${aws_s3_bucket.bootstrap.bucket}"
       }
+
     ]
   })
 


### PR DESCRIPTION
`s3:CopyObjects` and `s3:ListObjects` are not registered as IAM s3 actions. Fixes #977