### PR TITLE
Update analytics, CDash RDS instances to gp3

### DIFF
--- a/terraform/modules/spack_aws_k8s/analytics_db.tf
+++ b/terraform/modules/spack_aws_k8s/analytics_db.tf
@@ -41,6 +41,9 @@ module "analytics_db" {
 
   allocated_storage     = 500
   max_allocated_storage = 1000
+  storage_type          = "gp3"
+  iops                  = 12000 # 12,000 is the minimum IOPs for gp3 storage. We can increase this as needed.
+  storage_throughput    = 500   # 500 is the minimum throughput for gp3 storage. We can increase this as needed.
 
   vpc_security_group_ids = [module.postgres_security_group.security_group_id]
 

--- a/terraform/modules/spack_aws_k8s/cdash_db.tf
+++ b/terraform/modules/spack_aws_k8s/cdash_db.tf
@@ -37,7 +37,10 @@ module "cdash_db" {
   skip_final_snapshot     = true
   deletion_protection     = true
 
-  allocated_storage = 300
+  allocated_storage  = 300
+  storage_type       = "gp3"
+  iops               = 12000 # 3,000 is the minimum IOPs for <400 GB storage. We can increase this as needed.
+  storage_throughput = 125   # 125 is the minimum throughput for <400 GB storage. We can increase this as needed.
 
   vpc_security_group_ids = [module.mysql_security_group.security_group_id]
 }


### PR DESCRIPTION
Similar to #1060. We don't have any pressing issues with the performance of `gp2` on these instances, but `gp3` is cheaper in addition to more performant, so there's only upsides to doing this.