### PR TITLE
Add spot_reclamation error taxonomy class

### DIFF
--- a/analytics/analytics/job_processor/error_taxonomy.yaml
+++ b/analytics/analytics/job_processor/error_taxonomy.yaml
@@ -102,6 +102,10 @@ taxonomy:
       grep_for:
         - 'error dialing backend'
 
+    spot_reclamation:
+      grep_for:
+        - 'node no longer exists'
+
     pod_cleanup:
       grep_for:
         - 'Error cleaning up pod'
@@ -293,6 +297,7 @@ taxonomy:
     - 'fatal'
     - 'pod_exec'
     - 'pod_timeout'
+    - 'spot_reclamation'
     - 'pod_cleanup'
     - 'pod_not_found'
     - 'pod_failed'


### PR DESCRIPTION
This will help us properly classify instances of spot reclamation. At the moment, most of them are classified as `pod_cleanup`, although not exclusively. 

Here is a recent example of a spot reclamation: https://gitlab.spack.io/spack/spack-packages/-/jobs/18014807