### PR TITLE
notary: Use separate input and output directories

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -37,7 +37,7 @@ jobs:
           - docker-image: ./images/gitlab-skipped-pipelines
             image-tags: ghcr.io/spack/gitlab-skipped-pipelines:0.0.2
           - docker-image: ./images/notary
-            image-tags: ghcr.io/spack/notary:0.0.1
+            image-tags: ghcr.io/spack/notary:0.0.2
           - docker-image: ./images/python-aws-bash
             image-tags: ghcr.io/spack/python-aws-bash:0.0.2
           - docker-image: ./images/snapshot-release-tags

--- a/images/notary/sign.sh
+++ b/images/notary/sign.sh
@@ -59,7 +59,7 @@ gpg --import-ownertrust <(echo -e "${INTERMEDIATE_CI_PUBLIC_KEY_ID}:6:\n${UO_INT
 # Check downloaded spec files,  die if not signed/verified
 for FILE in $( find $INPUTDIR -type f ); do
     echo "VERIFY: ${FILE}"
-    gpg --no-tty --quiet ${FILE}
+    gpg --verify --no-tty --quiet ${FILE}
     rm ${FILE}
 done
 

--- a/images/notary/sign.sh
+++ b/images/notary/sign.sh
@@ -20,7 +20,10 @@ unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 
 
 WORKINGDIR=${WORKINGDIR:-/tmp}
-mkdir -p $WORKINGDIR
+INPUTDIR="${WORKINGDIR}/input"
+OUTPUTDIR="${WORKINGDIR}/output"
+mkdir -p $INPUTDIR
+mkdir -p $OUTPUTDIR
 
 KMS_KEY_ARN=arn:aws:kms:us-east-1:588562868276:key/bc739d17-8569-4741-9385-9264715b90b6
 
@@ -54,7 +57,7 @@ gpg --import-ownertrust <(echo -e "${INTERMEDIATE_CI_PUBLIC_KEY_ID}:6:\n${UO_INT
 
 
 # Check downloaded spec files,  die if not signed/verified
-for FILE in $( find $WORKINGDIR -type f ); do
+for FILE in $( find $INPUTDIR -type f ); do
     echo "VERIFY: ${FILE}"
     gpg --no-tty --quiet ${FILE}
     rm ${FILE}
@@ -66,9 +69,9 @@ gpg --no-tty --import <(aws-encryption-cli --decrypt -S -w "key=${KMS_KEY_ARN}" 
 
 
 # Sign Keys with reputational key
-for FILE in $( find $WORKINGDIR -type f ); do
+for FILE in $( find $INPUTDIR -type f ); do
    echo "SIGN: ${FILE}"
-   gpg --no-tty --output ${FILE}.sig --clearsign ${FILE}
+   gpg --no-tty --output "${OUTPUTDIR}/${FILE}" --clearsign ${FILE}
    rm ${FILE}
 done
 


### PR DESCRIPTION
After content-addressable tarballs is merged, clearsigning will be performed on spec manifest files, without changing the name of the file. This change keeps the original file name when re-signing, and to prevent issues with gpg overwriting files, it puts re-signed files into a different directory from the original files.

This can be merged before the content-addressable tarballs spack [PR](https://github.com/spack/spack/pull/48713).

