### PR TITLE
Fix faulty logic in `find_job_artifacts_file`

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -45,7 +45,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.4
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.4.7
+            image-tags: ghcr.io/spack/django:0.4.8
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/artifacts.py
+++ b/analytics/analytics/job_processor/artifacts.py
@@ -75,10 +75,12 @@ def find_job_artifacts_file(job: ProjectJob, filename: str):
         # Search for specific file within artifacts zip
         with zipfile.ZipFile(artifacts_file) as zfile:
             for zipinfo in zfile.filelist:
-                name = zipinfo.filename.split("/")[-1]
-                if name == filename:
-                    with zfile.open(filename) as timing_file:
+                basename = zipinfo.filename.split("/")[-1]
+                if basename == filename:
+                    # Use fully qualified zipinfo filename, so that it's found
+                    with zfile.open(zipinfo.filename) as timing_file:
                         yield timing_file
+                        return
 
             raise JobArtifactFileNotFound(job, filename)
 

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.4.7
+          image: ghcr.io/spack/django:0.4.8
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.4.7
+          image: ghcr.io/spack/django:0.4.8
           command:
             [
               "celery",


### PR DESCRIPTION
Fixes the buggy implementation from #1095. Tested successfully against several jobs in gitlab.