### PR TITLE
Refactor management of gitlab access tokens

### DIFF
--- a/terraform/modules/spack_gitlab/delete_stale_branches.tf
+++ b/terraform/modules/spack_gitlab/delete_stale_branches.tf
@@ -1,20 +1,8 @@
-locals {
-  delete_stale_branches_token_expires_at = "2026-04-25"
-}
+module "delete_stale_branches_token" {
+  source = "./modules/spackbot_personal_access_token"
 
-resource "gitlab_personal_access_token" "delete_stale_branches" {
-  user_id    = data.gitlab_user.spackbot.id
-  name       = "delete-stale-branches cronjob personal access token."
-  expires_at = local.delete_stale_branches_token_expires_at
-
+  name   = "delete-stale-branches cronjob personal access token"
   scopes = ["api"]
-
-  lifecycle {
-    precondition {
-      condition     = timecmp(timestamp(), "${local.delete_stale_branches_token_expires_at}T00:00:00Z") == -1
-      error_message = "The token has expired. Please update the expires_at date."
-    }
-  }
 }
 
 resource "kubectl_manifest" "delete_stale_branches" {
@@ -25,6 +13,6 @@ resource "kubectl_manifest" "delete_stale_branches" {
       name: delete-stale-branches-credentials
       namespace: custom
     data:
-      gitlab-token: ${base64encode("${gitlab_personal_access_token.delete_stale_branches.token}")}
+      gitlab-token: ${base64encode("${module.delete_stale_branches_token.token}")}
   YAML
 }

--- a/terraform/modules/spack_gitlab/gitlab.tf
+++ b/terraform/modules/spack_gitlab/gitlab.tf
@@ -7,7 +7,3 @@ data "gitlab_group" "spack" {
 data "gitlab_project" "spack" {
   path_with_namespace = "${data.gitlab_group.spack.name}/spack"
 }
-
-data "gitlab_user" "spackbot" {
-  username = "spackbot"
-}

--- a/terraform/modules/spack_gitlab/modules/spackbot_personal_access_token/main.tf
+++ b/terraform/modules/spack_gitlab/modules/spackbot_personal_access_token/main.tf
@@ -1,0 +1,33 @@
+locals {
+  # GitLab no longer allows tokens to be created with an indefinite expiration date,
+  # so we set a long expiration date and a warning date to remind us to update it.
+  token_expiration_date = "2026-04-25"
+}
+
+locals {
+  # Set the token expiration warning date to one month before the expiration date
+  # so that `terraform apply` will start failing a month before the expiration date.
+  # This should give us plenty of time to notice and update the token before it actually expires.
+
+  # Note: the largest time unit terraform's timeadd function supports is hours.
+  token_expiration_warning_date = timeadd("${local.token_expiration_date}T00:00:00Z", "-730h")
+}
+
+resource "gitlab_personal_access_token" "this" {
+  user_id    = data.gitlab_user.this.id
+  name       = var.name
+  expires_at = local.token_expiration_date
+
+  scopes = var.scopes
+
+  lifecycle {
+    precondition {
+      condition     = timecmp(timestamp(), local.token_expiration_warning_date) == -1
+      error_message = "The ${var.name} GitLab PAT will expire in less than a month. Update the expiration date as soon as possible."
+    }
+  }
+}
+
+data "gitlab_user" "this" {
+  username = "spackbot"
+}

--- a/terraform/modules/spack_gitlab/modules/spackbot_personal_access_token/outputs.tf
+++ b/terraform/modules/spack_gitlab/modules/spackbot_personal_access_token/outputs.tf
@@ -1,0 +1,3 @@
+output "token" {
+  value = gitlab_personal_access_token.this.token
+}

--- a/terraform/modules/spack_gitlab/modules/spackbot_personal_access_token/variables.tf
+++ b/terraform/modules/spack_gitlab/modules/spackbot_personal_access_token/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  description = "The name of the personal access token."
+  type        = string
+}
+
+variable "scopes" {
+  description = "The scopes of the personal access token."
+  type        = list(string)
+}

--- a/terraform/modules/spack_gitlab/modules/spackbot_personal_access_token/versions.tf
+++ b/terraform/modules/spack_gitlab/modules/spackbot_personal_access_token/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    gitlab = {
+      source = "gitlabhq/gitlab"
+    }
+  }
+}

--- a/terraform/modules/spack_gitlab/spack_gantry.tf
+++ b/terraform/modules/spack_gitlab/spack_gantry.tf
@@ -60,23 +60,11 @@ resource "aws_iam_role_policy_attachment" "spack_gantry" {
   policy_arn = aws_iam_policy.spack_gantry.arn
 }
 
-locals {
-  spack_gantry_token_expires_at = "2026-04-25"
-}
+module "spack_gantry_token" {
+  source = "./modules/spackbot_personal_access_token"
 
-resource "gitlab_personal_access_token" "spack_gantry" {
-  user_id    = data.gitlab_user.spackbot.id
-  name       = "spack-gantry personal access token."
-  expires_at = local.spack_gantry_token_expires_at
-
+  name   = "spack-gantry personal access token."
   scopes = ["read_api"]
-
-  lifecycle {
-    precondition {
-      condition     = timecmp(timestamp(), "${local.spack_gantry_token_expires_at}T00:00:00Z") == -1
-      error_message = "The token has expired. Please update the expires_at date."
-    }
-  }
 }
 
 resource "random_password" "spack_gantry_token" {
@@ -139,7 +127,7 @@ resource "kubectl_manifest" "spack_gantry_secrets" {
       name: gantry-credentials
       namespace: spack
     data:
-      gitlab_api_token: ${base64encode("${gitlab_personal_access_token.spack_gantry.token}")}
+      gitlab_api_token: ${base64encode("${module.spack_gantry_token.token}")}
       gitlab_webhook_token: ${base64encode("${random_password.spack_gantry_token.result}")}
   YAML
 }

--- a/terraform/modules/spack_gitlab/spackbot_secrets.tf
+++ b/terraform/modules/spack_gitlab/spackbot_secrets.tf
@@ -1,20 +1,8 @@
-locals {
-  spackbot_token_expires_at = "2026-04-25"
-}
+module "spackbot_token" {
+  source = "./modules/spackbot_personal_access_token"
 
-resource "gitlab_personal_access_token" "spackbot" {
-  user_id    = data.gitlab_user.spackbot.id
-  name       = "spackbot personal access token"
-  expires_at = local.spackbot_token_expires_at
-
+  name   = "spackbot personal access token"
   scopes = ["api"]
-
-  lifecycle {
-    precondition {
-      condition     = timecmp(timestamp(), "${local.spackbot_token_expires_at}T00:00:00Z") == -1
-      error_message = "The token has expired. Please update the expires_at date."
-    }
-  }
 }
 
 resource "kubectl_manifest" "spackbot_gitlab_credentials" {
@@ -25,6 +13,6 @@ resource "kubectl_manifest" "spackbot_gitlab_credentials" {
       name: spack-bot-gitlab-credentials
       namespace: spack
     data:
-      gitlab_token: ${base64encode("${gitlab_personal_access_token.spackbot.token}")}
+      gitlab_token: ${base64encode("${module.spackbot_token.token}")}
   YAML
 }

--- a/terraform/modules/spack_gitlab/webhooks.tf
+++ b/terraform/modules/spack_gitlab/webhooks.tf
@@ -9,23 +9,11 @@ resource "gitlab_project_hook" "job_webhook" {
 // TODO: Once https://gitlab.com/gitlab-org/terraform-provider-gitlab/-/issues/1350 is resolved the
 // gitlab_application_settings resource should be used to whitelist the domains in job_webhooks.
 
-locals {
-  webhook_handler_token_expires_at = "2026-04-25"
-}
+module "webhook_handler_token" {
+  source = "./modules/spackbot_personal_access_token"
 
-resource "gitlab_personal_access_token" "webhook_handler" {
-  user_id    = data.gitlab_user.spackbot.id
-  name       = "Webhook handler token"
-  expires_at = local.webhook_handler_token_expires_at
-
-  scopes = ["read_api", "read_repository"]
-
-  lifecycle {
-    precondition {
-      condition     = timecmp(timestamp(), "${local.webhook_handler_token_expires_at}T00:00:00Z") == -1
-      error_message = "The token has expired. Please update the expires_at date."
-    }
-  }
+  name   = "Webhook handler token"
+  scopes = ["api"]
 }
 
 resource "random_password" "webhook_handler" {
@@ -56,7 +44,7 @@ resource "kubectl_manifest" "webhook_secrets" {
        namespace: custom
      data:
        gitlab-endpoint: ${base64encode("${local.gitlab_url}")}
-       gitlab-token: ${base64encode("${gitlab_personal_access_token.webhook_handler.token}")}
+       gitlab-token: ${base64encode("${module.webhook_handler_token.token}")}
        gitlab-db-user: ${base64encode("${jsondecode(data.aws_secretsmanager_secret_version.gitlab_db_ro_credentials.secret_string)["username"]}")}
        gitlab-db-host: ${base64encode("${jsondecode(data.aws_secretsmanager_secret_version.gitlab_db_ro_credentials.secret_string)["host"]}")}
        gitlab-db-port: ${base64encode("${jsondecode(data.aws_secretsmanager_secret_version.gitlab_db_ro_credentials.secret_string)["port"]}")}


### PR DESCRIPTION
This PR does two things:
1) Refactors gitlab personal access tokens into a reusable Terraform module
2) Increases the time we will get warned about expiring tokens from 1 day before the expiration date to 1 month.

Currently we use the GitLab Terraform provider's [`gitlab_personal_access_token`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/personal_access_token) resource to manage the access tokens we need to create and store in k8s secrets for use by our various cron jobs and other services to interact with the GitLab API. I set up some [Terraform `precondition` rules](https://developer.hashicorp.com/terraform/language/expressions/custom-conditions#preconditions-and-postconditions) to fail TF plans if any token is set to expire in the next day.
 
This approach had two issues - (1) one day isn't enough, because we don't run `terraform {plan|apply}` everyday, and (2) the expiration dates for the various tokens were each defined separately throughout different files and required a dev to change each one when the time for token renewal comes (see #1102 for example)

This PR refactors the token creation into a reusable module so that common attributes like the expiration date are only located in one place. This means that next time we need to renew the tokens, we just need to modify the one timestamp in this module.