### PR TITLE
Autoretry process_job for any `RequestException`

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.23
+            image-tags: ghcr.io/spack/django:0.3.24
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/__init__.py
+++ b/analytics/analytics/job_processor/__init__.py
@@ -7,7 +7,7 @@ import gitlab.exceptions
 from celery import shared_task
 from django.db import transaction
 from gitlab.v4.objects import ProjectJob
-from requests.exceptions import ConnectionError, ReadTimeout
+from requests.exceptions import RequestException
 
 from analytics import setup_gitlab_job_sentry_tags
 from analytics.core.models.dimensions import JobDataDimension
@@ -121,10 +121,7 @@ def create_job_fact(
 
 @shared_task(
     name="process_job",
-    autoretry_for=(
-        ConnectionError,
-        ReadTimeout,
-    ),
+    autoretry_for=(RequestException,),
     max_retries=3,
 )
 def process_job(job_input_data_json: str):

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.23
+          image: ghcr.io/spack/django:0.3.24
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.23
+          image: ghcr.io/spack/django:0.3.24
           command:
             [
               "celery",


### PR DESCRIPTION
@jjnesbitt instead of trying to enumerate all the possible ways `requests` can fail transiently (such as the new `ChunkedEncodingError` [here](https://kitware-data.sentry.io/issues/6034682867/?alert_rule_id=15115735&alert_timestamp=1730415288676&alert_type=email&environment=production&notification_uuid=d144ae5f-0d71-4496-a4a0-b2787ebb8132&project=4507069616685056&referrer=alert_email)), what do you think about just retrying all `RequestException` exceptions? That's the parent class that all these exceptions inherit from.

The only downside I see is that we may end up retrying legitimate request failures, but in that case it will just retry it 3 times and propagate the exception to Sentry. That seems more reasonable to me, any thoughts?