### PR TITLE
Make protected and signing runners spack group runners

### DIFF
--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -171,7 +171,7 @@ spec:
       runUntagged: false
 
       tags: "arm,aarch64,graviton,graviton3,neoverse_v1,small,medium,large,huge,protected,aws,spack"
-      secret: spack-project-runner-registration-token
+      secret: spack-group-runner-secret
 
       serviceAccountName: runner
 

--- a/k8s/production/runners/protected/graviton/4/release.yaml
+++ b/k8s/production/runners/protected/graviton/4/release.yaml
@@ -171,7 +171,7 @@ spec:
       runUntagged: false
 
       tags: "arm,aarch64,graviton4,neoverse_v2,small,medium,large,huge,protected,aws,spack"
-      secret: spack-project-runner-registration-token
+      secret: spack-group-runner-secret
 
       serviceAccountName: runner
 

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -179,7 +179,7 @@ spec:
       runUntagged: false
 
       tags: "spack,protected,small,medium,win64,x86_64-win,x86_64_v2-win,aws"
-      secret: spack-project-runner-registration-token
+      secret: spack-group-runner-secret
 
       serviceAccountName: runner
 

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -190,7 +190,7 @@ spec:
       runUntagged: false
 
       tags: "x86_64,x86_64_v2,small,medium,large,huge,protected,aws,spack"
-      secret: spack-project-runner-registration-token
+      secret: spack-group-runner-secret
 
       serviceAccountName: runner
 

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -184,7 +184,7 @@ spec:
       runUntagged: false
 
       tags: "x86_64,x86_64_v2,x86_64_v3,avx,avx2,small,medium,large,huge,protected,aws,spack"
-      secret: spack-project-runner-registration-token
+      secret: spack-group-runner-secret
 
       serviceAccountName: runner
 

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -170,7 +170,7 @@ spec:
       runUntagged: false
 
       tags: "x86_64,x86_64_v2,x86_64_v3,x86_64_v4,avx,avx2,avx512,small,medium,large,huge,protected,aws,spack"
-      secret: spack-project-runner-registration-token
+      secret: spack-group-runner-secret
 
       serviceAccountName: runner
 

--- a/k8s/production/runners/sealed-secrets.yaml
+++ b/k8s/production/runners/sealed-secrets.yaml
@@ -1,18 +1,3 @@
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
-  name: spack-project-runner-registration-token
-  namespace: gitlab
-spec:
-  encryptedData:
-    # Token from: https://gitlab.spack.io/spack/spack/
-    runner-registration-token: AgDO3NK7LDt93F3azLzVTDvaBErV1h0zmf1z22Hk19rS3BpKFkvuzxcAs+nzN8jnYrFtM4Efko6agEk+NzqcjznvKXjs6kBevgvTQ5nRrtO1HySzxwDsm2ctJTndnvVu8K7cTT7RHhCs3t13CgQZlLvA05nZ3gzXxYAken6mQHE6otVpblHUnwfQisL+fUk53eicxz8e6txir7bJ9RzM+ADnwnTNG2T5khrdI3YS8OqohoW3TkNVYH3Pur0emjzLP/A0j5PM5/hES3tkiYHmNqio3On9ZcnJQIk6aeHlpf0AbBv6RQ/CuGcyZGol7jFzMdtX4Ge+Bqi8tPGdzd79ZqsHsZFC5a0Q5em99e1Aa1nZvm3cjwXsxjoWTW8oBwLM/+q6Sa3s7hBO/xXzqzYK3IAu1t5G61KertqmklP5AvvTwVztiqzZ4BLw0Kfo5+Rkr+hOCS+C+erahrAID1ZHmnayCPEtHP0WjKf3OonXNhr9pWVivHfvqaSoRGVtAPTthBvFyFBlbjpz0EOMUYQgPohYDuzPT0MgUlV3U7SSfBFyZltgiUHVR+mRF4JAlpWfuekYXAbKCEvgYK1wz21NXiJz26npen/memEhtBsbqdcV6X/3893AnU+XbmkuK0WtGD2GYc/HQbGmHC/0DC9/8zXF0N+a82/dTLvbD/wnPmNkPioms3JxhEm6TMzEFt2z57F0modprLUqG7Qhoh0SCQ0ORG7VlQ==
-    runner-token: AgAgN9rsjTHzjhykn5x7NNDiDwRm9f7d2W1IXy9kCmUObfsuc+Un6PY78P58vyH8h2dzXUSzR70FQLNELXU+0bDDKfK+NC8ZUAS9WDuGkGYJHmMsE3gPfFeWH/Wh4kEonfqrOSD+70/KREDLaxdIcuiXS80oCk08nrcvV5CqfqPARRwmToJQj/hlIiAj/pi72ZLvdvNY00rcJflZ7uBF8qw91LH2ISQ/8VtZr5YBNaCJ3p8aMC8h/uLQOy1cyUiM98rNgEyy7UZEwtNDSOA9UQzyZdUrhqMQFRwo/DTMtUj9jgmo+R+IL95NxhVoNlJQL45IRNZOFR4f7bCvJVFbBYBI0PCK/nCZsPFQOlQo3ZCOYyfot0/DM/vm2HVYIHZNrACNfBRRA5MrkgBkN98IAdRDUJ/7Ti3WCvuJqd13VLZRWklFpOu8iHg3O3YOF0qfzQmgg8ABrA5WJxS/w/gNq5T5rRalLe1z09IurTpD1yvRx8B8g3L7mbaH/r5m/xDKLxw2za4VWDbied5smQxNBiOE9TS8BDQEC3ioSCa1oaKvziX2HSR4ejvJHJZk/tgArvwN+MqaiN0CmFggDF1uEMs/Y6sBakXAbTUf1umYgNhUjmifhI8KYRk25OLEk44Lnt9L8HNQPAm5R46tUyInkXaQyER1Y0h4zukXp1VeMlloPIhIFLHthNV30D4q8yf4hQA=
-  template:
-    metadata:
-      annotations:
-        kustomize.toolkit.fluxcd.io/reconcile: disabled
-        sealedsecrets.bitnami.com/managed: "true"
 ---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -187,7 +187,7 @@ spec:
       locked: true
       protected: true
       runUntagged: false
-      secret: spack-signing-runner-secret
+      secret: spack-group-runner-secret
 
       services: {}
       # cpuRequests: 50m

--- a/k8s/production/runners/signing/sealed-secrets.yaml
+++ b/k8s/production/runners/signing/sealed-secrets.yaml
@@ -1,22 +1,6 @@
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
-  name: spack-signing-runner-secret
-  namespace: gitlab
-spec:
-  encryptedData:
-    # Token from: https://gitlab.spack.io/scott/pipeline-experiments/
-    runner-registration-token: AgCendQXYZTsxs1RU3Uf0AbH8RgVGitg5awQslJ4xtfRZOPpE36Fi6TS0aRp/n38MS8bPPvLvNHfePNo3Lk298Q5aFaT7B7DjtR5AcHVL8lWuWJMTn2H5xKw/M+XAkjhatU1lLIRbrAYNGUat+VKapMDYnh/McHRNnJX24R/7y73aJ0BLAQkZoOe6tw6fmkFZcJzsCf4kwYorkHBF3D6K6ExUqNHix8kbW7qdfG4aIqeL4dcYBlaBJyQP49w93pOkUwC+YzJXg9xgO2EAR3Bh/tj7NwSwfCec0P6GdX7X/lkML1lHn0QEtvcWpbn1C4+QyJBchnLgN3mCej+FmhVPUqCzzlYFBExM08WrKdpTYKdLNFYk/BAKYb3QoT5qwcRzbbyO0/Osk/Qvlrj0KQTlBQjvSVc6RLJr4DVyRzB2vuihdpplyT4RA3wGvFIGVmLl7IQKHzUgjnXWWEQB7rKGH++1zMXsTJRjhqgvVB9TFJ1I1fehlrj69QBdQEi8oUY3w7NhFOcThCXNSKiYkhncLjRlWHXkx41e8RHOwy+FR+KoUV0AsfgWVw5L1OQ1PTVbBQU3lQ/1vax2UfPKnVg5LmOyo/3OmcBZv+4kxjXl18N9YjlQGsCBdcGYaHFaA7Ie3dJseOJhdC1KT1IFtfPEh/cYkJghgicRZiVrEmMuyNfNRv+PAfcmycMFyb0yxtDupLDXCsoy3RBQhmkZvnCq/Cs2uPV+w==
-    runner-token: AgDX2rfwkcDTM3k0VW8xEZ9FqucncqtrlPwx1YHPZxYb2erCG7MrzrQ4I0kB6daJvauLLJqWNBYtX0QuW3tpuFF30p4ReXBja7tc5A3IEOd3/uiJTe91EhtQd7xU4a5tueq2maR/bjzkLsfCHKwISI2lPxu0SSf6QAugfYvNFHGnHNAbaANvtIXhH1u0Vh/WOLfvf8DUgr36UDS3UhV1GHmn7w4I3qwyLv08FUXE4yWXtcAFHZRxibpSgNGYUSEAtP95Aq/3WawJYYfuh8nqzJxCntRfgTfNIu/NkoMpmVDT/neVLQKx2wUD/RuK2i/RKu+QbGc5LeO9V7Sv6rP+l5yh6TtO2sq+samYeQQsf0dAm1XV6bDGVQ0Ozrmp6jV5Ab4jvYTpMhCgV5Udhs8YYaHpgvy41gvaj/Osk6GJrOckcy1taXIn6v62XZND6zudMoQaDA2pMJWUzMGvKxv2gbCvZK1yIh9x2XuGZTE7WW+jHgUpeHiiQlZH0nwjmkB5BG9YoGaIvnpPL0uMEDqVbvoxEP2JCW/tfNbFuecg3pS5g1xpPkq7GjCMrA0Y+2A+mUkgXoGB8cE7gz9aBJRS+4dWh6DVdvcbd/I/czi29v2Vn6K+391o8Ew7QDxuck4TkS9yvyONRBuTdm599ye9s3lJ9bFbX/g3DVQMMTBpyBrN3jbCDWaiT/x/eK15fKpL9b0=
-  template:
-    metadata:
-      annotations:
-        kustomize.toolkit.fluxcd.io/reconcile: disabled
-        sealedsecrets.bitnami.com/managed: "true"
----
-apiVersion: bitnami.com/v1alpha1
-kind: SealedSecret
-metadata:
   name: spack-signing-key-encrypted
   namespace: pipeline
 spec:


### PR DESCRIPTION
This applies the same change as #1152 to protected and signing runners. This also removes the `spack-project-runner-registration-token` and `spack-signing-runner-secret` secrets, as they are no longer used (and contained no unique information anyway).