### PR TITLE
cache_indexer: prepare for change to content-addressable

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -43,7 +43,7 @@ jobs:
           - docker-image: ./images/snapshot-release-tags
             image-tags: ghcr.io/spack/snapshot-release-tags:0.0.4
           - docker-image: ./images/cache-indexer
-            image-tags: ghcr.io/spack/cache-indexer:0.0.3
+            image-tags: ghcr.io/spack/cache-indexer:0.0.4
           - docker-image: ./analytics
             image-tags: ghcr.io/spack/django:0.4.6
           - docker-image: ./images/ci-prune-buildcache

--- a/images/cache-indexer/cache_indexer.py
+++ b/images/cache-indexer/cache_indexer.py
@@ -26,9 +26,20 @@ SUBREF_IGNORE_REGEXES = [
     re.compile(r"^e4s-mac$"),
 ]
 
+ROOT_PATTERN = r"build_cache"
+INDEX_PATH = r"index.json"
+
+### To switch to content-addressable: uncomment the lines below, and comment or
+### remove the similar lines above.
+# ROOT_MATCHER = r"v[\d]+"
+# INDEX_PATH = r"specs/index.json"
+
+ROOT_MATCHER = re.compile(rf"^{ROOT_PATTERN}$")
+INDEX_MATCHER = re.compile(rf"/{ROOT_PATTERN}/{INDEX_PATH}$")
+
 
 def get_label(subref):
-    if subref == "build_cache":
+    if ROOT_MATCHER.match(subref):
         return "root" # or top-level?
     for regex in SUBREF_IGNORE_REGEXES:
         if regex.match(subref):
@@ -69,7 +80,7 @@ def query_bucket(bucket_name):
     results = []
     for page in pages:
         for obj in page["Contents"]:
-            if obj["Key"].endswith("/build_cache/index.json"):
+            if INDEX_MATCHER.search(obj["Key"]):
                 results.append(obj["Key"])
 
     return results

--- a/k8s/production/custom/cache-indexer/cron-jobs.yaml
+++ b/k8s/production/custom/cache-indexer/cron-jobs.yaml
@@ -14,7 +14,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: index-binary-caches
-            image: ghcr.io/spack/cache-indexer:0.0.3
+            image: ghcr.io/spack/cache-indexer:0.0.4
             imagePullPolicy: IfNotPresent
             env:
               - name: BUCKET_NAME


### PR DESCRIPTION
The cache indexer runs nightly looking for buildcache indices in the `spack-binaries` bucket.  Once [spack/spack#48713](https://github.com/spack/spack/pull/48713) is merged, spack will cease putting buildcaches under the `build_cache` directory/prefix of a mirror, and instead it will begin putting them under `v3/specs`. At that point the cache indexer will have until the end of the day to update to do the same.

This PR contains a small refactor which we can merge now, to make that transition easier so only a tiny cache_indexer change is required once the spack PR is merged.