### PR TITLE
Use the spackbot latest images

### DIFF
--- a/k8s/production/spack/spackbotdev-spack-io/deployments.yaml
+++ b/k8s/production/spack/spackbotdev-spack-io/deployments.yaml
@@ -101,9 +101,9 @@ spec:
       serviceAccountName: spackbotdev-spack-io
       containers:
       - name: worker
-        # image: "ghcr.io/spack/spackbot-workers:latest"
+        image: "ghcr.io/spack/spackbot-workers:latest"
         # Can use some other image for testing, see README.md
-        image: "ghcr.io/kwryankrattiger/spackbot-workers:0.0.1"
+        # image: "ghcr.io/kwryankrattiger/spackbot-workers:0.0.1"
         imagePullPolicy: Always
         resources:
           requests:
@@ -192,9 +192,9 @@ spec:
       serviceAccountName: spackbotdev-spack-io
       containers:
       - name: long-task-worker
-        # image: "ghcr.io/spack/spackbot-workers:latest"
+        image: "ghcr.io/spack/spackbot-workers:latest"
         # Can use some other image for testing, see README.md
-        image: "ghcr.io/kwryankrattiger/spackbot-workers:0.0.1"
+        # image: "ghcr.io/kwryankrattiger/spackbot-workers:0.0.1"
         imagePullPolicy: Always
         resources:
           requests:


### PR DESCRIPTION
For some reason the workers are not starting with the image I built. Since I am not changing anything in the image, just use the latest spack version of the image.