### PR TITLE
Revert "[gh-actions](deps): Bump docker/build-push-action from 6.12.0 to 6.13.0"

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build ${{ (github.ref == 'refs/heads/main' && 'and push ') || '' }}${{ matrix.docker-image }}
         id: docker-build-push
-        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+        uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6.12.0
         with:
           context: ${{ matrix.docker-image }}
           file: ${{ matrix.docker-image }}/Dockerfile


### PR DESCRIPTION
Reverts spack/spack-infrastructure#1045

This update broke image pushing to GHCR. I'm not sure what's going on, the changelog doesn't indicate anything that would cause a breakage like this. Just reverting this for now :shrug: 