### PR TITLE
Move network errors down in deconflict order

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.26
+            image-tags: ghcr.io/spack/django:0.3.27
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/error_taxonomy.yaml
+++ b/analytics/analytics/job_processor/error_taxonomy.yaml
@@ -256,10 +256,6 @@ taxonomy:
     scheduler_failure: null
 
   deconflict_order:
-    # Network errors
-    - 'oidc_certificate_expired'
-    - 'network_timeout'
-    - 'network_error'
     # API Scrape erorrs
     - 'job_log_missing'
     # Spack Errors
@@ -285,6 +281,10 @@ taxonomy:
     - 'deprecated_stack_bug'
     - 'aborted_terminated'
     - 'bootstrap_patchelf_failure'
+    # Network errors
+    - 'oidc_certificate_expired'
+    - 'network_timeout'
+    - 'network_error'
     # System Errors
     - 'oom'
     - 'gitlab_down'

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.26
+          image: ghcr.io/spack/django:0.3.27
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.26
+          image: ghcr.io/spack/django:0.3.27
           command:
             [
               "celery",


### PR DESCRIPTION
These jobs are failing due to spack errors, but they are getting incorrectly labeled as network errors. This change moves the network errors down in the deconflict order to fix this.

This is the reason for all the `network_error` failures on the error dashboard.