### PR TITLE
Add missing svc account for spackbotdev

### DIFF
--- a/terraform/modules/spack_aws_k8s/iam_service_accounts.tf
+++ b/terraform/modules/spack_aws_k8s/iam_service_accounts.tf
@@ -125,6 +125,39 @@ module "spackbot" {
   service_account_namespace = "spack"
 }
 
+module "spackbot_dev" {
+  source = "../iam_service_account"
+
+  deployment_name  = var.deployment_name
+  deployment_stage = var.deployment_stage
+
+  service_account_iam_policies = [
+    jsonencode({
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Action" : "s3:PutObject",
+          "Resource" : "${module.pr_binary_mirror.bucket_arn}/*"
+        }
+      ]
+    }),
+    jsonencode({
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Effect" : "Allow",
+          "Action" : "s3:DeleteObject",
+          "Resource" : "${module.pr_binary_mirror.bucket_arn}/*"
+        }
+      ]
+    })
+  ]
+
+  service_account_name      = "spackbotdev-spack-io"
+  service_account_namespace = "spack"
+}
+
 module "fluent_bit" {
   source = "../iam_service_account"
 


### PR DESCRIPTION
This service account is referenced by the spackbot-dev deployment, but isn't defined anywhere, resulting in the `spackbotdev-workers` deployment from failing to start.

@kwryankrattiger so it looks like spackbot-dev was failing to start its workers long before #1159.