### PR TITLE
Remove service tag from graviton2-pub runners

### DIFF
--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -54,29 +54,26 @@ spec:
       config: |
         [[runners]]
           pre_build_script = """
-          if [ ${CI_OIDC_REQUIRED:-1} == 1 ]; then
-            echo 'Executing Spack pre-build setup script'
+          echo 'Executing Spack pre-build setup script'
 
-            for cmd in "${PY3:-}" python3 python; do
-              if command -v > /dev/null "$cmd"; then
-                export PY3="$(command -v "$cmd")"
-                break
-              fi
-            done
-
-
-            if [ -z "${PY3:-}" ]; then
-              echo "Unable to find python3 executable"
-              exit 1
+          for cmd in "${PY3:-}" python3 python; do
+            if command -v > /dev/null "$cmd"; then
+              export PY3="$(command -v "$cmd")"
+              break
             fi
+          done
 
-            $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
-            $PY3 pre_build.py > envvars
-
-            . ./envvars
-            rm -f envvars
-            unset GITLAB_OIDC_TOKEN
+          if [ -z "${PY3:-}" ]; then
+            echo "Unable to find python3 executable"
+            exit 1
           fi
+
+          $PY3 -c "import urllib.request;urllib.request.urlretrieve('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', 'pre_build.py')"
+          $PY3 pre_build.py > envvars
+
+          . ./envvars
+          rm -f envvars
+          unset GITLAB_OIDC_TOKEN
           """
 
           output_limit = 20480
@@ -180,7 +177,7 @@ spec:
       imagePullPolicy: "if-not-present"
       locked: false
 
-      tags: "arm,aarch64,graviton,graviton2,small,medium,large,huge,public,aws,spack,service"
+      tags: "arm,aarch64,graviton,graviton2,small,medium,large,huge,public,aws,spack"
       runUntagged: false
       secret: gitlab-gitlab-runner-secret # from gitlab release
 


### PR DESCRIPTION
We continue to see a lot of `pod_failed` errors for this runner. The fact that it bears the service tag is a primary difference between it and the graviton3-pub runners, which do not suffer from this same error rate.

Try removing the service tag to see if these runners start performing better.

Note that the x86-64-v2-pub runner still bears the "service" tag, and it is not used for many other types of jobs.