### PR TITLE
Increase GitLab GraphQL timeout 30s=>90s

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -116,6 +116,10 @@ spec:
           enabled: false
         packages:
           enabled: false
+        # The graphQL API can be slow to respond when querying for
+        # pipelines with many jobs, so we increase the timeout
+        # to 90 from its default of 30.
+        graphQlTimeout: 90
 
       antiAffinity: hard
     ### END OF GLOBAL SECTION


### PR DESCRIPTION
We're seeing pipelines with many jobs ([like this one](https://gitlab.spack.io/spack/spack/-/pipelines/914561)) timeout in the GitLab UI. This is happening because the UI's request to the GitLab GraphQL API is hitting its default timeout of 30 seconds. 

Note - I increased the value to 90 because the graphql call on that page took 82 (!!) seconds to load. 

Source: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/24400/diffs