### PR TITLE
notary: build/use numbered tags instead of 'latest'

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -37,7 +37,7 @@ jobs:
           - docker-image: ./images/gitlab-skipped-pipelines
             image-tags: ghcr.io/spack/gitlab-skipped-pipelines:0.0.2
           - docker-image: ./images/notary
-            image-tags: ghcr.io/spack/notary:latest
+            image-tags: ghcr.io/spack/notary:0.0.1
           - docker-image: ./images/python-aws-bash
             image-tags: ghcr.io/spack/python-aws-bash:0.0.2
           - docker-image: ./images/snapshot-release-tags

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -180,7 +180,7 @@ spec:
               medium = "Memory"
 
       # default image
-      image: "ghcr.io/spack/notary:latest"
+      image: "ghcr.io/spack/notary:0.0.1"
       imagePullPolicy: "always"
       tags: "spack,notary,aws,protected"
 


### PR DESCRIPTION
Instead of using the `latest` tag when we push the notary image and use it in the signing runner helm release, prefer numbered tags.  The goal here is to allow spack develop to keep using a known working version, while allowing us to test the next version elsewhere.