### PR TITLE
Update GitLab RDS instance to `gp3` storage

### DIFF
--- a/terraform/modules/spack_aws_k8s/gitlab_db.tf
+++ b/terraform/modules/spack_aws_k8s/gitlab_db.tf
@@ -45,6 +45,7 @@ module "gitlab_db" {
   max_allocated_storage = 1000
   storage_type          = "gp3"
   iops                  = 12000 # 12,000 is the minimum IOPs for gp3 storage. We can increase this as needed.
+  storage_throughput    = 500   # 500 is the minimum throughput for gp3 storage. We can increase this as needed.
 
   vpc_security_group_ids = [module.postgres_security_group.security_group_id]
 }


### PR DESCRIPTION
We are currently on gp2, and encountering IOPS issues. Updating to gp3 will increase the IOPS and also save us some money.

![Screenshot from 2025-02-19 12-27-57](https://github.com/user-attachments/assets/a2896a25-4f12-4115-b334-598d82db1c6f)

This will require some downtime; if no one has any objections to this, I'll apply it to staging and then coordinate the deploy to production.