### PR TITLE
webhook-handler: ignore install times for failed jobs

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.27
+            image-tags: ghcr.io/spack/django:0.3.28
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/__init__.py
+++ b/analytics/analytics/job_processor/__init__.py
@@ -140,5 +140,6 @@ def process_job(job_input_data_json: str):
 
     # Create build timing facts in a separate transaction, in case this fails
     with transaction.atomic():
-        if job.job.job_type == JobDataDimension.JobType.BUILD:
+        job_data = job.job
+        if job_data.job_type == JobDataDimension.JobType.BUILD and job_data.status == 'success':
             create_build_timing_facts(job_fact=job, gljob=gl_job)

--- a/analytics/analytics/job_processor/artifacts.py
+++ b/analytics/analytics/job_processor/artifacts.py
@@ -8,6 +8,12 @@ from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import ProjectJob
 
 
+class JobArtifactDownloadFailed(Exception):
+    def __init__(self, job: ProjectJob) -> None:
+        message = f"Job {job.id} artifact download failed"
+        super().__init__(message)
+
+
 class JobArtifactFileNotFound(Exception):
     def __init__(self, job: ProjectJob, filename: str):
         message = f"File {filename} not found in job artifacts of job {job.id}"
@@ -37,7 +43,7 @@ def get_job_artifacts_file(job: ProjectJob, filename: str):
             with open(artifacts_file, "wb") as f:
                 job.artifacts(streamed=True, action=f.write)
         except GitlabGetError:
-            raise JobArtifactFileNotFound(job, filename)
+            raise JobArtifactDownloadFailed(job)
 
         # Open specific file within artifacts zip
         with zipfile.ZipFile(artifacts_file) as zfile:

--- a/analytics/analytics/job_processor/metadata.py
+++ b/analytics/analytics/job_processor/metadata.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from gitlab.v4.objects import ProjectJob
 
 from analytics.job_processor.artifacts import (
+    JobArtifactDownloadFailed,
     JobArtifactFileNotFound,
     JobArtifactVariablesNotFound,
     get_job_artifacts_data,
@@ -180,7 +181,7 @@ def retrieve_job_info(gljob: ProjectJob, is_build: bool) -> JobInfo:
     # If the build is failed, this is not unexpected. Otherwise, raise the error
     try:
         artifacts = get_job_artifacts_data(gljob)
-    except (JobArtifactFileNotFound, JobArtifactVariablesNotFound):
+    except (JobArtifactDownloadFailed, JobArtifactFileNotFound, JobArtifactVariablesNotFound):
         if gljob.status == "failed":
             return JobInfo()
 

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.27
+          image: ghcr.io/spack/django:0.3.28
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.27
+          image: ghcr.io/spack/django:0.3.28
           command:
             [
               "celery",


### PR DESCRIPTION
If a build job fails, it won't have an install_times.json.

@jjnesbitt this accounts for some, but not all, of the sentry errors complaining about missing install_times.json.