### PR TITLE
Update Karpenter manifests to apiVersion v1

### DIFF
--- a/k8s/production/karpenter/provisioners/base/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/base/provisioner.yaml
@@ -1,6 +1,6 @@
 ---
 # Provisioner for base pods
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: base
@@ -32,9 +32,9 @@ spec:
         values: ["linux"]
 
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
         kind: EC2NodeClass
         name: default
+        group: karpenter.k8s.aws
 
   # Terminate nodes after 5 minutes of idle time
   disruption:

--- a/k8s/production/karpenter/provisioners/beefy/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/beefy/provisioner.yaml
@@ -1,6 +1,6 @@
 ---
 # Provisioner for beefy pods
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: beefy
@@ -29,9 +29,9 @@ spec:
         values: ["linux"]
 
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
         kind: EC2NodeClass
         name: default
+        group: karpenter.k8s.aws
 
   # Terminate nodes after 5 minutes of idle time
   disruption:

--- a/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
@@ -1,6 +1,6 @@
 ---
 # Provisioner for gitlab pods
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: gitlab
@@ -29,9 +29,9 @@ spec:
           values: ["linux"]
 
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
         kind: EC2NodeClass
         name: default
+        group: karpenter.k8s.aws
 
   # Terminate nodes after 5 minutes of idle time
   disruption:

--- a/k8s/production/karpenter/provisioners/runners/graviton/3/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/graviton/3/provisioners.yaml
@@ -1,6 +1,6 @@
 ---
 # Provisioner for graviton3 gitlab runners
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: glr-graviton3
@@ -65,9 +65,9 @@ spec:
           values: ["linux"]
 
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
         kind: EC2NodeClass
         name: default
+        group: karpenter.k8s.aws
 
       # Taint these nodes so only pipeline pods will be scheduled on them.
       taints:

--- a/k8s/production/karpenter/provisioners/runners/graviton/4/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/graviton/4/provisioners.yaml
@@ -1,6 +1,6 @@
 ---
 # Provisioner for graviton4 gitlab runners
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: glr-graviton4
@@ -65,9 +65,9 @@ spec:
           values: ["linux"]
 
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
         kind: EC2NodeClass
         name: default
+        group: karpenter.k8s.aws
 
       # Taint these nodes so only pipeline pods will be scheduled on them.
       taints:

--- a/k8s/production/karpenter/provisioners/runners/testing/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/testing/provisioners.yaml
@@ -1,6 +1,6 @@
 ---
 # Provisioner for testing gitlab runners
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: testing
@@ -47,9 +47,9 @@ spec:
         values: ["linux"]
 
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
         kind: EC2NodeClass
         name: default
+        group: karpenter.k8s.aws
 
       # Taint these nodes so only pipeline pods will be scheduled on them.
       taints:

--- a/k8s/production/karpenter/provisioners/runners/windows/x86_64/v2/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/runners/windows/x86_64/v2/provisioner.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: x86-64-v2-win
@@ -40,9 +40,9 @@ spec:
             - "us-east-1d"
 
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
         kind: EC2NodeClass
         name: windows
+        group: karpenter.k8s.aws
 
       taints:
         # Taint windows nodes to ensure pods must explicitly "opt-in" to be scheduled on them.

--- a/k8s/production/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
@@ -1,6 +1,6 @@
 ---
 # Provisioner for x86_64_v2 gitlab runners
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: glr-x86-64-v2
@@ -55,9 +55,9 @@ spec:
         values: ["linux"]
 
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
         kind: EC2NodeClass
         name: default
+        group: karpenter.k8s.aws
 
       # Taint these nodes so only pipeline pods will be scheduled on them.
       taints:

--- a/k8s/production/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
@@ -1,6 +1,6 @@
 ---
 # Provisioner for x86_64_v3 gitlab runners
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: glr-x86-64-v3
@@ -88,9 +88,9 @@ spec:
         values: ["spot"]
 
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
         kind: EC2NodeClass
         name: default
+        group: karpenter.k8s.aws
 
       # Taint these nodes so only pipeline pods will be scheduled on them.
       taints:

--- a/k8s/production/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
@@ -1,6 +1,6 @@
 ---
 # Provisioner for x86_64_v4 gitlab runners
-apiVersion: karpenter.sh/v1beta1
+apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
   name: glr-x86-64-v4
@@ -76,9 +76,9 @@ spec:
           values: ["linux"]
 
       nodeClassRef:
-        apiVersion: karpenter.k8s.aws/v1beta1
         kind: EC2NodeClass
         name: default
+        group: karpenter.k8s.aws
 
       # Taint these nodes so only pipeline pods will be scheduled on them.
       taints:

--- a/terraform/modules/spack_aws_k8s/karpenter.tf
+++ b/terraform/modules/spack_aws_k8s/karpenter.tf
@@ -62,12 +62,14 @@ resource "helm_release" "karpenter" {
 
 resource "kubectl_manifest" "karpenter_node_class" {
   yaml_body = <<-YAML
-    apiVersion: karpenter.k8s.aws/v1beta1
+    apiVersion: karpenter.k8s.aws/v1
     kind: EC2NodeClass
     metadata:
       name: default
     spec:
       amiFamily: AL2023
+      amiSelectorTerms:
+        - alias: al2023@latest
       userData: |
         apiVersion: node.eks.aws/v1alpha1
         kind: NodeConfig
@@ -104,12 +106,14 @@ resource "kubectl_manifest" "karpenter_node_class" {
 
 resource "kubectl_manifest" "karpenter_windows_node_class" {
   yaml_body = <<-YAML
-    apiVersion: karpenter.k8s.aws/v1beta1
+    apiVersion: karpenter.k8s.aws/v1
     kind: EC2NodeClass
     metadata:
       name: windows
     spec:
       amiFamily: Windows2022
+      amiSelectorTerms:
+        - alias: windows2022@latest
       role: ${module.karpenter_windows.node_iam_role_name}
       subnetSelectorTerms:
         - tags:


### PR DESCRIPTION
The v1beta1 API is deprecated, and removed in Karpenter 1.1. See https://karpenter.sh/v1.0/upgrading/v1-migration/#before-upgrading-to-v110 for the required changes.