### PR TITLE
Enable Gitaly Bundle URIs

### DIFF
--- a/k8s/production/custom/gitlab-gitaly-bundle-refresher/cronjobs.yaml
+++ b/k8s/production/custom/gitlab-gitaly-bundle-refresher/cronjobs.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: refresh-gitaly-bundle
+  namespace: gitlab
+spec:
+  schedule: "*/15 * * * *"  # Every 15 minutes
+  successfulJobsHistoryLimit: 1  # Only save most recent run to avoid overpopulating the pod list in the gitlab namespace
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: refresh-gitaly-bundle
+          restartPolicy: Never
+          containers:
+            - name: refresh-gitaly-bundle
+              image: bitnami/kubectl
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+
+                  # Enable Gitaly bundle URI feature
+                  # This command is idempotent, so we can run it every time to ensure the feature is enabled
+                  kubectl exec --stdin --namespace gitlab deploy/gitlab-toolbox --container toolbox -- /srv/gitlab/bin/rails runner "Feature.enable(:gitaly_bundle_uri)"
+
+                  # Get the hashed repository path
+                  REPO_PATH="$(kubectl exec --stdin --namespace gitlab deploy/gitlab-toolbox --container toolbox -- /srv/gitlab/bin/rails runner "puts Project.find_by_full_path('spack/spack').repository.disk_path").git"
+
+                  if [ -z "$REPO_PATH" ]; then
+                    echo "Error: Repository path not found!"
+                    exit 1
+                  fi
+
+                  echo "Found repository path: $REPO_PATH"
+
+                  # Run Gitaly bundle-uri command
+                  kubectl exec --stdin $(kubectl get pod --namespace gitlab --selector app=gitaly --output jsonpath='{.items[0].metadata.name}') -- \
+                    gitaly bundle-uri \
+                      --config=/etc/gitaly/config.toml \
+                      --storage=default \
+                      --repository=$REPO_PATH
+          nodeSelector:
+            spack.io/node-pool: base

--- a/k8s/production/custom/gitlab-gitaly-bundle-refresher/serviceaccounts.yaml
+++ b/k8s/production/custom/gitlab-gitaly-bundle-refresher/serviceaccounts.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: refresh-gitaly-bundle
+  namespace: gitlab
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: refresh-gitaly-bundle
+  namespace: gitlab
+rules:
+  - apiGroups: ["", "apps"]
+    resources: ["deployments", "pods", "pods/exec"]
+    verbs: ["get", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: refresh-gitaly-bundle
+  namespace: gitlab
+subjects:
+  - kind: ServiceAccount
+    name: refresh-gitaly-bundle
+roleRef:
+  kind: Role
+  name: refresh-gitaly-bundle
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -21,7 +21,7 @@ spec:
   chart:
     spec:
       chart: gitlab
-      version: 8.10.3 # gitlab@17.10.3
+      version: 8.11.0 # gitlab@17.11.0
       sourceRef:
         kind: HelmRepository
         name: gitlab

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-prot

--- a/k8s/production/runners/protected/graviton/4/release.yaml
+++ b/k8s/production/runners/protected/graviton/4/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-graviton4-prot

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       chart: gitlab-runner
       # Note: ensure this stays in sync with the `helper_image` field below
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-prot-windows
@@ -115,7 +115,7 @@ spec:
 
             # Image for windows 2022, runner helper
             image = "mcr.microsoft.com/windows/servercore:ltsc2022"
-            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v17.9.1-servercore21H2"
+            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v17.11.0-servercore21H2"
 
             ephemeral_storage_request = "500M"
             helper_ephemeral_storage_request = "500M"

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-prot

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v3-prot

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v4-prot

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-graviton3-pub

--- a/k8s/production/runners/public/graviton/4/release.yaml
+++ b/k8s/production/runners/public/graviton/4/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-graviton4-pub

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       chart: gitlab-runner
       # Note: ensure this stays in sync with the `helper_image` field below
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-pub-windows

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v2-pub

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v3-pub

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-x86-v4-pub

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab-runner
-      version: 0.75.0 # gitlab-runner@17.10.0
+      version: 0.76.0 # gitlab-runner@17.11.0
       sourceRef:
         kind: HelmRepository
         name: runner-spack-package-signing


### PR DESCRIPTION
This enables the "bundle URI" feature for Gitaly (gitlab's internal remote git server). Bundle URIs are a part of the `git` protocol and allow parts of the git repo to be cached in another place, (S3 in our case). `git clone` is essentially be redirected to S3 when there are cache hits, which lowers the overall load on gitaly itself.

The gitlab docs on this are not great and do not specify how to configure the gitlab helm chart to use it, but I was able to figure it out by looking at the gitaly helm chart internals (https://gitlab.com/gitlab-org/charts/gitlab/-/commit/556a5b1e3a6f6692dbc4c829fae5b4558d0f4ccf). It's deployed on staging and works.

Note: this requires a gitlab upgrade since the commit referenced above was released for the first time in gitlab 17.11.0.

`git` docs - https://git-scm.com/docs/bundle-uri
GitLab docs - https://docs.gitlab.com/administration/gitaly/bundle_uris/

https://gitlab.com/gitlab-org/charts/gitlab/-/commit/556a5b1e3a6f6692dbc4c829fae5b4558d0f4ccf
