### PR TITLE
Fix protected publish for v3 layout buildcaches

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -49,7 +49,7 @@ jobs:
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish
-            image-tags: ghcr.io/spack/protected-publish:0.0.3
+            image-tags: ghcr.io/spack/protected-publish:0.0.4
           - docker-image: ./images/retry-trigger-jobs
             image-tags: ghcr.io/spack/retry-trigger-jobs:0.0.1
     steps:

--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: protected-publish
-            image: ghcr.io/spack/protected-publish:0.0.3
+            image: ghcr.io/spack/protected-publish:0.0.4
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
Updates the v3 version of protected publish to correctly look for manifests, generating the meta and archive urls from those.

I tested this by publishing a single test stack (build_systems) to the root under both v2 and v3 layouts.  We should be able to merge it now, and publishing v2 stacks to the root will continue to work.  Once the content-addressable tarballs PR is merged to spack `develop`, we will need a tiny PR to the cron job arguments to swtich from `--version 2` to `--version 3`.