### PR TITLE
Set `permissions` for pushing to GHCR

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -17,6 +17,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The GitHub docs say to include these fields in order to push to the GHCR - https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages. We've never set them before and pushing has worked just fine until now, but there's at least one instance of this randomly fixing the issue for others (https://github.com/docker/build-push-action/issues/687#issuecomment-1651816012)