### PR TITLE
Add memory requests to all GitLab runners

### DIFF
--- a/k8s/production/runners/protected/graviton/2/release.yaml
+++ b/k8s/production/runners/protected/graviton/2/release.yaml
@@ -197,5 +197,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-graviton.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -182,5 +182,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-graviton.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -188,5 +188,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-x86.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -203,5 +203,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-x86.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -197,5 +197,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-x86.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -183,5 +183,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-x86.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/graviton/2/release.yaml
+++ b/k8s/production/runners/public/graviton/2/release.yaml
@@ -190,5 +190,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-graviton.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -175,5 +175,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-graviton.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -179,5 +179,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-x86.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -197,5 +197,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-x86.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -188,5 +188,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-x86.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -174,5 +174,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-x86.*"})
+        memory: 1G
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -204,5 +204,11 @@ spec:
     nodeSelector:
       spack.io/node-pool: base # pool for the runner
 
+    resources:
+      requests:
+        # Based on this prometheus query:
+        # sum by (pod) (container_memory_max_usage_bytes{namespace="gitlab", pod=~"runner-spack-package-signing.*"})
+        memory: 500M
+
     podAnnotations:
       karpenter.sh/do-not-disrupt: true


### PR DESCRIPTION
There's an unusually high amount of `Nominated` events for some runners (`graviton2` in particular), indicating that Karpenter is constantly rescheduling runner pods. [Dashboard](https://opensearch.spack.io/_dashboards/app/visualize#/edit/7b11c910-b8d6-11ef-96a3-41804d781b2b?type=histogram&indexPattern=59594930-ae4a-11ed-a0b4-4f356475697b&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1d,to:now))&_a=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'59594930-ae4a-11ed-a0b4-4f356475697b',key:involvedObject.namespace.keyword,negate:!f,params:(query:gitlab),type:phrase),query:(match_phrase:(involvedObject.namespace.keyword:gitlab))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'59594930-ae4a-11ed-a0b4-4f356475697b',key:involvedObject.labels.app.keyword,negate:!f,params:!(runner-graviton2-pub-gitlab-runner,runner-x86-v4-pub-gitlab-runner,runner-x86-v3-prot-gitlab-runner,runner-x86-v2-prot-gitlab-runner,runner-x86-v3-pub-gitlab-runner,runner-x86-v2-pub-windows-gitlab-runner,runner-x86-v2-prot-windows-gitlab-runner,runner-x86-v4-prot-gitlab-runner,runner-x86-v2-pub-gitlab-runner,runner-graviton2-prot-gitlab-runner),type:phrases,value:'runner-graviton2-pub-gitlab-runner,%20runner-x86-v4-pub-gitlab-runner,%20runner-x86-v3-prot-gitlab-runner,%20runner-x86-v2-prot-gitlab-runner,%20runner-x86-v3-pub-gitlab-runner,%20runner-x86-v2-pub-windows-gitlab-runner,%20runner-x86-v2-prot-windows-gitlab-runner,%20runner-x86-v4-prot-gitlab-runner,%20runner-x86-v2-pub-gitlab-runner,%20runner-graviton2-prot-gitlab-runner'),query:(bool:(minimum_should_match:1,should:!((match_phrase:(involvedObject.labels.app.keyword:runner-graviton2-pub-gitlab-runner)),(match_phrase:(involvedObject.labels.app.keyword:runner-x86-v4-pub-gitlab-runner)),(match_phrase:(involvedObject.labels.app.keyword:runner-x86-v3-prot-gitlab-runner)),(match_phrase:(involvedObject.labels.app.keyword:runner-x86-v2-prot-gitlab-runner)),(match_phrase:(involvedObject.labels.app.keyword:runner-x86-v3-pub-gitlab-runner)),(match_phrase:(involvedObject.labels.app.keyword:runner-x86-v2-pub-windows-gitlab-runner)),(match_phrase:(involvedObject.labels.app.keyword:runner-x86-v2-prot-windows-gitlab-runner)),(match_phrase:(involvedObject.labels.app.keyword:runner-x86-v4-prot-gitlab-runner)),(match_phrase:(involvedObject.labels.app.keyword:runner-x86-v2-pub-gitlab-runner)),(match_phrase:(involvedObject.labels.app.keyword:runner-graviton2-prot-gitlab-runner))))))),linked:!f,query:(language:kuery,query:''),savedQuery:'gitlab%20runner%20events',uiState:(),vis:(aggs:!((enabled:!t,id:'1',params:(),schema:metric,type:count),(enabled:!t,id:'2',params:(field:involvedObject.labels.app.keyword,missingBucket:!f,missingBucketLabel:Missing,order:desc,orderBy:'1',otherBucket:!f,otherBucketLabel:Other,size:1000),schema:segment,type:terms),(enabled:!t,id:'3',params:(field:reason.keyword,missingBucket:!f,missingBucketLabel:Missing,order:desc,orderBy:'1',otherBucket:!f,otherBucketLabel:Other,size:1000),schema:group,type:terms)),params:(addLegend:!t,addTimeMarker:!f,addTooltip:!t,categoryAxes:!((id:CategoryAxis-1,labels:(filter:!t,show:!t,truncate:100),position:bottom,scale:(type:linear),show:!t,style:(),title:(),type:category)),grid:(categoryLines:!f),labels:(show:!f),legendPosition:right,seriesParams:!((data:(id:'1',label:Count),drawLinesBetweenPoints:!t,lineWidth:2,mode:stacked,show:!t,showCircles:!t,type:histogram,valueAxis:ValueAxis-1)),thresholdLine:(color:%23E7664C,show:!f,style:full,value:10,width:1),times:!(),type:histogram,valueAxes:!((id:ValueAxis-1,labels:(filter:!f,rotate:0,show:!t,truncate:100),name:LeftAxis-1,position:left,scale:(mode:normal,type:linear),show:!t,style:(),title:(text:Count),type:value))),title:'Runner%20events%20by%20type',type:histogram)))

I also noticed we don't have any resource requests on our gitlab runners. I didn't see any evidence in the kube event logs that the nodes are getting oversubscribed in terms of memory, but it's worth a shot and we should be doing this anyways. We should also decide on CPU requests, and some limits for these.