### PR TITLE
enable setting CPU limits on k8s runners

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -84,6 +84,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
+            cpu_limit_overwrite_max_allowed = "32"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -84,6 +84,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
+            cpu_limit_overwrite_max_allowed = "32"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -95,6 +95,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"
+            cpu_limit_overwrite_max_allowed = "24"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -83,6 +83,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
+            cpu_limit_overwrite_max_allowed = "32"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -83,6 +83,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
+            cpu_limit_overwrite_max_allowed = "32"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -83,6 +83,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
+            cpu_limit_overwrite_max_allowed = "32"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -87,6 +87,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
+            cpu_limit_overwrite_max_allowed = "32"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -84,6 +84,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "16"
+            cpu_limit_overwrite_max_allowed = "32"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "64G"

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -95,6 +95,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"
+            cpu_limit_overwrite_max_allowed = "24"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "48G"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -85,6 +85,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"
+            cpu_limit_overwrite_max_allowed = "24"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "48G"

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -83,6 +83,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"
+            cpu_limit_overwrite_max_allowed = "24"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "48G"

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -83,6 +83,7 @@ spec:
 
             cpu_request = "750m"
             cpu_request_overwrite_max_allowed = "12"
+            cpu_limit_overwrite_max_allowed = "24"
 
             memory_request = "2G"
             memory_request_overwrite_max_allowed = "48G"


### PR DESCRIPTION
Setting `cpu_limit_overwrite_max_allowed` is [required](https://docs.gitlab.com/runner/executors/kubernetes/#cpu-requests-and-limits) to enable CPU limit overwrite (ie, using `KUBERNETES_CPU_LIMIT` within build definitions).

Unlike CPU request and RAM request/limit, we should avoid setting a default CPU limit as this is for experimental purposes only.

@zackgalbreath @jjnesbitt 