### PR TITLE
Fix analytics webhook crash on non-retryable jobs

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.20
+            image-tags: ghcr.io/spack/django:0.3.21
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/core/job_failure_classifier/__init__.py
+++ b/analytics/analytics/core/job_failure_classifier/__init__.py
@@ -85,7 +85,13 @@ def _job_retry_data(
             retry_config = json.loads(job[0])
 
         retry_max = retry_config["max"]
-        retry_reasons = retry_config["when"]
+        # A non-retryable job can either have an explicit max of zero, or no max at all.
+        # If the job is not retryable, the 'when' key will not exist
+        if retry_max in (0, None):
+            retry_reasons = []
+        # If the job is retryable, the 'when' key will be a list of reasons to retry
+        else:
+            retry_reasons = retry_config["when"]
         # final_attempt is defined as an attempt that won't be retried for the retry_reasons
         # or because it's gone beyond the max number of retries.
         retryable_by_reason = (

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.20
+          image: ghcr.io/spack/django:0.3.21
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.20
+          image: ghcr.io/spack/django:0.3.21
           command:
             [
               "celery",


### PR DESCRIPTION
We've been seeing this crash for a while now, where the job retry reasons field doesn't exist. This is actually expected behavior, as there is now a subset of jobs that we do not retry on failure (no-spec-to-rebuild jobs; see https://github.com/spack/spack/pull/46713/commits/e988ce058133f74066709ae8217bdb9add12190d). This went into effect about a month ago, which lines up roughly with when we first started seeing this crash.