### PR TITLE
Replace 'do-not-evict' Karpenter annotation with 'do-not-disrupt'

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -142,7 +142,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -196,4 +196,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -127,7 +127,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -181,4 +181,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -132,7 +132,7 @@ spec:
               ttlSecondsAfterFinished = "300" # 5 minutes
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -187,4 +187,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -146,7 +146,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -202,4 +202,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -140,7 +140,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -196,4 +196,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -126,7 +126,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -182,4 +182,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -145,7 +145,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -192,4 +192,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -127,7 +127,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -174,4 +174,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -132,7 +132,7 @@ spec:
               ttlSecondsAfterFinished = "300" # 5 minutes
             [runners.kubernetes.pod_annotations]
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -178,4 +178,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -149,7 +149,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -196,4 +196,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -140,7 +140,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -187,4 +187,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -126,7 +126,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -173,4 +173,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -151,7 +151,7 @@ spec:
             [runners.kubernetes.pod_annotations]
               "pod-cleanup.gitlab.com/ttl" = "7h"
               "fluentbit.io/exclude" = "true"
-              "karpenter.sh/do-not-evict" = "true"
+              "karpenter.sh/do-not-disrupt" = "true"
               "gitlab/ci_pipeline_url" = "$CI_PIPELINE_URL"
               "gitlab/ci_job_url" = "$CI_JOB_URL"
               "gitlab/ci_project_url" = "$CI_PROJECT_URL"
@@ -205,4 +205,4 @@ spec:
       spack.io/node-pool: base # pool for the runner
 
     podAnnotations:
-      karpenter.sh/do-not-evict: true
+      karpenter.sh/do-not-disrupt: true


### PR DESCRIPTION
This is documented in the v0.32 upgrade guide:
https://karpenter.sh/v0.32/upgrading/v1beta1-migration/#annotations-labels-and-status-conditions