### PR TITLE
Update error taxonomy with new regexes

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -45,7 +45,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.4
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.4.6
+            image-tags: ghcr.io/spack/django:0.4.7
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/error_taxonomy.yaml
+++ b/analytics/analytics/job_processor/error_taxonomy.yaml
@@ -172,6 +172,8 @@ taxonomy:
         - 'Error: module .+ has no attribute'
         - 'spack.error.InstallError'
         - 'Traceback \(most recent call last\):[\S\n\t\v ]+AssertionError'
+        - 'spack.error.SpecError'
+        - 'spack.config.ConfigFileError'
 
     invalid_pipeline_yaml:
       grep_for:

--- a/analytics/analytics/job_processor/error_taxonomy.yaml
+++ b/analytics/analytics/job_processor/error_taxonomy.yaml
@@ -174,6 +174,7 @@ taxonomy:
         - 'Traceback \(most recent call last\):[\S\n\t\v ]+AssertionError'
         - 'spack.error.SpecError'
         - 'spack.config.ConfigFileError'
+        - 'Error: Invalid URL scheme'
 
     invalid_pipeline_yaml:
       grep_for:

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.4.6
+          image: ghcr.io/spack/django:0.4.7
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.4.6
+          image: ghcr.io/spack/django:0.4.7
           command:
             [
               "celery",


### PR DESCRIPTION
Hopefully this will help cut down the number of failed jobs that are labelled as `other` recently.