### PR TITLE
Service Upgrade 9/2/25

### DIFF
--- a/k8s/production/ingress-nginx/release.yaml
+++ b/k8s/production/ingress-nginx/release.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
-      version: 4.13.1 # ingress-nginx@1.13.1
+      version: 4.13.2 # ingress-nginx@1.13.2
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx

--- a/k8s/production/metabase/metabase-deployment.yaml
+++ b/k8s/production/metabase/metabase-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: metabase
-          image: metabase/metabase:v0.56.2
+          image: metabase/metabase:v0.56.3
           imagePullPolicy: "IfNotPresent"
           resources:
             requests:

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      version: 76.4.0 # prometheus-operator@v0.84.1, grafana@9.3.2
+      version: 77.2.1 # prometheus-operator@v0.85.0, grafana@9.4.4
       sourceRef:
         kind: HelmRepository
         name: kube-prometheus-stack

--- a/k8s/production/prometheus/release.yaml
+++ b/k8s/production/prometheus/release.yaml
@@ -17,6 +17,8 @@ metadata:
   namespace: monitoring
 spec:
   interval: 10m
+  # Prometheus can take a while to deploy due to the DaemonSet, so give it an increased timeout
+  timeout: 15m
   chart:
     spec:
       chart: kube-prometheus-stack


### PR DESCRIPTION
Note this PR also updates the timeout for the `kube-prometheus-stack` Helm chart; we frequently see that time out and take longer than 10 minutes (the default timeout), requiring a manual restart.