### PR TITLE
Include public signing key when publishing stacks

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -46,7 +46,7 @@ jobs:
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish
-            image-tags: ghcr.io/spack/protected-publish:0.0.1
+            image-tags: ghcr.io/spack/protected-publish:0.0.2
     steps:
       - name: Checkout
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3

--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: protected-publish
-            image: ghcr.io/spack/protected-publish:0.0.1
+            image: ghcr.io/spack/protected-publish:0.0.2
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
When moving the `protected-publish` job from spack gitlab pipelines to a dedicated cron job, I neglected to take care of publishing the signing key to the root mirror.  This PR resolves that issue.

I tested this change by removing a spec from the `s3://spack-binaries/v0.23.0` mirror, then building the imgae locally, and running the container to publish the `v0.23.0` ref.  After which, I could successfully install keys from that mirror:

```
$ git clone https://github.com/spack/spack.git
$ cd spack
$ git checkout v0.23.0
$ spack mirror add binaries s3://spack-binaries/v0.23.0
$ spack buildcache keys --install
==> Fetching s3://spack-binaries/v0.23.0/build_cache/_pgp/spack-public-binary-key.pub
```