### PR TITLE
Enable interruption handling for Karpenter

### DIFF
--- a/terraform/modules/spack_aws_k8s/karpenter.tf
+++ b/terraform/modules/spack_aws_k8s/karpenter.tf
@@ -51,7 +51,7 @@ resource "helm_release" "karpenter" {
     settings:
       clusterName: ${module.eks.cluster_name}
       clusterEndpoint: ${module.eks.cluster_endpoint}
-      interruptionQueueName: ${module.karpenter.queue_name}
+      interruptionQueue: ${module.karpenter.queue_name}
     serviceMonitor:
       enabled: true
     EOT


### PR DESCRIPTION
The name of the relevant value appears to be settings.interruptionQueue, not settings.interruptionQueueName

https://github.com/aws/karpenter-provider-aws/blob/v1.1.0/charts/karpenter/values.yaml#L173

https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-0320