### PR TITLE
Upgrade to GitLab 17.3.7

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -21,7 +21,7 @@ spec:
   chart:
     spec:
       chart: gitlab
-      version: 7.11.10 # gitlab@16.11.10
+      version: 8.3.7 # gitlab@17.3.7
       sourceRef:
         kind: HelmRepository
         name: gitlab

--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-graviton2-prot

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-prot

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       chart: gitlab-runner
       # Note: ensure this stays in sync with the `helper_image` field below
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-prot-windows
@@ -109,7 +109,7 @@ spec:
 
             # Image for windows 2022, runner helper
             image = "mcr.microsoft.com/windows/servercore:ltsc2022"
-            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v16.11.3-servercore21H2"
+            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v17.3.3-servercore21H2"
 
             ephemeral_storage_request = "500M"
             helper_ephemeral_storage_request = "500M"

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-prot

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v3-prot

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v4-prot

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-graviton2-pub

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-pub

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       chart: gitlab-runner
       # Note: ensure this stays in sync with the `helper_image` field below
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-pub-windows
@@ -109,7 +109,7 @@ spec:
 
             # Image for windows 2022, runner helper
             image = "mcr.microsoft.com/windows/servercore:ltsc2022"
-            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v16.11.3-servercore21H2"
+            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v17.3.3-servercore21H2"
 
             ephemeral_storage_request = "500M"
             helper_ephemeral_storage_request = "500M"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-pub

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v3-pub

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v4-pub

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.64.3 # gitlab-runner@16.11.3
+      version: 0.68.3 # gitlab-runner@17.3.3
       sourceRef:
         kind: HelmRepository
         name: runner-spack-package-signing


### PR DESCRIPTION
Runners get upgraded to 17.3.3 because that's currently their latest patch in this series.