### PR TITLE
Downgrade windows runners to v17.7.1

### DIFF
--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       chart: gitlab-runner
       # Note: ensure this stays in sync with the `helper_image` field below
-      version: 0.73.1 # gitlab-runner@17.8.1
+      version: 0.72.1 # gitlab-runner@17.7.1
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-prot-windows
@@ -111,7 +111,7 @@ spec:
 
             # Image for windows 2022, runner helper
             image = "mcr.microsoft.com/windows/servercore:ltsc2022"
-            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v17.7.0-servercore21H2"
+            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v17.7.1-servercore21H2"
 
             ephemeral_storage_request = "500M"
             helper_ephemeral_storage_request = "500M"

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       chart: gitlab-runner
       # Note: ensure this stays in sync with the `helper_image` field below
-      version: 0.73.1 # gitlab-runner@17.8.1
+      version: 0.72.1 # gitlab-runner@17.7.1
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-pub-windows
@@ -111,7 +111,7 @@ spec:
 
             # Image for windows 2022, runner helper
             image = "mcr.microsoft.com/windows/servercore:ltsc2022"
-            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v17.8.1-servercore21H2"
+            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v17.7.1-servercore21H2"
 
             ephemeral_storage_request = "500M"
             helper_ephemeral_storage_request = "500M"


### PR DESCRIPTION
The helper image for v17.8.1 doesn't seem to be available in the gitlab container registry. Despite being listed here
https://gitlab.com/gitlab-org/gitlab-runner/container_registry/1472754?orderBy=NAME&sort=desc&search[]=x86_64-v1&search[]=servercore21H2, running a `docker pull` on it fails.

I've downgraded it for now to 17.7.1, as all windows CI jobs are currently failing with a `pod failed` error due to this.