### PR TITLE
Fix analytics docker image build

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
     build-essential ca-certificates coreutils curl \
     environment-modules gfortran git gpg lsb-release \
-    python3 python3-distutils python3-venv unzip zip \
+    python3 python3-venv unzip zip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install spack

--- a/analytics/dev/django.Dockerfile
+++ b/analytics/dev/django.Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
     build-essential ca-certificates coreutils curl \
     environment-modules gfortran git gpg lsb-release \
-    python3 python3-distutils python3-venv unzip zip
+    python3 python3-venv unzip zip
 
 # Cleanup
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The image is failing to build because it's attempting to install `python3-distutils`, which is deprecated in favor of `setuptools`. As far as I can tell, we don't actually need either package, so I've simply removed it.