### PR TITLE
Add new `spack_error` regex to catch `module has no attribute`

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.26
+            image-tags: ghcr.io/spack/django:0.3.27
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/error_taxonomy.yaml
+++ b/analytics/analytics/job_processor/error_taxonomy.yaml
@@ -169,6 +169,7 @@ taxonomy:
         - 'cannot load package .+ from the .builtin. repository'
         - 'must have a default provider in /builds/spack/spack/etc/spack/defaults/packages.yaml'
         - 'Error: .+ object has no attribute'
+        - 'Error: module .+ has no attribute'
         - 'spack.error.InstallError'
         - 'Traceback \(most recent call last\):[\S\n\t\v ]+AssertionError'
 

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.26
+          image: ghcr.io/spack/django:0.3.27
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.26
+          image: ghcr.io/spack/django:0.3.27
           command:
             [
               "celery",


### PR DESCRIPTION
This will properly categorize jobs like the failed generate jobs from this pipeline:

https://gitlab.spack.io/spack/spack/-/pipelines/913233

```
RuntimeError: module 'spack.solver' has no attribute 'asp'
```