### PR TITLE
Add project name namespace to PR cache

### DIFF
--- a/scripts/gitlab_runner_pre_build/pre_build.py
+++ b/scripts/gitlab_runner_pre_build/pre_build.py
@@ -40,6 +40,13 @@ def _token_to_sts_request(raw_jwt, decoded_jwt):
                         "Action": "*",
                         # scope the actions down the pr prefix
                         "Resource": f"{os.environ['PR_BINARY_MIRROR_BUCKET_ARN']}/{os.environ['CI_COMMIT_REF_NAME']}/*",
+                    },
+                    {
+                        "Effect": "Allow",
+                        # allow every action the broader RoleArn allows
+                        "Action": "*",
+                        # scope the actions down the pr prefix
+                        "Resource": f"{os.environ['PR_BINARY_MIRROR_BUCKET_ARN']}/{os.environ['CI_PROJECT_NAME']}/{os.environ['CI_COMMIT_REF_NAME']}/*",
                     }
                 ]
             }

--- a/scripts/gitlab_runner_pre_build/pre_build.py
+++ b/scripts/gitlab_runner_pre_build/pre_build.py
@@ -39,14 +39,11 @@ def _token_to_sts_request(raw_jwt, decoded_jwt):
                         # allow every action the broader RoleArn allows
                         "Action": "*",
                         # scope the actions down the pr prefix
-                        "Resource": f"{os.environ['PR_BINARY_MIRROR_BUCKET_ARN']}/{os.environ['CI_COMMIT_REF_NAME']}/*",
-                    },
-                    {
-                        "Effect": "Allow",
-                        # allow every action the broader RoleArn allows
-                        "Action": "*",
-                        # scope the actions down the pr prefix
-                        "Resource": f"{os.environ['PR_BINARY_MIRROR_BUCKET_ARN']}/{os.environ['CI_PROJECT_NAME']}/{os.environ['CI_COMMIT_REF_NAME']}/*",
+                        "Resource": [
+                            # TODO: remove first resource after transition is complete
+                            f"{os.environ['PR_BINARY_MIRROR_BUCKET_ARN']}/{os.environ['CI_COMMIT_REF_NAME']}/*",
+                            f"{os.environ['PR_BINARY_MIRROR_BUCKET_ARN']}/{os.environ['CI_PROJECT_NAME']}/{os.environ['CI_COMMIT_REF_NAME']}/*",
+                        ],
                     }
                 ]
             }


### PR DESCRIPTION
This is required in order to ensure no collisions between PR started from different repositories.

PR change [here](https://github.com/spack/spack-packages/pull/342/files#diff-f8188dc893dfb8c4140ed2ce9cd2b927e97e88f331bf4221c5dd3d95caafa671)

Error in CI [here](https://gitlab.spack.io/spack/spack/-/jobs/18009189#L1249)