### PR TITLE
Add gh-gl-sync cron for spack-packages

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include:
           - docker-image: ./images/gh-gl-sync
-            image-tags: ghcr.io/spack/ci-bridge:0.0.44
+            image-tags: ghcr.io/spack/ci-bridge:0.0.45
           - docker-image: ./images/ci-key-clear
             image-tags: ghcr.io/spack/ci-key-clear:0.0.2
           - docker-image: ./images/gitlab-stuckpods

--- a/k8s/production/custom/gh-gl-sync-packages/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync-packages/cron-jobs.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: gh-gl-sync-packages
+  namespace: custom
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 1200 # terminate any running job after 20 minutes
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: sync
+            image: ghcr.io/spack/ci-bridge:0.0.44
+            imagePullPolicy: IfNotPresent
+            resources:
+              requests:
+                cpu: 500m
+                memory: 500M
+            env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: gh-gl-sync
+                  key: github-access-token
+            # This secret is double base64 encoded
+            - name: GITLAB_SSH_KEY_BASE64
+              valueFrom:
+                secretKeyRef:
+                  name: gh-gl-sync
+                  key: gitlab-ssh-key
+            envFrom:
+              - configMapRef:
+                  name: gh-gl-sync-sentry-config
+            args:
+              - "spack/spack"
+              - "ssh://git@ssh.gitlab.spack.io/spack/spack-packages"
+              - "https://gitlab.spack.io"
+              - "spack/spack-packages"
+              - "--pr-mirror-bucket"
+              - "spack-binaries-prs"
+              - "--main-branch"
+              - "develop"
+              # - "--prereq-check"
+              # - "all-prechecks"
+          nodeSelector:
+            spack.io/node-pool: base

--- a/k8s/production/custom/gh-gl-sync-packages/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync-packages/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.44
+            image: ghcr.io/spack/ci-bridge:0.0.45
             imagePullPolicy: IfNotPresent
             resources:
               requests:
@@ -38,14 +38,16 @@ spec:
               - configMapRef:
                   name: gh-gl-sync-sentry-config
             args:
-              - "spack/spack"
+              - "spack/spack-packages"
               - "ssh://git@ssh.gitlab.spack.io/spack/spack-packages"
               - "https://gitlab.spack.io"
               - "spack/spack-packages"
               - "--pr-mirror-bucket"
               - "spack-binaries-prs"
-              - "--main-branch"
-              - "develop"
+              # - "--main-branch"
+              # - "develop"
+              - "--disable-protected-sync"
+              - "--disable-tag-sync"
               # - "--prereq-check"
               # - "all-prechecks"
           nodeSelector:

--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.44
+            image: ghcr.io/spack/ci-bridge:0.0.45
             imagePullPolicy: IfNotPresent
             resources:
               requests:

--- a/k8s/production/custom/kokkos-sync/cron-jobs.yaml
+++ b/k8s/production/custom/kokkos-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.44
+            image: ghcr.io/spack/ci-bridge:0.0.45
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
Create a new sync script cron for the packages repo. Reuse the robot secrets from the existing `gh-gl-sync` cron.