### PR TITLE
Fix missing queries in analytics migration 0010

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -45,7 +45,7 @@ jobs:
           - docker-image: ./images/cache-indexer
             image-tags: ghcr.io/spack/cache-indexer:0.0.6
           - docker-image: ./analytics
-            image-tags: ghcr.io/spack/django:0.5.6
+            image-tags: ghcr.io/spack/django:0.5.7
           - docker-image: ./images/ci-prune-buildcache
             image-tags: ghcr.io/spack/ci-prune-buildcache:0.0.4
           - docker-image: ./images/protected-publish

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.5.6
+          image: ghcr.io/spack/django:0.5.7
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.5.6
+          image: ghcr.io/spack/django:0.5.7
           command:
             [
               "celery",


### PR DESCRIPTION
In #1170, I updated the time keys in the `JobFact` table , but forgot to do so in the `TimerFact` and `TimerPhaseFact` tables as well. This adds those additional operations.

When tested locally with all 3 fact tables, this is successful.