### PR TITLE
Ignore all extra cache=False install times

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.4.0
+            image-tags: ghcr.io/spack/django:0.4.1
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/build_timings.py
+++ b/analytics/analytics/job_processor/build_timings.py
@@ -114,7 +114,7 @@ def create_build_timing_facts(job_fact: JobFact, gljob: ProjectJob):
     except JobArtifactFileNotFound:
         return
 
-    # For boostrapped packages, install times with cache=False can be present, which don't have a
+    # For bootstrapped packages, install times with cache=False can be present, which don't have a
     # corresonding entry in the spec json. To filter these out, avoid all install times that are
     # cache=False, except the package being built.
     job_package_hash = job_fact.spec.hash

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.4.0
+          image: ghcr.io/spack/django:0.4.1
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.4.0
+          image: ghcr.io/spack/django:0.4.1
           command:
             [
               "celery",


### PR DESCRIPTION
This should fix all the `KeyError` errors we've been seeing in sentry.

This was being caused by install time entries that didn't exist in the spec json. This seems to mainly occur with bootstrapped packages.