### PR TITLE
signing: allow specifying image by sha

### DIFF
--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -92,7 +92,7 @@ spec:
             service_account = "notary"
 
             # TODO Change to actual image before merge
-            allowed_images = ["ghcr.io/spack/notary:*"]
+            allowed_images = ["ghcr.io/spack/notary:*", "ghcr.io/spack/notary@*"]
             allowed_services = [""]
 
             # TODO Set up security contexts with the image


### PR DESCRIPTION
The goal of this PR is to allow us to specify the image used by the spack signing job by it's computed sha.