### PR TITLE
Fix migration to create most recent layout

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -49,7 +49,7 @@ jobs:
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish
-            image-tags: ghcr.io/spack/protected-publish:0.0.4
+            image-tags: ghcr.io/spack/protected-publish:0.0.5
           - docker-image: ./images/retry-trigger-jobs
             image-tags: ghcr.io/spack/retry-trigger-jobs:0.0.1
     steps:

--- a/images/protected-publish/TESTING.txt
+++ b/images/protected-publish/TESTING.txt
@@ -43,6 +43,12 @@ aws s3 sync \
     s3://spack-binaries-prs/scott/test-backup/develop/build_systems/build_cache \
     s3://spack-binaries-prs/develop/build_cache
 
+OR for a mirror signed with a test key:
+
+aws s3 sync \
+    s3://spack-binaries-prs/scott/test-backup/develop/my_key/build_systems/build_cache \
+    s3://spack-binaries-prs/develop/build_cache
+
 kubectl apply -f migrate_service_account.yaml
 kubectl apply -f migrate_job.yaml
 

--- a/images/protected-publish/migrate_job.yaml
+++ b/images/protected-publish/migrate_job.yaml
@@ -14,8 +14,7 @@ spec:
       serviceAccountName: migration-notary
       containers:
       - name: migrate
-        image: ghcr.io/spack/protected-publish:0.0.3
-        # image: ghcr.io/scottwittenburg/protected-publish:0.0.4
+        image: ghcr.io/spack/protected-publish:0.0.5
         command: ["/srcs/migrate.sh"]
         args:
           - s3://spack-binaries/develop-2024-12-15/build_systems

--- a/images/protected-publish/pkg/common.py
+++ b/images/protected-publish/pkg/common.py
@@ -1,4 +1,5 @@
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -252,6 +253,21 @@ def s3_upload_file(file_path: str, bucket: str, prefix: str):
 
     with open(file_path, "rb") as fd:
         s3_client.upload_fileobj(fd, bucket, prefix)
+
+
+################################################################################
+#
+def compute_checksum(input_file: str, buf_size: int = 65536) -> str:
+    sha256 = hashlib.sha256()
+
+    with open(input_file, 'rb') as f:
+        while True:
+            data = f.read(buf_size)
+            if not data:
+                break
+            sha256.update(data)
+
+    return sha256.hexdigest()
 
 
 ################################################################################

--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: protected-publish
-            image: ghcr.io/spack/protected-publish:0.0.4
+            image: ghcr.io/spack/protected-publish:0.0.5
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
Update migration logic to latest layout structure:

- For all specs:
  * Download v2 spec, compress it, and compute checksum
  * Push compressed spec as a blob
  * Create and push manifest for buildcache entry (including archive and spec file)
- For all public keys:
  * Download key, compute checksum and size
  * Push uncompressed key as blob
  * Create and push key manifest

Buildcache index and public key index are still handled by `spack buildcache update-index --keys <mirror-url>` after completing the steps above.  The `update-index` is currently using my branch, but can be updated to use mainline spack `develop` after the content-addressable tarballs [PR](https://github.com/spack/spack/pull/48713) is merged.  