### PR TITLE
Search through artifacts zip for files of interest

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -45,7 +45,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.4
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.4.6
+            image-tags: ghcr.io/spack/django:0.4.7
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/artifacts.py
+++ b/analytics/analytics/job_processor/artifacts.py
@@ -1,11 +1,11 @@
-from contextlib import contextmanager
-from dataclasses import dataclass
 import tempfile
 import zipfile
+from contextlib import contextmanager
+from dataclasses import dataclass
 
+import yaml
 from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import ProjectJob
-import yaml
 
 
 class JobArtifactDownloadFailed(Exception):
@@ -28,15 +28,13 @@ class JobArtifactVariablesNotFound(Exception):
 
 class JobArtifactsMissingVariable(Exception):
     def __init__(self, job: ProjectJob, variable: str) -> None:
-        message = (
-            f"The following variable was missing in the artifacts for job {job.id}: {variable}"
-        )
+        message = f"The following variable was missing in the artifacts for job {job.id}: {variable}"
         super().__init__(message)
 
 
 @contextmanager
-def get_job_artifacts_file(job: ProjectJob, filename: str):
-    """Yields a file IO, raises KeyError if the filename is not present"""
+def get_job_artifacts_file(job: ProjectJob, filepath: str):
+    """Yields a file IO, raises KeyError if filepath is not present."""
     with tempfile.NamedTemporaryFile(suffix=".zip") as temp:
         artifacts_file = temp.name
 
@@ -50,10 +48,39 @@ def get_job_artifacts_file(job: ProjectJob, filename: str):
         # Open specific file within artifacts zip
         with zipfile.ZipFile(artifacts_file) as zfile:
             try:
-                with zfile.open(filename) as timing_file:
+                with zfile.open(filepath) as timing_file:
                     yield timing_file
             except KeyError:
-                raise JobArtifactFileNotFound(job, filename)
+                raise JobArtifactFileNotFound(job, filepath)
+
+
+@contextmanager
+def find_job_artifacts_file(job: ProjectJob, filename: str):
+    """
+    Yields a file IO, raises KeyError if the filename is not present.
+
+    Search for a file within the artifacts zip file, and yield its bytes.
+    Filename should be just the name of the file itself, without any prefix.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".zip") as temp:
+        artifacts_file = temp.name
+
+        # Download artifacts zip
+        try:
+            with open(artifacts_file, "wb") as f:
+                job.artifacts(streamed=True, action=f.write)
+        except GitlabGetError:
+            raise JobArtifactDownloadFailed(job)
+
+        # Search for specific file within artifacts zip
+        with zipfile.ZipFile(artifacts_file) as zfile:
+            for zipinfo in zfile.filelist:
+                name = zipinfo.filename.split("/")[-1]
+                if name == filename:
+                    with zfile.open(filename) as timing_file:
+                        yield timing_file
+
+            raise JobArtifactFileNotFound(job, filename)
 
 
 @dataclass
@@ -74,8 +101,7 @@ class JobArtifactsData:
 
 def get_job_artifacts_data(gljob: ProjectJob) -> JobArtifactsData:
     """Fetch the artifacts of a job to retrieve info about it."""
-    pipeline_yml_filename = "jobs_scratch_dir/reproduction/cloud-ci-pipeline.yml"
-    with get_job_artifacts_file(gljob, pipeline_yml_filename) as pipeline_file:
+    with find_job_artifacts_file(gljob, "cloud-ci-pipeline.yml") as pipeline_file:
         raw_pipeline = yaml.safe_load(pipeline_file)
 
     pipeline_vars = raw_pipeline.get("variables", {})

--- a/analytics/analytics/job_processor/build_timings.py
+++ b/analytics/analytics/job_processor/build_timings.py
@@ -9,23 +9,23 @@ from analytics.core.models.dimensions import (
     TimerPhaseDimension,
 )
 from analytics.core.models.facts import JobFact, TimerFact, TimerPhaseFact
-from analytics.job_processor.artifacts import JobArtifactFileNotFound, get_job_artifacts_file
+from analytics.job_processor.artifacts import (
+    JobArtifactFileNotFound,
+    find_job_artifacts_file,
+)
 
 
 def get_timings_json(job: ProjectJob) -> list[dict]:
-    timing_filename = "jobs_scratch_dir/user_data/install_times.json"
-    with get_job_artifacts_file(job, timing_filename) as file:
+    with find_job_artifacts_file(job, "install_times.json") as file:
         return json.load(file)
 
 
 def get_spec_json(job: ProjectJob) -> list[dict]:
-    repro_dir_prefix = "jobs_scratch_dir/reproduction"
-    with get_job_artifacts_file(job, f"{repro_dir_prefix}/repro.json") as file:
+    with find_job_artifacts_file(job, "repro.json") as file:
         repro = json.load(file)
 
     spec_filename = repro["job_spec_json"]
-    spec_file = f"{repro_dir_prefix}/{spec_filename}"
-    with get_job_artifacts_file(job, spec_file) as file:
+    with find_job_artifacts_file(job, spec_filename) as file:
         spec = json.load(file)
 
     return spec
@@ -118,7 +118,6 @@ def create_build_timing_facts(job_fact: JobFact, gljob: ProjectJob):
     # cache=False, except the package being built.
     job_package_hash = job_fact.spec.hash
     timings = [t for t in timing_data if t["cache"] or t["hash"] == job_package_hash]
-
 
     # First, ensure that all packages and specs are entered into the db. Then, fetch all timing packages
     create_packages_and_specs(gljob)

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.4.6
+          image: ghcr.io/spack/django:0.4.7
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.4.6
+          image: ghcr.io/spack/django:0.4.7
           command:
             [
               "celery",


### PR DESCRIPTION
Fixes an issue where the webhook handler would crash if processing jobs from https://github.com/spack/spack/pull/49547.

Previously we simply hardcoded paths like `jobs_scratch_dir/reproduction/cloud-ci-pipeline.yml`. Since this occasionally changes, searching through the artifacts file list fixes the problem.