### PR TITLE
Fix lingering job_type field in gitlab job data dimension

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -45,7 +45,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.6
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.5.0
+            image-tags: ghcr.io/spack/django:0.5.1
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/__init__.py
+++ b/analytics/analytics/job_processor/__init__.py
@@ -56,7 +56,7 @@ def create_job_fact(
     job_info = retrieve_job_info(gljob=gljob, is_build=is_build)
 
     start_date, start_time = create_date_time_dimensions(gljob=gljob)
-    spack_job = create_spack_job_data_dimension(data=job_info.misc)
+    spack_job = create_spack_job_data_dimension(data=job_info.misc, job_input_data=job_input_data)
     gitlab_job_data = create_gitlab_job_data_dimension(
         gljob=gljob, job_input_data=job_input_data, job_trace=job_trace
     )
@@ -162,7 +162,7 @@ def process_job(job_input_data_json: str):
     # Create build timing facts in a separate transaction, in case this fails
     with transaction.atomic():
         if (
-            job.gitlab_job_data.job_type == JobType.BUILD
+            job.job_result.job_type == JobType.BUILD
             and job.job_result.status == "success"
         ):
             create_build_timing_facts(job_fact=job, gljob=gl_job)

--- a/analytics/analytics/job_processor/dimensions.py
+++ b/analytics/analytics/job_processor/dimensions.py
@@ -112,12 +112,14 @@ def determine_job_type(job_input_data: dict):
     raise UnrecognizedJobType(job_input_data["build_id"], name)
 
 
-def create_spack_job_data_dimension(data: JobMiscInfo | None):
+def create_spack_job_data_dimension(data: JobMiscInfo | None, job_input_data: dict):
     if data is None:
         return SpackJobDataDimension.get_empty_row()
 
     res, _ = SpackJobDataDimension.objects.get_or_create(
-        job_size=data.job_size, stack=data.stack
+        job_size=data.job_size,
+        stack=data.stack,
+        job_type=determine_job_type(job_input_data),
     )
     return res
 
@@ -133,7 +135,6 @@ def create_gitlab_job_data_dimension(
         ref=gljob.ref,
         tags=gljob.tag_list,
         commit_id=job_input_data["commit"]["id"],
-        job_type=determine_job_type(job_input_data),
     )
 
     return res

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.5.0
+          image: ghcr.io/spack/django:0.5.1
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.5.0
+          image: ghcr.io/spack/django:0.5.1
           command:
             [
               "celery",


### PR DESCRIPTION
Follow on to #1050 

I moved the `job_type` field from the `gitlab_job_data_dimension` table to the `spack_job_data_dimension` table, but missed a couple of spots where `job_type` was still being used with `gitlab_job_data_dimension` table.