### PR TITLE
Enable `--serialize-image-pulls` for Karpenter linux nodes

### DIFF
--- a/terraform/modules/spack_aws_k8s/karpenter.tf
+++ b/terraform/modules/spack_aws_k8s/karpenter.tf
@@ -68,6 +68,18 @@ resource "kubectl_manifest" "karpenter_node_class" {
       name: default
     spec:
       amiFamily: AL2023
+      userData: |
+        apiVersion: node.eks.aws/v1alpha1
+        kind: NodeConfig
+        spec:
+          kubelet:
+            config:
+              # The Amazon Linux 2023 AMI overrides the default kubelet config to disable
+              # serializeImagePulls in order to improve performance.
+              # This is not ideal for our use case, where we frequently create many pods at once
+              # when start a CI pipeline, because it can cause us to hit the container registry's
+              # max QPS, so we override it here.
+              serializeImagePulls: true
       role: ${module.karpenter.node_iam_role_name}
       subnetSelectorTerms:
         - tags:

--- a/terraform/modules/spack_aws_k8s/karpenter.tf
+++ b/terraform/modules/spack_aws_k8s/karpenter.tf
@@ -67,7 +67,7 @@ resource "kubectl_manifest" "karpenter_node_class" {
     metadata:
       name: default
     spec:
-      amiFamily: AL2
+      amiFamily: AL2023
       role: ${module.karpenter.node_iam_role_name}
       subnetSelectorTerms:
         - tags:


### PR DESCRIPTION
A common system error in Spack CI is this `image pull failed: pull QPS exceeded`.

![Screenshot 2025-05-25 at 11 34 10 PM (2)](https://github.com/user-attachments/assets/80cf17ea-5d54-48ec-ae50-1a327d942343)

GitHub container registry claims to have no rate limits for pulling images, but it seems they do have an unpublished queries-per-second (QPS) of 1. I was able to replicate the issue with [artificially generated pipelines in staging](https://gitlab.staging.spack.io/mvandenburgh/testci/-/pipelines/1687) and played around with lowering `--registry-qps`[^docs]  (a kubelet argument that lets kubernetes know how many images it can pull in parallel; Amazon Linux EKS-optimized AMI defaults to `5`), and still encountered that QPS limit error even going down to just `2`.

We can disable parallel image pulling by setting the `--serialize-image-pulls`[^docs] kubelet argument to true.
(actually, kubelet's default behavior is to set --serialize-image-pulls  to true , but the EKS-optimized amazon linux APIs explicitly set it to false . I guess AWS disables it so that image pulls happen faster by default)

**Note that this involves upgrading our base AMI for all karpenter nodes to Amazon Linux 2023.** Configuring this CLI argument in AL2 is cumbersome and must be done in the EC2 userdata by manually editing the config file with `sed` for example.

[^docs]: All of these CLI args are documented [here](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)
