### PR TITLE
protected-publish: Do not buffer python output

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -49,7 +49,7 @@ jobs:
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish
-            image-tags: ghcr.io/spack/protected-publish:0.0.7
+            image-tags: ghcr.io/spack/protected-publish:0.0.8
           - docker-image: ./images/retry-trigger-jobs
             image-tags: ghcr.io/spack/retry-trigger-jobs:0.0.1
     steps:

--- a/images/protected-publish/Dockerfile
+++ b/images/protected-publish/Dockerfile
@@ -14,5 +14,6 @@ RUN pip install --upgrade pip && \
 COPY pkg /srcs/pkg
 COPY --chmod=755 migrate.sh /srcs/migrate.sh
 
+ENV PYTHONUNBUFFERED=1
 WORKDIR /srcs
 ENTRYPOINT ["python", "-m", "pkg.publish"]

--- a/images/protected-publish/migrate_job.yaml
+++ b/images/protected-publish/migrate_job.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: migration-notary
       containers:
       - name: migrate
-        image: ghcr.io/spack/protected-publish:0.0.7
+        image: ghcr.io/spack/protected-publish:0.0.8
         command: ["/srcs/migrate.sh"]
         args:
           - s3://spack-binaries/develop/aws-pcluster-neoverse_v1

--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: protected-publish
-            image: ghcr.io/spack/protected-publish:0.0.7
+            image: ghcr.io/spack/protected-publish:0.0.8
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
We stopped getting output from the protected-publish cron job when moving from `0.0.6` to `0.0.7`. This PR is an attempt to get it back.