### PR TITLE
Increase probe timeout for GitLab CI runners

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -36,6 +36,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 3
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -36,6 +36,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 3
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -37,6 +37,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -36,6 +36,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -36,6 +36,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -36,6 +36,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -36,6 +36,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -36,6 +36,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -37,6 +37,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6
+    probeTimeoutSeconds: 70
 
     # TODO: change to production when ready
     gitlabUrl: "https://gitlab.spack.io/"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -36,6 +36,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -36,6 +36,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -36,6 +36,7 @@ spec:
   values:
     imagePullPolicy: IfNotPresent
     replicas: 6
+    probeTimeoutSeconds: 70
 
     gitlabUrl: "https://gitlab.spack.io/"
     unregisterRunners: true


### PR DESCRIPTION
Set probeTimeoutSeconds to 70 seconds, increasing it from the default value of 1 second.

This change should hopefully alleviate events of the following form:

```
Events:
  Type     Reason     Age    From     Message
  ----     ------     ---    ----     -------
  Normal   Killing    ...    kubelet  Container failed liveness probe, will be restarted

```

The ability to specify this value was added here:
https://gitlab.com/gitlab-org/charts/gitlab-runner/-/merge_requests/306

This is mentioned as a solution to the type of instability we're seeing in this upstream issue:
https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37242

For thoroughness, here's a couple other, relevant upstream MRs related to this topic:
* https://gitlab.com/gitlab-org/charts/gitlab-runner/-/merge_requests/457
* https://gitlab.com/gitlab-org/charts/gitlab-runner/-/merge_requests/483