### PR TITLE
sync script: block on "all-prechecks"

### DIFF
--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -47,6 +47,6 @@ spec:
               - "--main-branch"
               - "develop"
               - "--prereq-check"
-              - "prechecks / style"
+              - "all-prechecks"
           nodeSelector:
             spack.io/node-pool: base


### PR DESCRIPTION
Update our sync script configuration to not push Spack PR branches until the "all-prechecks" check has succeeded.