### PR TITLE
webhook-handler: Don't crash when `install_times.json` is missing

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.3.29
+            image-tags: ghcr.io/spack/django:0.3.30
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.3.29
+          image: ghcr.io/spack/django:0.3.30
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.3.29
+          image: ghcr.io/spack/django:0.3.30
           command:
             [
               "celery",


### PR DESCRIPTION
Since the `install_times.json` file is generated using `spack` itself, it is possible that the file is missing in a PR pipeline. This PR accounts for this case and gracefully exits when the file is missing.

We should set up alternative alerting mechanisms (like a CI test in`spack/spack` for the install_times generator, or a metabase alert that lets us know when a large amount of timing data is missing from the analytics DB) to handle this, instead of blowing up Sentry with errors when a spack PR breaks it.