### PR TITLE
protected-publish: Speed up publishing specs to the root

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -49,7 +49,7 @@ jobs:
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish
-            image-tags: ghcr.io/spack/protected-publish:0.0.8
+            image-tags: ghcr.io/spack/protected-publish:0.0.9
           - docker-image: ./images/retry-trigger-jobs
             image-tags: ghcr.io/spack/retry-trigger-jobs:0.0.1
     steps:

--- a/images/protected-publish/migrate_job.yaml
+++ b/images/protected-publish/migrate_job.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: migration-notary
       containers:
       - name: migrate
-        image: ghcr.io/spack/protected-publish:0.0.8
+        image: ghcr.io/spack/protected-publish:0.0.9
         command: ["/srcs/migrate.sh"]
         args:
           - s3://spack-binaries/develop/aws-pcluster-neoverse_v1

--- a/k8s/production/custom/protected-publish/cron-jobs.yaml
+++ b/k8s/production/custom/protected-publish/cron-jobs.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: protected-publish
-            image: ghcr.io/spack/protected-publish:0.0.8
+            image: ghcr.io/spack/protected-publish:0.0.9
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
This PR does two things to speed up protected publish:

1. Use `aws s3 sync ...` to download the manifests, instead of the current approach of `s3_client.download_fileobj()` for each one using multithreading
2. When copying the manifest, metadata, and archive for a spec, create only one s3 session rather than three

