### PR TITLE
Switch staging cdash to Helm chart

### DIFF
--- a/k8s/staging/cdash/kustomization.yaml
+++ b/k8s/staging/cdash/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../production/cdash/certificates.yaml
+  - ../../production/cdash/ingress.yaml
+  - ../../production/cdash/namespace.yaml
+
+patches:
+  - target:
+      kind: Certificate
+      name: tls-cdash
+      namespace: cdash
+    patch: |-
+      - op: replace
+        path: /spec/commonName
+        value: cdash.staging.spack.io
+      - op: replace
+        path: /spec/dnsNames/0
+        value: cdash.staging.spack.io
+
+  - target:
+      kind: Ingress
+      name: cdash
+      namespace: cdash
+    patch: |-
+      - op: replace
+        path: /spec/rules/0/host
+        value: cdash.staging.spack.io

--- a/k8s/staging/cdash/release.yaml
+++ b/k8s/staging/cdash/release.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kitware
+  namespace: cdash
+spec:
+  interval: 10m
+  url: https://kitware.github.io/helm
+
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cdash
+  namespace: cdash
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: cdash
+      version: 0.2.1
+      sourceRef:
+        kind: HelmRepository
+        name: kitware
+  values:
+    nodeSelector:
+      spack.io/node-pool: base
+
+    cdash:
+      host: cdash.staging.spack.io
+      serviceAccountName: cdash
+      website:
+        resources:
+          requests:
+            memory: 50Mi
+      worker:
+        replicas: 1
+        resources:
+          requests:
+            memory: 50Mi
+
+    postgresql:
+      enabled: false
+
+    minio:
+      enabled: false

--- a/terraform/modules/spack_aws_k8s/cdash_db.tf
+++ b/terraform/modules/spack_aws_k8s/cdash_db.tf
@@ -1,3 +1,9 @@
+locals {
+  cdash_db_name = "cdash"
+  cdash_db_user = "cdash"
+  cdash_db_port = "5432"
+}
+
 resource "aws_db_subnet_group" "cdash_db" {
   name       = "spack-cdash${local.suffix}"
   subnet_ids = module.vpc.private_subnets
@@ -12,17 +18,17 @@ module "cdash_db" {
   source  = "terraform-aws-modules/rds/aws"
   version = "6.10.0"
 
-  identifier = "spack-cdash${local.suffix}"
+  identifier = "spack-cdash-postgres${local.suffix}"
 
-  engine               = "mysql"
-  engine_version       = "8.0.35"
-  family               = "mysql8.0"
-  major_engine_version = "8.0"
+  engine               = "postgres"
+  family               = "postgres17"
+  major_engine_version = "17"
   instance_class       = var.cdash_db_instance_class
 
-  username                    = "admin"
-  port                        = "3306"
-  password                    = random_password.cdash_db_password.result
+  db_name                     = local.cdash_db_name
+  username                    = local.cdash_db_user
+  password                    = random_password.gitlab_db_password.result
+  port                        = local.cdash_db_port
   manage_master_user_password = false
 
   publicly_accessible  = false
@@ -37,29 +43,142 @@ module "cdash_db" {
   skip_final_snapshot     = true
   deletion_protection     = true
 
-  allocated_storage  = 300
+  allocated_storage  = 400
   storage_type       = "gp3"
   iops               = 12000 # 3,000 is the minimum IOPs for <400 GB storage. We can increase this as needed.
-  storage_throughput = 125   # 125 is the minimum throughput for <400 GB storage. We can increase this as needed.
+  storage_throughput = 500   # 500 is the minimum throughput for >=400 GB storage. We can increase this as needed.
 
-  vpc_security_group_ids = [module.mysql_security_group.security_group_id]
+  vpc_security_group_ids = [module.postgres_security_group.security_group_id]
 }
 
-module "mysql_security_group" {
-  source  = "terraform-aws-modules/security-group/aws"
-  version = "5.2.0"
+resource "aws_s3_bucket" "cdash" {
+  bucket = "spack-cdash${local.suffix}"
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
-  name        = "mysql_sg"
-  description = "Security group for RDS MySQL database"
-  vpc_id      = module.vpc.vpc_id
+# Bucket policy that prevents deletion of CDash bucket.
+resource "aws_s3_bucket_policy" "cdash" {
+  bucket = aws_s3_bucket.cdash.id
 
-  ingress_with_cidr_blocks = [
-    {
-      from_port   = 3306
-      to_port     = 3306
-      protocol    = "tcp"
-      description = "MySQL access from within VPC"
-      cidr_blocks = module.vpc.vpc_cidr_block
-    },
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Principal" : "*"
+        "Effect" : "Deny",
+        "Action" : [
+          "s3:DeleteBucket",
+        ],
+        "Resource" : aws_s3_bucket.cdash.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "cdash" {
+  name        = "CDashS3Role-${var.deployment_name}-${var.deployment_stage}"
+  description = "Managed by Terraform. Role for CDash to assume so that it can access relevant S3 buckets."
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : module.eks.oidc_provider_arn,
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "${module.eks.oidc_provider}:aud" : "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "cdash" {
+  name        = "CDashS3Role-${var.deployment_name}-${var.deployment_stage}"
+  description = "Managed by Terraform. Grants required permissions for CDash to read/write to relevant S3 buckets."
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:GetBucketLocation",
+          "s3:ListBucket"
+        ],
+        "Resource" : aws_s3_bucket.cdash.arn
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:DeleteObject",
+          "s3:DeleteObjectVersion",
+          "s3:GetObject",
+          "s3:GetObjectAcl",
+          "s3:GetObjectVersion",
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:ReplicateObject"
+        ],
+        "Resource" : [
+          aws_s3_bucket.cdash.arn,
+          "${aws_s3_bucket.cdash.arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cdash" {
+  role       = aws_iam_role.cdash.name
+  policy_arn = aws_iam_policy.cdash.arn
+}
+
+resource "kubectl_manifest" "cdash_service_account" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: cdash
+      namespace: cdash
+      annotations:
+        eks.amazonaws.com/role-arn: ${aws_iam_role.cdash.arn}
+  YAML
+  depends_on = [
+    aws_iam_role_policy_attachment.cdash,
   ]
+}
+
+resource "kubectl_manifest" "cdash_s3_secret" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cdash-s3
+      namespace: cdash
+    stringData:
+      region: "${data.aws_region.current.name}"
+      bucket: "${aws_s3_bucket.cdash.id}"
+  YAML
+}
+
+resource "kubectl_manifest" "cdash_db_secret" {
+  yaml_body = <<-YAML
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cdash-db
+      namespace: cdash
+    stringData:
+      host: "${module.cdash_db.db_instance_address}"
+      database: "${local.cdash_db_name}"
+      username: "${local.cdash_db_user}"
+      password: "${random_password.cdash_db_password.result}"
+      port: "${local.cdash_db_port}"
+  YAML
 }

--- a/terraform/modules/spack_aws_k8s/cdash_db_old.tf
+++ b/terraform/modules/spack_aws_k8s/cdash_db_old.tf
@@ -1,0 +1,55 @@
+module "cdash_db_old" {
+  source  = "terraform-aws-modules/rds/aws"
+  version = "6.10.0"
+
+  identifier = "spack-cdash${local.suffix}"
+
+  engine               = "mysql"
+  engine_version       = "8.0.35"
+  family               = "mysql8.0"
+  major_engine_version = "8.0"
+  instance_class       = var.cdash_db_instance_class
+
+  username                    = "admin"
+  port                        = "3306"
+  password                    = random_password.cdash_db_password.result
+  manage_master_user_password = false
+
+  publicly_accessible  = false
+  db_subnet_group_name = aws_db_subnet_group.cdash_db.name
+
+  maintenance_window           = "Sun:00:00-Sun:03:00"
+  backup_window                = "03:00-06:00"
+  create_cloudwatch_log_group  = true
+  performance_insights_enabled = var.deployment_name == "prod"
+
+  backup_retention_period = 7
+  skip_final_snapshot     = true
+  deletion_protection     = true
+
+  allocated_storage  = 300
+  storage_type       = "gp3"
+  iops               = 12000 # 3,000 is the minimum IOPs for <400 GB storage. We can increase this as needed.
+  storage_throughput = 125   # 125 is the minimum throughput for <400 GB storage. We can increase this as needed.
+
+  vpc_security_group_ids = [module.mysql_security_group.security_group_id]
+}
+
+module "mysql_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.2.0"
+
+  name        = "mysql_sg"
+  description = "Security group for RDS MySQL database"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 3306
+      to_port     = 3306
+      protocol    = "tcp"
+      description = "MySQL access from within VPC"
+      cidr_blocks = module.vpc.vpc_cidr_block
+    },
+  ]
+}


### PR DESCRIPTION
This PR pulls most of the changes out of #1097, but refactors it so that the current production cdash deployment (cdash.spack.io) is not modified. 

Note that this will still result in a new Postgres RDS instance being created in the production AWS region, but it will not be connected to by cdash yet and the existing MySQL instance will not be touched.