### PR TITLE
migration: update develop stack list

### DIFF
--- a/images/protected-publish/develop_stacks.txt
+++ b/images/protected-publish/develop_stacks.txt
@@ -1,35 +1,26 @@
-s3://spack-binaries/develop/aws-isc-aarch64
-s3://spack-binaries/develop/aws-isc
-s3://spack-binaries/develop/aws-pcluster-icelake
-s3://spack-binaries/develop/aws-pcluster-neoverse_v1
-s3://spack-binaries/develop/aws-pcluster-x86_64_v4
-s3://spack-binaries/develop/bootstrap-x86_64-linux-gnu
-s3://spack-binaries/develop/build_systems
-s3://spack-binaries/develop/data-vis-sdk
-s3://spack-binaries/develop/deprecated
-s3://spack-binaries/develop/developer-tools-aarch64-linux-gnu
-s3://spack-binaries/develop/developer-tools-darwin
-s3://spack-binaries/develop/developer-tools-manylinux2014
-s3://spack-binaries/develop/developer-tools-x86_64_v3-linux-gnu
-s3://spack-binaries/develop/developer-tools
-s3://spack-binaries/develop/e4s-cray-rhel
-s3://spack-binaries/develop/e4s-cray-sles
-s3://spack-binaries/develop/e4s-neoverse-v2
-s3://spack-binaries/develop/e4s-neoverse_v1
-s3://spack-binaries/develop/e4s-oneapi
-s3://spack-binaries/develop/e4s-power
-s3://spack-binaries/develop/e4s-rocm-external
-s3://spack-binaries/develop/e4s
-s3://spack-binaries/develop/gpu-tests
-s3://spack-binaries/develop/hep
-s3://spack-binaries/develop/ml-darwin-aarch64-mps
-s3://spack-binaries/develop/ml-linux-aarch64-cpu
-s3://spack-binaries/develop/ml-linux-aarch64-cuda
-s3://spack-binaries/develop/ml-linux-x86_64-cpu
-s3://spack-binaries/develop/ml-linux-x86_64-cuda
-s3://spack-binaries/develop/ml-linux-x86_64-rocm
-s3://spack-binaries/develop/radiuss-aws-aarch64
-s3://spack-binaries/develop/radiuss-aws
-s3://spack-binaries/develop/radiuss
-s3://spack-binaries/develop/tutorial
-s3://spack-binaries/develop/windows-vis
+- s3://spack-binaries/develop/aws-pcluster-neoverse_v1/
+- s3://spack-binaries/develop/aws-pcluster-x86_64_v4/
+- s3://spack-binaries/develop/bootstrap-aarch64-darwin/
+- s3://spack-binaries/develop/bootstrap-x86_64-linux-gnu/
+- s3://spack-binaries/develop/build_systems/
+- s3://spack-binaries/develop/data-vis-sdk/
+- s3://spack-binaries/develop/developer-tools-aarch64-linux-gnu/
+- s3://spack-binaries/develop/developer-tools-darwin/
+- s3://spack-binaries/develop/developer-tools-manylinux2014/
+- s3://spack-binaries/develop/e4s-cray-rhel/
+- s3://spack-binaries/develop/e4s-neoverse-v2/
+- s3://spack-binaries/develop/e4s-oneapi/
+- s3://spack-binaries/develop/e4s-rocm-external/
+- s3://spack-binaries/develop/e4s/
+- s3://spack-binaries/develop/hep/
+- s3://spack-binaries/develop/ml-darwin-aarch64-mps/
+- s3://spack-binaries/develop/ml-linux-aarch64-cpu/
+- s3://spack-binaries/develop/ml-linux-aarch64-cuda/
+- s3://spack-binaries/develop/ml-linux-x86_64-cpu/
+- s3://spack-binaries/develop/ml-linux-x86_64-cuda/
+- s3://spack-binaries/develop/ml-linux-x86_64-rocm/
+- s3://spack-binaries/develop/radiuss-aws-aarch64/
+- s3://spack-binaries/develop/radiuss-aws/
+- s3://spack-binaries/develop/radiuss/
+- s3://spack-binaries/develop/tutorial/
+- s3://spack-binaries/develop/windows-vis/


### PR DESCRIPTION
This is just to record the stacks we're migrating, so it should not require any image version bumps.