### PR TITLE
Revert "Enable stesachs@amazon.com to run `s3 sync` on a sub-bucket"

### DIFF
--- a/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
+++ b/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
@@ -36,12 +36,9 @@ resource "aws_s3_bucket_policy" "bootstrap" {
           "AWS" : "arn:aws:iam::679174810898:root"
         },
         "Action" : [
-          "s3:CopyObject*",
-          "s3:DeleteObject*",
           "s3:GetObject*",
-          "s3:ListBucket*",
-          "s3:ListObjects*",
-          "s3:PutObject*"
+          "s3:PutObject*",
+          "s3:DeleteObject*"
         ],
         "Resource" : "arn:aws:s3:::${aws_s3_bucket.bootstrap.bucket}/pcluster/*"
       }


### PR DESCRIPTION
Reverts spack/spack-infrastructure#977.

That PR introduced some invalid actions to a bucket policy, the fix is being worked on in #978. In the meantime, I'll revert that invalid PR so terraform applies cleanly again.