### PR TITLE
Reapply Gantry DB Backup

### DIFF
--- a/terraform/modules/spack_gitlab/spack_gantry.tf
+++ b/terraform/modules/spack_gitlab/spack_gantry.tf
@@ -123,6 +123,8 @@ resource "kubectl_manifest" "spack_gantry_config" {
               - type: s3
                 bucket: ${aws_s3_bucket.spack_gantry.id}
                 path: db
+                snapshot-interval: 12h
+                retention: 120h
   YAML
   depends_on = [
     aws_iam_role_policy_attachment.spack_gantry,


### PR DESCRIPTION
I think the cluster upgrade may have wiped out the change made in #955, so I'm reapplying it here.

@mvandenburgh