### PR TITLE
Upgrade GitLab to 18.0.3

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -21,7 +21,7 @@ spec:
   chart:
     spec:
       chart: gitlab
-      version: 9.0.2 # gitlab@18.0.2
+      version: 9.0.3 # gitlab@18.0.3
       sourceRef:
         kind: HelmRepository
         name: gitlab


### PR DESCRIPTION
This addresses `CVE-2025-1754`. See https://about.gitlab.com/releases/2025/06/25/patch-release-gitlab-18-1-1-released/ for more info