### PR TITLE
Post content addressable tarballs

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -49,7 +49,7 @@ jobs:
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish
-            image-tags: ghcr.io/spack/protected-publish:0.0.5
+            image-tags: ghcr.io/spack/protected-publish:0.0.6
           - docker-image: ./images/retry-trigger-jobs
             image-tags: ghcr.io/spack/retry-trigger-jobs:0.0.1
     steps:

--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -43,7 +43,7 @@ jobs:
           - docker-image: ./images/snapshot-release-tags
             image-tags: ghcr.io/spack/snapshot-release-tags:0.0.4
           - docker-image: ./images/cache-indexer
-            image-tags: ghcr.io/spack/cache-indexer:0.0.5
+            image-tags: ghcr.io/spack/cache-indexer:0.0.6
           - docker-image: ./analytics
             image-tags: ghcr.io/spack/django:0.4.8
           - docker-image: ./images/ci-prune-buildcache

--- a/images/cache-indexer/cache_indexer.py
+++ b/images/cache-indexer/cache_indexer.py
@@ -27,13 +27,9 @@ SUBREF_IGNORE_REGEXES = [
     re.compile(r"^e4s-mac$"),
 ]
 
-ROOT_PATTERN = r"build_cache"
-INDEX_PATH = r"index.json"
-
-### To switch to content-addressable: uncomment the lines below, and comment or
-### remove the similar lines above.
-# ROOT_PATTERN = r"v[\d]+"
-# INDEX_PATH = r"manifests/index/index.manifest.json"
+# Regex and path to find modern index manifest
+ROOT_PATTERN = r"v[\d]+"
+INDEX_PATH = r"manifests/index/index.manifest.json"
 
 INDEX_MEDIA_TYPE_PREFIX = "application/vnd.spack.db"
 

--- a/images/protected-publish/migrate_job.yaml
+++ b/images/protected-publish/migrate_job.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: migration-notary
       containers:
       - name: migrate
-        image: ghcr.io/spack/protected-publish:0.0.5
+        image: ghcr.io/spack/protected-publish:0.0.6
         command: ["/srcs/migrate.sh"]
         args:
           - s3://spack-binaries/develop/aws-pcluster-neoverse_v1

--- a/images/protected-publish/pkg/migrate.py
+++ b/images/protected-publish/pkg/migrate.py
@@ -30,9 +30,6 @@ from .common import (
 
 sentry_sdk.init(traces_sample_rate=1.0)
 
-CONTENT_ADDRESSABLE_TARBALLS_REPO = "https://github.com/scottwittenburg/spack.git"
-CONTENT_ADDRESSABLE_TARBALLS_REF = "content-addressable-tarballs-2"
-
 
 class MigrationResult(NamedTuple):
     #: False unless a spec was actually migrated
@@ -381,11 +378,7 @@ def update_mirror_index(mirror_url: str, clone_spack_dir: str):
     """Clone spack and update the index for the new layout"""
     print(f"Rebuilding index at {mirror_url}")
 
-    clone_spack(
-        ref=CONTENT_ADDRESSABLE_TARBALLS_REF,
-        repo=CONTENT_ADDRESSABLE_TARBALLS_REPO,
-        clone_dir=clone_spack_dir,
-    )
+    clone_spack(clone_dir=clone_spack_dir)
 
     try:
         subprocess.run(

--- a/k8s/production/custom/cache-indexer/cron-jobs.yaml
+++ b/k8s/production/custom/cache-indexer/cron-jobs.yaml
@@ -14,7 +14,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: index-binary-caches
-            image: ghcr.io/spack/cache-indexer:0.0.5
+            image: ghcr.io/spack/cache-indexer:0.0.6
             imagePullPolicy: IfNotPresent
             env:
               - name: BUCKET_NAME

--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: protected-publish
-            image: ghcr.io/spack/protected-publish:0.0.5
+            image: ghcr.io/spack/protected-publish:0.0.6
             imagePullPolicy: IfNotPresent
             resources:
               requests:

--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -35,7 +35,7 @@ spec:
               - "--parallel"
               - "16"
               - "--version"
-              - "2"
+              - "3"
             volumeMounts:
               - name: ephemeral
                 mountPath: "/tmp"


### PR DESCRIPTION
This PR updates the way some things work to how they'll be after spack switches to content-addressable tarballs:

- Update the version of spack used by the migration logic to use the `develop` branch of spack from the mainline repo, in case any further migration is needed after merging the spack PR
- Update the cache-indexer so it looks in the correct location for buildcache indices
- Change the layout version to 3 on the cli of the publish cron job

This is a draft, as it should not be merged until the content-addressable tarballs [PR](https://github.com/spack/spack/pull/48713) has been merged into spack `develop`.