### PR TITLE
Upgrade to GitLab 17.9.2

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -21,7 +21,7 @@ spec:
   chart:
     spec:
       chart: gitlab
-      version: 8.9.1 # gitlab@17.9.1
+      version: 8.9.2 # gitlab@17.9.2
       sourceRef:
         kind: HelmRepository
         name: gitlab


### PR DESCRIPTION
Addresses https://nvd.nist.gov/vuln/detail/CVE-2025-1257