### PR TITLE
Allow Karpenter to use any amd64 for GitLab

### DIFF
--- a/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
@@ -12,15 +12,10 @@ spec:
         spack.io/node-pool: gitlab
     spec:
       requirements:
-        - key: "node.kubernetes.io/instance-type"
+        # Always use amd64 nodes
+        - key: "kubernetes.io/arch"
           operator: In
-          values:
-          # Instance types are partly based on gitlab's recommendations
-          # https://docs.gitlab.com/ee/administration/reference_architectures/3k_users.html#cluster-topology
-            - "t3.xlarge"
-            - "m5.xlarge"
-            - "m5.4xlarge"
-            - "c5.4xlarge"
+          values: ["amd64"]
 
         # Always use on-demand
         - key: "karpenter.sh/capacity-type"


### PR DESCRIPTION
Relax the constraints on our GitLab node pool, giving Karpenter more freedom to choose appropriate instance types based on our resource requests.