### PR TITLE
Increase `max_yaml_size_bytes` to 50MB

### DIFF
--- a/k8s/production/custom/gitlab-setting-updater/cronjobs.yaml
+++ b/k8s/production/custom/gitlab-setting-updater/cronjobs.yaml
@@ -37,7 +37,7 @@ spec:
                   "--",
                   "/srv/gitlab/bin/rails",
                   "runner",
-                  "ApplicationSetting.update(max_yaml_size_bytes: 20.megabytes)",
+                  "ApplicationSetting.update(max_yaml_size_bytes: 50.megabytes)",
                 ]
           nodeSelector:
             spack.io/node-pool: base


### PR DESCRIPTION
See https://spackpm.slack.com/archives/C02N33GM28H/p1730299174926259.

We've encountered a generated pipeline yaml that exceeded the currently set limit of 20MB (https://gitlab.spack.io/spack/spack/-/pipelines/873775). That particular yaml took 20.9MB of memory, which I was able to confirm by [patching the staging gitlab instance](https://github.com/mvandenburgh/docker-images/commit/5eee6b0d91bd92182f6009b0d7429bcbbc0fdd83) to report the memory used. (https://gitlab.staging.spack.io/mvandenburgh/spack/-/pipelines/1372)

I'm not sure what the best approach is here; I've bumped up the limit to 50MB, but technically that's a lot more than what we needed in this case. I'm not sure what the implications of a high yaml size limit are, anyone have any thoughts? 