### PR TITLE
Wait for CSR approval on runner nodes

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -52,6 +52,8 @@ jobs:
             image-tags: ghcr.io/spack/protected-publish:0.0.9
           - docker-image: ./images/retry-trigger-jobs
             image-tags: ghcr.io/spack/retry-trigger-jobs:0.0.2
+          - docker-image: ./images/runner-node-certificate-controller
+            image-tags: ghcr.io/spack/runner-node-certificate-controller:0.0.1
     steps:
       - name: Checkout
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3

--- a/images/runner-node-certificate-controller/Dockerfile
+++ b/images/runner-node-certificate-controller/Dockerfile
@@ -1,0 +1,14 @@
+FROM ghcr.io/astral-sh/uv:debian
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY main.py /main.py
+COPY pyproject.toml /pyproject.toml
+COPY uv.lock /uv.lock
+
+# Install dependencies here so that they are bundled into the image
+# and don't need to be installed every time the image is run.
+RUN uv sync
+
+ENTRYPOINT [ "./main.py" ]

--- a/images/runner-node-certificate-controller/README.md
+++ b/images/runner-node-certificate-controller/README.md
@@ -1,0 +1,37 @@
+# Runner Node Certificate Controller
+
+## Overview
+
+The Runner Node Certificate Controller is a Kubernetes CronJob that fixes CSR (Certificate Signing Request) timing issues that cause GitLab CI job failures on newly created runner nodes.
+
+## Problem
+
+### The Issue
+When Karpenter creates new EKS nodes for GitLab runners, there's a timing gap where:
+
+1. **Node becomes "Ready"** in Kubernetes
+1. **Pod scheduling begins** immediately
+1. **Node certificates are still being provisioned** by EKS
+1. **GitLab runner pods fail** with `error dialing backend: remote error: tls: internal error`
+1. **Jobs fail within 1-2 seconds** before certificates are fully ready
+
+This affects many jobs that land on newly created nodes, causing frequent CI failures and requiring manual job retries.
+
+### Root Cause
+The EKS node certificate provisioning process completes after the node is marked as "Ready", creating a race condition where workloads can be scheduled before the node can successfully communicate with the Kubernetes API server.
+
+See this issue for more details https://github.com/awslabs/amazon-eks-ami/issues/1944.
+
+## Solution
+
+### How It Works
+1. **Karpenter creates nodes** with a `node.spack.io/certificate-pending=true:NoSchedule` taint
+1. **Workloads are blocked** from scheduling on the tainted node
+1. **Certificate Controller runs every minute** checking for tainted runner nodes
+1. **Controller waits** for nodes to be Ready
+1. **Taint is removed** once certificates are confirmed working
+1. **Workloads can now safely schedule** on the node
+
+### Karpenter Configuration
+Nodes must be created with the certificate-pending taint. This requires the Karpenter EC2NodeClass
+for each GitLab runner to apply the `node.spack.io/certificate-pending` taint as a `startupTaint`.

--- a/images/runner-node-certificate-controller/main.py
+++ b/images/runner-node-certificate-controller/main.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env -S uv run
+"""
+Runner Node Certificate Controller
+
+This script manages certificate-pending taints on runner nodes in a Kubernetes cluster.
+It verifies that node certificates are working properly before removing the taint.
+"""
+
+from datetime import datetime, timezone
+
+import sentry_sdk
+from kubernetes import client, config
+from kubernetes.client.exceptions import ApiException
+
+TAINT_KEY = "node.spack.io/certificate-pending"
+
+sentry_sdk.init(traces_sample_rate=0.1)
+
+
+def get_k8s_clients() -> tuple[client.CoreV1Api, client.CertificatesV1Api]:
+    """Load kubernetes config and return API clients"""
+    config.load_incluster_config()
+
+    return client.CoreV1Api(), client.CertificatesV1Api()
+
+
+def remove_taint_from_node(v1_client: client.CoreV1Api, node_name: str) -> bool:
+    """Remove certificate-pending taint from a node"""
+    print(f"Removing certificate-pending taint from node: {node_name}")
+
+    try:
+        # Get current node
+        node = v1_client.read_node(name=node_name)
+
+        # Remove the taint
+        if node.spec and node.spec.taints:
+            filtered_taints = [t for t in node.spec.taints if t.key != TAINT_KEY]
+            node.spec.taints = filtered_taints if filtered_taints else None
+
+        # Update the node
+        v1_client.patch_node(name=node_name, body=node)
+        print(f"✓ Successfully removed taint from {node_name}")
+        return True
+
+    except ApiException as e:
+        print(f"✗ Failed to remove taint from {node_name}: {e}")
+        return False
+
+
+def is_node_ready(v1_client: client.CoreV1Api, node_name: str) -> bool:
+    """Check if node is ready"""
+    try:
+        node = v1_client.read_node_status(name=node_name)
+        if node.status and node.status.conditions:
+            for condition in node.status.conditions:
+                if condition.type == "Ready":
+                    return condition.status == "True"
+        return False
+    except ApiException:
+        return False
+
+
+def verify_node_certificates(
+    v1_client: client.CoreV1Api, cert_client: client.CertificatesV1Api, node_name: str
+) -> bool:
+    """Verify node certificates are actually working"""
+    print(f"  🔍 Verifying certificates are functional on {node_name}...")
+
+    # Test 1: Check if CSRs for this node are approved
+    try:
+        csr_list = cert_client.list_certificate_signing_request()
+        approved_csrs = []
+
+        for csr in csr_list.items:
+            if csr.spec.username and node_name in csr.spec.username:
+                if csr.status and csr.status.conditions:
+                    if any(c.type == "Approved" for c in csr.status.conditions):
+                        approved_csrs.append(csr.metadata.name)
+
+        if not approved_csrs:
+            print(f"  ❌ No approved CSRs found for node {node_name}")
+            return False
+
+        print(f"  ✅ Found approved CSRs for node: {', '.join(approved_csrs)}")
+
+    except ApiException as e:
+        print(f"  ❌ Failed to get CSRs: {e}")
+        return False
+
+    # Test 2: Verify node can make API calls by checking kubelet endpoints
+    print("  🔍 Testing kubelet API responsiveness...")
+
+    kubelet_test_passed = False
+
+    # Test multiple endpoints with increasing complexity
+    test_endpoints = [
+        f"/api/v1/nodes/{node_name}/proxy/metrics/cadvisor",
+        f"/api/v1/nodes/{node_name}/proxy/stats/summary",
+        f"/api/v1/nodes/{node_name}/proxy/healthz",
+    ]
+
+    api_client = client.ApiClient()
+
+    for endpoint in test_endpoints:
+        try:
+            api_client.call_api(endpoint, "GET", response_type="str")
+            endpoint_name = endpoint.split("/")[-1]
+            print(f"  ✅ Node kubelet {endpoint_name} accessible")
+            kubelet_test_passed = True
+            break
+        except ApiException:
+            continue
+
+    # Fallback test: basic connectivity test
+    if not kubelet_test_passed:
+        print("  🔍 Testing basic API server connectivity from control plane...")
+        if is_node_ready(v1_client, node_name):
+            print("  ✅ Node is reporting Ready status (indicates API connectivity)")
+            kubelet_test_passed = True
+        else:
+            print("  ❌ All kubelet API tests failed")
+            return False
+
+    if kubelet_test_passed:
+        print("  ✅ Node kubelet API is responsive (at least one test passed)")
+    else:
+        print("  ❌ Node kubelet API is not responsive")
+        return False
+
+    # Test 3: Check node conditions for certificate-related issues
+    try:
+        node = v1_client.read_node_status(name=node_name)
+        if node.status and node.status.conditions:
+            for condition in node.status.conditions:
+                reason = condition.reason or ""
+                message = condition.message or ""
+
+                if reason == "KubeletNotReady" or "certificate" in message.lower():
+                    print(f"  ❌ Certificate-related issues found: {message}")
+                    return False
+    except ApiException:
+        print("  ❌ Failed to get node conditions")
+        return False
+
+    print("  ✅ No certificate-related issues in node conditions")
+    print(f"  🎉 All certificate checks passed for {node_name}")
+    return True
+
+
+def get_node_age_seconds(v1_client: client.CoreV1Api, node_name: str) -> int:
+    """Get node age in seconds"""
+    try:
+        node = v1_client.read_node(name=node_name)
+        if node.metadata and node.metadata.creation_timestamp:
+            current_dt = datetime.now(timezone.utc)
+            age_seconds = int(
+                (current_dt - node.metadata.creation_timestamp).total_seconds()
+            )
+            return age_seconds
+        return 0
+    except ApiException:
+        return 0
+
+
+def get_tainted_runner_nodes(v1_client: client.CoreV1Api) -> list[str]:
+    """Find all runner nodes with certificate-pending taint"""
+    print("Finding runner nodes with certificate-pending taint...")
+
+    try:
+        nodes = v1_client.list_node(label_selector="spack.io/pipeline=true")
+        tainted_nodes = []
+
+        for node in nodes.items:
+            node_name = node.metadata.name
+            if node.spec.taints:
+                # Check if this node has our taint
+                if any(taint.key == TAINT_KEY for taint in node.spec.taints):
+                    tainted_nodes.append(node_name)
+
+        return tainted_nodes
+
+    except ApiException as e:
+        print(f"Failed to get nodes: {e}")
+        return []
+
+
+def main():
+    print(f"=== Runner Node Certificate Controller - {datetime.now()} ===")
+
+    # Get Kubernetes clients
+    v1_client, cert_client = get_k8s_clients()
+
+    # Find tainted nodes
+    tainted_nodes = get_tainted_runner_nodes(v1_client)
+
+    if not tainted_nodes:
+        print("No runner nodes found with certificate-pending taint")
+        print("=== Job Complete ===")
+        return
+
+    print("Found nodes with certificate-pending taint:")
+    for node in tainted_nodes:
+        print(node)
+    print()
+
+    # Process each tainted node
+    processed = 0
+    removed = 0
+
+    for node in tainted_nodes:
+        print(f"Processing node: {node}")
+        processed += 1
+
+        # Log node age for reference
+        node_age = get_node_age_seconds(v1_client, node)
+        print(f"  Node age: {node_age}s")
+
+        # Check if node is ready
+        if not is_node_ready(v1_client, node):
+            print("  ⏳ Node not Ready yet, keeping taint")
+            continue
+
+        print("  ✓ Node is Ready, now verifying certificates...")
+
+        # Verify certificates are actually working
+        if verify_node_certificates(v1_client, cert_client, node):
+            print("  ✅ Certificates verified, removing taint")
+            if remove_taint_from_node(v1_client, node):
+                removed += 1
+        else:
+            print("  ❌ Certificate verification failed, keeping taint for now")
+            print("  ℹ️  Will retry on next run")
+        print()
+
+    print("=== Summary ===")
+    print(f"Processed nodes: {processed}")
+    print(f"Removed taints: {removed}")
+    print("=== Job Complete ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/images/runner-node-certificate-controller/pyproject.toml
+++ b/images/runner-node-certificate-controller/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "runner-node-certificate-controller"
+version = "0.1.0"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "kubernetes>=33.1.0",
+    "sentry-sdk>=2.38.0",
+]
+
+[dependency-groups]
+dev = [
+    "kubernetes-stubs>=22.6.0.post1",
+]

--- a/images/runner-node-certificate-controller/uv.lock
+++ b/images/runner-node-certificate-controller/uv.lock
@@ -1,0 +1,277 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "cachetools"
+version = "5.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14", size = 122371, upload-time = "2025-08-09T07:57:28.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/ca/2135ac97709b400c7654b4b764daf5c5567c2da45a30cdd20f9eefe2d658/charset_normalizer-3.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:14c2a87c65b351109f6abfc424cab3927b3bdece6f706e4d12faaf3d52ee5efe", size = 205326, upload-time = "2025-08-09T07:56:24.721Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/98a04c3c97dd34e49c7d247083af03645ca3730809a5509443f3c37f7c99/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41d1fc408ff5fdfb910200ec0e74abc40387bccb3252f3f27c0676731df2b2c8", size = 146008, upload-time = "2025-08-09T07:56:26.004Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/4659a4cb3c4ec146bec80c32d8bb16033752574c20b1252ee842a95d1a1e/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1bb60174149316da1c35fa5233681f7c0f9f514509b8e399ab70fea5f17e45c9", size = 159196, upload-time = "2025-08-09T07:56:27.25Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9e/f552f7a00611f168b9a5865a1414179b2c6de8235a4fa40189f6f79a1753/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30d006f98569de3459c2fc1f2acde170b7b2bd265dc1943e87e1a4efe1b67c31", size = 156819, upload-time = "2025-08-09T07:56:28.515Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/95/42aa2156235cbc8fa61208aded06ef46111c4d3f0de233107b3f38631803/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:416175faf02e4b0810f1f38bcb54682878a4af94059a1cd63b8747244420801f", size = 151350, upload-time = "2025-08-09T07:56:29.716Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a9/3865b02c56f300a6f94fc631ef54f0a8a29da74fb45a773dfd3dcd380af7/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aab0f181c486f973bc7262a97f5aca3ee7e1437011ef0c2ec04b5a11d16c927", size = 148644, upload-time = "2025-08-09T07:56:30.984Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d9/cbcf1a2a5c7d7856f11e7ac2d782aec12bdfea60d104e60e0aa1c97849dc/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fdabf8315679312cfa71302f9bd509ded4f2f263fb5b765cf1433b39106c3cc9", size = 160468, upload-time = "2025-08-09T07:56:32.252Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/42/6f45efee8697b89fda4d50580f292b8f7f9306cb2971d4b53f8914e4d890/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5", size = 158187, upload-time = "2025-08-09T07:56:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/70/99/f1c3bdcfaa9c45b3ce96f70b14f070411366fa19549c1d4832c935d8e2c3/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:18343b2d246dc6761a249ba1fb13f9ee9a2bcd95decc767319506056ea4ad4dc", size = 152699, upload-time = "2025-08-09T07:56:34.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/b0081f2f99a4b194bcbb1934ef3b12aa4d9702ced80a37026b7607c72e58/charset_normalizer-3.4.3-cp313-cp313-win32.whl", hash = "sha256:6fb70de56f1859a3f71261cbe41005f56a7842cc348d3aeb26237560bfa5e0ce", size = 99580, upload-time = "2025-08-09T07:56:35.981Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/8f/ae790790c7b64f925e5c953b924aaa42a243fb778fed9e41f147b2a5715a/charset_normalizer-3.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:cf1ebb7d78e1ad8ec2a8c4732c7be2e736f6e5123a4146c5b89c9d1f585f8cef", size = 107366, upload-time = "2025-08-09T07:56:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/91/b5a06ad970ddc7a0e513112d40113e834638f4ca1120eb727a249fb2715e/charset_normalizer-3.4.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3cd35b7e8aedeb9e34c41385fda4f73ba609e561faedfae0a9e75e44ac558a15", size = 204342, upload-time = "2025-08-09T07:56:38.687Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ec/1edc30a377f0a02689342f214455c3f6c2fbedd896a1d2f856c002fc3062/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89bc04de1d83006373429975f8ef9e7932534b8cc9ca582e4db7d20d91816db", size = 145995, upload-time = "2025-08-09T07:56:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e5/5e67ab85e6d22b04641acb5399c8684f4d37caf7558a53859f0283a650e9/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2001a39612b241dae17b4687898843f254f8748b796a2e16f1051a17078d991d", size = 158640, upload-time = "2025-08-09T07:56:41.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e5/38421987f6c697ee3722981289d554957c4be652f963d71c5e46a262e135/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8dcfc373f888e4fb39a7bc57e93e3b845e7f462dacc008d9749568b1c4ece096", size = 156636, upload-time = "2025-08-09T07:56:43.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e4/5a075de8daa3ec0745a9a3b54467e0c2967daaaf2cec04c845f73493e9a1/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b97b8404387b96cdbd30ad660f6407799126d26a39ca65729162fd810a99aa", size = 150939, upload-time = "2025-08-09T07:56:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f7/3611b32318b30974131db62b4043f335861d4d9b49adc6d57c1149cc49d4/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccf600859c183d70eb47e05a44cd80a4ce77394d1ac0f79dbd2dd90a69a3a049", size = 148580, upload-time = "2025-08-09T07:56:46.684Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/61/19b36f4bd67f2793ab6a99b979b4e4f3d8fc754cbdffb805335df4337126/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:53cd68b185d98dde4ad8990e56a58dea83a4162161b1ea9272e5c9182ce415e0", size = 159870, upload-time = "2025-08-09T07:56:47.941Z" },
+    { url = "https://files.pythonhosted.org/packages/06/57/84722eefdd338c04cf3030ada66889298eaedf3e7a30a624201e0cbe424a/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:30a96e1e1f865f78b030d65241c1ee850cdf422d869e9028e2fc1d5e4db73b92", size = 157797, upload-time = "2025-08-09T07:56:49.756Z" },
+    { url = "https://files.pythonhosted.org/packages/72/2a/aff5dd112b2f14bcc3462c312dce5445806bfc8ab3a7328555da95330e4b/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16", size = 152224, upload-time = "2025-08-09T07:56:51.369Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8c/9839225320046ed279c6e839d51f028342eb77c91c89b8ef2549f951f3ec/charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce", size = 100086, upload-time = "2025-08-09T07:56:52.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7a/36fbcf646e41f710ce0a563c1c9a343c6edf9be80786edeb15b6f62e17db/charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c", size = 107400, upload-time = "2025-08-09T07:56:55.172Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.40.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "kubernetes"
+version = "33.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "google-auth" },
+    { name = "oauthlib" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/52/19ebe8004c243fdfa78268a96727c71e08f00ff6fe69a301d0b7fcbce3c2/kubernetes-33.1.0.tar.gz", hash = "sha256:f64d829843a54c251061a8e7a14523b521f2dc5c896cf6d65ccf348648a88993", size = 1036779, upload-time = "2025-06-09T21:57:58.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/43/d9bebfc3db7dea6ec80df5cb2aad8d274dd18ec2edd6c4f21f32c237cbbb/kubernetes-33.1.0-py2.py3-none-any.whl", hash = "sha256:544de42b24b64287f7e0aa9513c93cb503f7f40eea39b20f66810011a86eabc5", size = 1941335, upload-time = "2025-06-09T21:57:56.327Z" },
+]
+
+[[package]]
+name = "kubernetes-stubs"
+version = "22.6.0.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/aa/3242e96c43e5432619a0bdca51a1cc1849e329fe43ee981c80a46a202592/kubernetes-stubs-22.6.0.post1.tar.gz", hash = "sha256:9f4de86ef3c5aeb8ca555164f7427e8d909b00ad0b2081cf2bf17dc44cfb63e9", size = 109892, upload-time = "2022-04-20T04:31:48.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ba/6618982cef12645ab183aa0c6fd44764af3c2dae7353e354ca68e28e3ae3/kubernetes_stubs-22.6.0.post1-py2.py3-none-any.whl", hash = "sha256:46a4d6fc30458f245c54d2f5777dcb2ecc16bc86258fb37c7b87c631d2ac61da", size = 345879, upload-time = "2022-04-20T04:31:47.359Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "runner-node-certificate-controller"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "kubernetes" },
+    { name = "sentry-sdk" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "kubernetes-stubs" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "kubernetes", specifier = ">=33.1.0" },
+    { name = "sentry-sdk", specifier = ">=2.38.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "kubernetes-stubs", specifier = ">=22.6.0.post1" }]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/22/60fd703b34d94d216b2387e048ac82de3e86b63bc28869fb076f8bb0204a/sentry_sdk-2.38.0.tar.gz", hash = "sha256:792d2af45e167e2f8a3347143f525b9b6bac6f058fb2014720b40b84ccbeb985", size = 348116, upload-time = "2025-09-15T15:00:37.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/84/bde4c4bbb269b71bc09316af8eb00da91f67814d40337cc12ef9c8742541/sentry_sdk-2.38.0-py2.py3-none-any.whl", hash = "sha256:2324aea8573a3fa1576df7fb4d65c4eb8d9929c8fa5939647397a07179eef8d0", size = 370346, upload-time = "2025-09-15T15:00:35.821Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
+]

--- a/k8s/production/custom/runner-node-certificate-controller/cron-jobs.yaml
+++ b/k8s/production/custom/runner-node-certificate-controller/cron-jobs.yaml
@@ -1,0 +1,43 @@
+# CronJob to remove certificate-pending taints from ready runner nodes
+# Fixes CSR timing issues that cause GitLab CI job failures
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: runner-node-certificate-controller
+  namespace: custom
+  labels:
+    app: runner-node-certificate-controller
+    component: certificate-controller
+    purpose: csr-timing-fix
+spec:
+  schedule: "*/1 * * * *"  # Run every minute
+  concurrencyPolicy: Forbid  # Don't run concurrent jobs
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: runner-node-certificate-controller-job
+        spec:
+          serviceAccountName: runner-node-certificate-controller
+          restartPolicy: Never
+          containers:
+          - name: runner-node-certificate-controller
+            image: ghcr.io/spack/runner-node-certificate-controller:0.0.1
+            imagePullPolicy: IfNotPresent
+            resources:
+              requests:
+                cpu: 20m
+                memory: 64Mi
+              limits:
+                cpu: 200m
+                memory: 256Mi
+            envFrom:
+            - configMapRef:
+              name: python-scripts-sentry-config
+          nodeSelector:
+            spack.io/node-pool: base

--- a/k8s/production/custom/runner-node-certificate-controller/service-accounts.yaml
+++ b/k8s/production/custom/runner-node-certificate-controller/service-accounts.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: runner-node-certificate-controller
+  namespace: custom
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: runner-node-certificate-controller
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "update"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: runner-node-certificate-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: runner-node-certificate-controller
+subjects:
+- kind: ServiceAccount
+  name: runner-node-certificate-controller
+  namespace: custom

--- a/k8s/production/karpenter/provisioners/runners/graviton/3/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/graviton/3/provisioners.yaml
@@ -75,6 +75,13 @@ spec:
           value: "true"
           effect: NoSchedule
 
+      startupTaints:
+        # See k8s/production/custom/runner-node-certificate-controller/
+        # for explanation of this
+        - key: "node.spack.io/certificate-pending"
+          value: "true"
+          effect: "NoSchedule"
+
   # Terminate nodes after 5 minutes of idle time
   disruption:
     consolidationPolicy: WhenEmpty

--- a/k8s/production/karpenter/provisioners/runners/graviton/4/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/graviton/4/provisioners.yaml
@@ -75,6 +75,13 @@ spec:
           value: "true"
           effect: NoSchedule
 
+      startupTaints:
+        # See k8s/production/custom/runner-node-certificate-controller/
+        # for explanation of this
+        - key: "node.spack.io/certificate-pending"
+          value: "true"
+          effect: "NoSchedule"
+
   # Terminate nodes after 5 minutes of idle time
   disruption:
     consolidationPolicy: WhenEmpty

--- a/k8s/production/karpenter/provisioners/runners/testing/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/testing/provisioners.yaml
@@ -57,6 +57,13 @@ spec:
           value: "true"
           effect: NoSchedule
 
+      startupTaints:
+        # See k8s/production/custom/runner-node-certificate-controller/
+        # for explanation of this
+        - key: "node.spack.io/certificate-pending"
+          value: "true"
+          effect: "NoSchedule"
+
   # Terminate nodes after 5 minutes of idle time
   disruption:
     consolidationPolicy: WhenEmpty

--- a/k8s/production/karpenter/provisioners/runners/windows/x86_64/v2/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/runners/windows/x86_64/v2/provisioner.yaml
@@ -54,6 +54,13 @@ spec:
           value: "true"
           effect: NoSchedule
 
+      startupTaints:
+        # See k8s/production/custom/runner-node-certificate-controller/
+        # for explanation of this
+        - key: "node.spack.io/certificate-pending"
+          value: "true"
+          effect: "NoSchedule"
+
   limits:
     cpu: 3840 # 16 vCPUs * 6 replicas * 20 concurrent jobs * 2 runners (public & protected)
     memory: 15Ti # 64 Gi * 6 replicas * 20 concurrent jobs * 2 runners (public & protected)

--- a/k8s/production/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/x86_64/v2/provisioners.yaml
@@ -65,6 +65,13 @@ spec:
           value: "true"
           effect: NoSchedule
 
+      startupTaints:
+        # See k8s/production/custom/runner-node-certificate-controller/
+        # for explanation of this
+        - key: "node.spack.io/certificate-pending"
+          value: "true"
+          effect: "NoSchedule"
+
 
   # Terminate nodes after 5 minutes of idle time
   disruption:

--- a/k8s/production/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/x86_64/v3/provisioners.yaml
@@ -98,6 +98,13 @@ spec:
           value: "true"
           effect: NoSchedule
 
+      startupTaints:
+        # See k8s/production/custom/runner-node-certificate-controller/
+        # for explanation of this
+        - key: "node.spack.io/certificate-pending"
+          value: "true"
+          effect: "NoSchedule"
+
   # Terminate nodes after 5 minutes of idle time
   disruption:
     consolidationPolicy: WhenEmpty

--- a/k8s/production/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
+++ b/k8s/production/karpenter/provisioners/runners/x86_64/v4/provisioners.yaml
@@ -86,6 +86,13 @@ spec:
           value: "true"
           effect: NoSchedule
 
+      startupTaints:
+        # See k8s/production/custom/runner-node-certificate-controller/
+        # for explanation of this
+        - key: "node.spack.io/certificate-pending"
+          value: "true"
+          effect: "NoSchedule"
+
 
   # Terminate nodes after 5 minutes of idle time
   disruption:


### PR DESCRIPTION
It's possible for a runner node to become `Ready` before its `CertificateSigningRequest` is approved, resulting in a (usually short) window of time where communication between the node and the kube control plane server is impossible. This manifests as a runner system failure on GitLab with an error message like this - `error dialing backend: remote error: tls: internal error`,

See this issue for further context -
https://github.com/awslabs/amazon-eks-ami/issues/1944


This PR fixes this by configuring Karpenter to apply a taint to all runner nodes upon provisioning that prevents any pods from being scheduled on it. A new cronjob that runs every minute will query for new nodes that have that taint, check if their CSR is approved, and remove the taint if it is.

I've tested this extensively with https://gitlab.staging.spack.io/spack/test-tls-issue. Before applying the changes in this PR, I can reproduce the error by kicking off 2-3 pipelines on that repo. After applying the changes, I'm unable to reproduce the error with up to 4 pipelines running concurrently; attempting to run more pipelines than 4 causes unrelated errors like unresponsive GitLab server (due to high load from the CI jobs).