### PR TITLE
webhook-handler: increase gitlab API timeout

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -42,7 +42,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.3
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.4.1
+            image-tags: ghcr.io/spack/django:0.4.2
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/utils.py
+++ b/analytics/analytics/job_processor/utils.py
@@ -112,7 +112,7 @@ def get_gitlab_handle():
         settings.GITLAB_ENDPOINT,
         settings.GITLAB_TOKEN,
         retry_transient_errors=True,
-        timeout=15,
+        timeout=30,
     )
 
 

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.4.1
+          image: ghcr.io/spack/django:0.4.2
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.4.1
+          image: ghcr.io/spack/django:0.4.2
           command:
             [
               "celery",


### PR DESCRIPTION
GitLab itself won't timeout until after 60 seconds https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/bulk_imports/clients/graphql.rb#L7, and we've seen cases where fetching a job trace takes more than 15 seconds. So, I've bumped the timeout for the GitLab Python client to 30 seconds to account for this; we can always increase it further if needed, but I think this should be a good start while avoiding potentially introducing head-of-line blocking to the celery queue.