### PR TITLE
Add new regexes to error taxonomy

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.19
+            image-tags: ghcr.io/spack/django:0.3.20
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
+++ b/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
@@ -29,6 +29,9 @@ taxonomy:
         - "trying to set variant .+ in package .+, but the package has no such variant"
         - "No such variant .+ for spec"
         - "UnknownVariantError"
+        - "Spec version is not concrete"
+        - "UnsatisfiableSpecError"
+        - "cannot have a dependency on"
 
     job_log_missing:
         grep_for:
@@ -165,6 +168,7 @@ taxonomy:
         - 'Error: errors occurred during concretization of the environment'
         - 'cannot load package .+ from the .builtin. repository'
         - 'must have a default provider in /builds/spack/spack/etc/spack/defaults/packages.yaml'
+        - 'RuntimeError: .+ object has no attribute'
 
     invalid_pipeline_yaml:
       grep_for:

--- a/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
+++ b/analytics/analytics/core/job_failure_classifier/taxonomy.yaml
@@ -168,7 +168,7 @@ taxonomy:
         - 'Error: errors occurred during concretization of the environment'
         - 'cannot load package .+ from the .builtin. repository'
         - 'must have a default provider in /builds/spack/spack/etc/spack/defaults/packages.yaml'
-        - 'RuntimeError: .+ object has no attribute'
+        - 'Error: .+ object has no attribute'
 
     invalid_pipeline_yaml:
       grep_for:

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.19
+          image: ghcr.io/spack/django:0.3.20
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.19
+          image: ghcr.io/spack/django:0.3.20
           command:
             [
               "celery",


### PR DESCRIPTION
Example jobs (these are just from today, but I've seen these errors come up multiple times the last couple days):
https://gitlab.spack.io/spack/spack/-/jobs/13088400 
https://gitlab.spack.io/spack/spack/-/jobs/13088128
https://gitlab.spack.io/spack/spack/-/jobs/13088255 
https://gitlab.spack.io/spack/spack/-/jobs/13088333
https://gitlab.spack.io/spack/spack/-/jobs/13088178 
https://gitlab.spack.io/spack/spack/-/jobs/13088078 
https://gitlab.spack.io/spack/spack/-/jobs/13088077 
https://gitlab.spack.io/spack/spack/-/jobs/13088006 
https://gitlab.spack.io/spack/spack/-/jobs/13085121 
https://gitlab.spack.io/spack/spack/-/jobs/13084926
https://gitlab.spack.io/spack/spack/-/jobs/13084862