### PR TITLE
Increase log verbosity for gitlab-runner-pod-cleanup, switch to `Deployment`

### DIFF
--- a/k8s/production/gitlab/pod-cleanup.yaml
+++ b/k8s/production/gitlab/pod-cleanup.yaml
@@ -26,26 +26,34 @@ subjects:
     name: pod-cleanup-sa
     namespace: gitlab
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: gitlab-runner-pod-cleanup
   namespace: gitlab
 spec:
-  restartPolicy: Always
-  serviceAccountName: pod-cleanup-sa
-  containers:
-    - name: gitlab-runner-pod-cleanup
-      image: registry.gitlab.com/gitlab-org/ci-cd/gitlab-runner-pod-cleanup:latest
-      env:
-        - name: POD_CLEANUP_KUBERNETES_NAMESPACES
-          value: pipeline
-        - name: POD_CLEANUP_LOG_LEVEL
-          value: debug
-      resources:
-        requests:
-          cpu: 20m
-          memory: 300M
-        limits:
-          cpu: 1000m
-          memory: 2G
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitlab-runner-pod-cleanup
+  template:
+    metadata:
+      labels:
+        app: gitlab-runner-pod-cleanup
+    spec:
+      serviceAccountName: pod-cleanup-sa
+      containers:
+        - name: gitlab-runner-pod-cleanup
+          image: registry.gitlab.com/gitlab-org/ci-cd/gitlab-runner-pod-cleanup:latest
+          env:
+            - name: POD_CLEANUP_KUBERNETES_NAMESPACES
+              value: pipeline
+            - name: POD_CLEANUP_LOG_LEVEL
+              value: debug
+          resources:
+            requests:
+              cpu: 20m
+              memory: 300M
+            limits:
+              cpu: 1000m
+              memory: 2G


### PR DESCRIPTION
`gitlab-runner-pod-cleanup` does not currently do much logging (only 10 log statements to stdout in the past 15 days according to opensearch). I'd like to rule it out as a cause of the current issues with "DeletionByPodGC" errors ([example](https://gitlab.spack.io/spack/spack-packages/-/jobs/17692703)), and it seems we can increase the log verbosity with an env var (see https://gitlab.com/gitlab-org/ci-cd/gitlab-runner-pod-cleanup docs). 

This PR sets that env var and also converts the `Pod` resource into a `Deployment` with one replica. It's not ideal to use a `Pod` resource directly as it may not be restarted properly when modified by Flux. (see https://www.baeldung.com/ops/kubernetes-pod-vs-deployment for more details)