### PR TITLE
Enable `FF_WAIT_FOR_POD_TO_BE_REACHABLE` on all k8s runners

### DIFF
--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -77,7 +77,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm-latest"
             privileged = false

--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -77,13 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm-latest"
             privileged = false

--- a/k8s/production/runners/protected/graviton/4/release.yaml
+++ b/k8s/production/runners/protected/graviton/4/release.yaml
@@ -77,13 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm64-latest"
             privileged = false

--- a/k8s/production/runners/protected/graviton/4/release.yaml
+++ b/k8s/production/runners/protected/graviton/4/release.yaml
@@ -77,7 +77,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm64-latest"
             privileged = false

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -90,9 +90,12 @@ spec:
           executor = "kubernetes"
           output_limit = 20480
 
-          # Ensure windows paths are used
           [runners.feature_flags]
+            # Ensure windows paths are used
             FF_USE_POWERSHELL_PATH_RESOLVER = true
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
 
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -77,13 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -77,7 +77,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -77,13 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -77,7 +77,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -77,13 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -77,7 +77,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -77,7 +77,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm-latest"
             privileged = false

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -77,13 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm-latest"
             privileged = false

--- a/k8s/production/runners/public/graviton/4/release.yaml
+++ b/k8s/production/runners/public/graviton/4/release.yaml
@@ -77,13 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm64-latest"
             privileged = false

--- a/k8s/production/runners/public/graviton/4/release.yaml
+++ b/k8s/production/runners/public/graviton/4/release.yaml
@@ -77,7 +77,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm64-latest"
             privileged = false

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -91,9 +91,12 @@ spec:
           executor = "kubernetes"
           output_limit = 20480
 
-          # Ensure windows paths are used
           [runners.feature_flags]
+            # Ensure windows paths are used
             FF_USE_POWERSHELL_PATH_RESOLVER = true
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
 
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -79,7 +79,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -79,13 +79,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -77,13 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -77,7 +77,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -77,13 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -77,7 +77,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -78,7 +78,13 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+          environment = [
+            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
+
+            # Avoid TLS errors when scheduling jobs on a new node
+            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
+            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
+          ]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -78,13 +78,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = [
-            "FF_GITLAB_REGISTRY_HELPER_IMAGE=1",
-
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
             # Avoid TLS errors when scheduling jobs on a new node
             # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            "FF_WAIT_FOR_POD_TO_BE_REACHABLE=1",
-          ]
+            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"


### PR DESCRIPTION
This will enable the `FF_WAIT_FOR_POD_TO_BE_REACHABLE` feature flag on all of our AWS/k8s-based GitLab runners. This feature flag makes it so a runner executor pod is only "Ready" in k8s (and thus can accept new jobs) when the underlying node has its TLS certificates all ready.

This helps avoid an issue where a runner executor pod gets scheduled on a brand new node that has no certs yet, resulting in new jobs failing with errors like these that @tgamblin saw over the weekend -
- https://gitlab.spack.io/spack/spack/-/jobs/16676859
- https://gitlab.spack.io/spack/spack/-/jobs/16676867
- https://gitlab.spack.io/spack/spack/-/jobs/16676872


See https://docs.gitlab.com/runner/configuration/feature-flags/ (ctrl-F for `FF_WAIT_FOR_POD_TO_BE_REACHABLE`)

As part of this PR, I've also moved the runner feature flags into the `runners.feature_flags` section of the TOML config. The GitLab docs mention this as an option that will prevent downstream jobs from overriding these env vars themselves; for example, with the old way, a `spack/spack` PR could set `FF_WAIT_FOR_POD_TO_BE_REACHABLE=false` in its environment and disable that feature flag.