### PR TITLE
Upgrade EKS to v1.31

### DIFF
--- a/terraform/modules/spack_aws_k8s/eks.tf
+++ b/terraform/modules/spack_aws_k8s/eks.tf
@@ -59,23 +59,23 @@ module "eks" {
 
   cluster_addons = {
     coredns = {
-      addon_version = "v1.11.1-eksbuild.11"
+      addon_version = "v1.11.4-eksbuild.2"
     }
     eks-pod-identity-agent = {
-      addon_version = "v1.3.0-eksbuild.1"
+      addon_version = "v1.3.4-eksbuild.1"
     }
     kube-proxy = {
-      addon_version = "v1.30.3-eksbuild.2"
+      addon_version = "v1.31.3-eksbuild.2"
     }
     vpc-cni = {
-      addon_version = "v1.18.3-eksbuild.2"
+      addon_version = "v1.19.0-eksbuild.1"
     }
     aws-ebs-csi-driver = {
-      addon_version            = "v1.33.0-eksbuild.1"
+      addon_version            = "v1.38.1-eksbuild.2"
       service_account_role_arn = aws_iam_role.ebs_csi_driver.arn
     }
     aws-efs-csi-driver = {
-      addon_version            = "v2.0.7-eksbuild.1"
+      addon_version            = "v2.1.4-eksbuild.1"
       service_account_role_arn = aws_iam_role.efs_csi_driver.arn
     }
   }

--- a/terraform/modules/spack_aws_k8s/eks.tf
+++ b/terraform/modules/spack_aws_k8s/eks.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "20.31.3"
 
   cluster_name    = local.eks_cluster_name
-  cluster_version = "1.30"
+  cluster_version = "1.31"
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster

--- a/terraform/modules/spack_aws_k8s/karpenter.tf
+++ b/terraform/modules/spack_aws_k8s/karpenter.tf
@@ -1,5 +1,5 @@
 locals {
-  karpenter_chart_version = "1.0.0"
+  karpenter_chart_version = "1.0.5"
 }
 
 module "karpenter" {


### PR DESCRIPTION
Updates the kubernetes version of our EKS cluster to the latest version (1.31). Nothing in this upgrade requires any changes to our infrastructure, see [upgrade docs](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html#kubernetes-1.31).

This PR also upgrades Karpenter's patch version (1.0.0 => 1.0.5). This is required because 1.0.5 is the minimum supported version for k8s v1.31 (see https://karpenter.sh/docs/upgrading/compatibility/). This is only a patch release, so no breaking changes are introduced. There _is_ a minor upgrade for Karpenter available (1.1), but I figured we can do that in a follow up to avoid making too many unrelated changes here.

I've applied this to the staging cluster, and everything appears to be working as intended. Example gitlab pipeline I ran after upgrading the staging cluster https://gitlab.staging.spack.io/spack/spack/-/pipelines/1624