### PR TITLE
Update media types used in protected publish

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -49,7 +49,7 @@ jobs:
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish
-            image-tags: ghcr.io/spack/protected-publish:0.0.6
+            image-tags: ghcr.io/spack/protected-publish:0.0.7
           - docker-image: ./images/retry-trigger-jobs
             image-tags: ghcr.io/spack/retry-trigger-jobs:0.0.1
     steps:

--- a/images/protected-publish/migrate_job.yaml
+++ b/images/protected-publish/migrate_job.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: migration-notary
       containers:
       - name: migrate
-        image: ghcr.io/spack/protected-publish:0.0.6
+        image: ghcr.io/spack/protected-publish:0.0.7
         command: ["/srcs/migrate.sh"]
         args:
           - s3://spack-binaries/develop/aws-pcluster-neoverse_v1

--- a/images/protected-publish/pkg/publish.py
+++ b/images/protected-publish/pkg/publish.py
@@ -46,8 +46,8 @@ PROTECTED_REF_REGEXES = [
 
 SPACK_PUBLIC_KEY_LOCATION = "https://spack.github.io/keys"
 SPACK_PUBLIC_KEY_NAME = "spack-public-binary-key.pub"
-TARBALL_MEDIA_TYPE = "application/vnd.spack.install.v1.tar+gzip"
-SPEC_METADATA_MEDIA_TYPE = "application/vnd.spack.buildcache_spec.v3+json"
+TARBALL_MEDIA_TYPE = "application/vnd.spack.install.v2.tar+gzip"
+SPEC_METADATA_MEDIA_TYPE = "application/vnd.spack.spec.v5+json"
 
 
 ################################################################################

--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: protected-publish
-            image: ghcr.io/spack/protected-publish:0.0.6
+            image: ghcr.io/spack/protected-publish:0.0.7
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
I must have failed to update these media types after the most recent change request to the spack content-addressable tarballs PR, as when I was testing #1099, my branch of spack was still using `buildcache_spec.v3` and `install.v1`.

This updates those media types to match value used by spack (and the migrate job).