### PR TITLE
Add missing python import

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -45,7 +45,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.6
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.5.2
+            image-tags: ghcr.io/spack/django:0.5.3
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/analytics/analytics/job_processor/utils.py
+++ b/analytics/analytics/job_processor/utils.py
@@ -9,6 +9,7 @@ from django.db import connections
 import gitlab
 from gitlab.v4.objects import Project
 import requests
+import sentry_sdk
 
 T = typing.TypeVar("T")
 P = typing.ParamSpec("P")

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.5.2
+          image: ghcr.io/spack/django:0.5.3
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.5.2
+          image: ghcr.io/spack/django:0.5.3
           command:
             [
               "celery",


### PR DESCRIPTION
`sentry_sdk` is used in this module but is not imported. 

We should probably start using `flake8` at least to catch things like this. Or ideally, just replace the entire linting toolchain with `ruff`.