### PR TITLE
Revert "Enable `FF_WAIT_FOR_POD_TO_BE_REACHABLE` on all k8s runners"

### DIFF
--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -77,11 +77,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm-latest"
             privileged = false

--- a/k8s/production/runners/protected/graviton/4/release.yaml
+++ b/k8s/production/runners/protected/graviton/4/release.yaml
@@ -77,11 +77,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm64-latest"
             privileged = false

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -90,12 +90,9 @@ spec:
           executor = "kubernetes"
           output_limit = 20480
 
+          # Ensure windows paths are used
           [runners.feature_flags]
-            # Ensure windows paths are used
             FF_USE_POWERSHELL_PATH_RESOLVER = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
 
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -77,11 +77,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -77,11 +77,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -77,11 +77,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -77,11 +77,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm-latest"
             privileged = false

--- a/k8s/production/runners/public/graviton/4/release.yaml
+++ b/k8s/production/runners/public/graviton/4/release.yaml
@@ -77,11 +77,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm64-latest"
             privileged = false

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -91,12 +91,9 @@ spec:
           executor = "kubernetes"
           output_limit = 20480
 
+          # Ensure windows paths are used
           [runners.feature_flags]
-            # Ensure windows paths are used
             FF_USE_POWERSHELL_PATH_RESOLVER = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
 
           [runners.kubernetes]
             privileged = false

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -79,11 +79,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -77,11 +77,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -77,11 +77,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -78,11 +78,7 @@ spec:
           """
 
           output_limit = 20480
-          [runners.feature_flags]
-            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
-            # Avoid TLS errors when scheduling jobs on a new node
-            # https://gitlab.com/gitlab-org/gitlab-runner/-/issues/37244
-            FF_WAIT_FOR_POD_TO_BE_REACHABLE = true
+          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"


### PR DESCRIPTION
Reverts spack/spack-infrastructure#1122

We've seen a large increase in runner system failures after enabling this feature flag. Reverting until we figure out more details.