### PR TITLE
Re-enable Windows Karpenter nodes

### DIFF
--- a/terraform/modules/spack_aws_k8s/eks.tf
+++ b/terraform/modules/spack_aws_k8s/eks.tf
@@ -105,43 +105,6 @@ module "eks" {
         }
       }
     }
-    windows_mng = {
-      platform = "windows"
-      ami_type = "WINDOWS_FULL_2022_x86_64"
-
-      instance_types = ["m5.2xlarge"]
-
-      scaling_config = {
-        min_size     = 2
-        max_size     = 2
-        desired_size = 2
-      }
-
-      taints = {
-        windows = {
-          key    = "windows"
-          value  = "true"
-          effect = "NO_SCHEDULE"
-        }
-        runner = {
-          key    = "spack.io/runner-taint"
-          value  = "true"
-          effect = "NO_SCHEDULE"
-        }
-      }
-
-      capacity_type = "ON_DEMAND"
-      block_device_mappings = {
-        sda1 = {
-          device_name = "/dev/sda1"
-          ebs = {
-            volume_size           = 200
-            volume_type           = "gp3"
-            delete_on_termination = true
-          }
-        }
-      }
-    }
   }
 
   node_security_group_name            = "${local.eks_cluster_name}-node-sg"


### PR DESCRIPTION
This re-enables Karpenter support for Windows. This will get us back to autoscaling based on load, instead of just running a couple static instances 24/7.

The issue turned out to be an IAM policy that needed to be attached to the Karpenter controller node, in order for Windows nodes to have the necessary permissions to create EC2 instance profiles. Previously, Karpenter created a static instance profile for all nodes, but starting in v1, they changed the behavior. Since we're using Karpenter for both Linux and Windows nodes, there's some complications to setting up the Terraform modules; I've expanded on the details in a code comment.