### PR TITLE
Fix CSR script

### DIFF
--- a/.github/workflows/custom_docker_builds.yml
+++ b/.github/workflows/custom_docker_builds.yml
@@ -53,7 +53,7 @@ jobs:
           - docker-image: ./images/retry-trigger-jobs
             image-tags: ghcr.io/spack/retry-trigger-jobs:0.0.2
           - docker-image: ./images/runner-node-certificate-controller
-            image-tags: ghcr.io/spack/runner-node-certificate-controller:0.0.1
+            image-tags: ghcr.io/spack/runner-node-certificate-controller:0.0.2
     steps:
       - name: Checkout
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3

--- a/k8s/production/custom/runner-node-certificate-controller/cron-jobs.yaml
+++ b/k8s/production/custom/runner-node-certificate-controller/cron-jobs.yaml
@@ -27,7 +27,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: runner-node-certificate-controller
-            image: ghcr.io/spack/runner-node-certificate-controller:0.0.1
+            image: ghcr.io/spack/runner-node-certificate-controller:0.0.2
             imagePullPolicy: IfNotPresent
             resources:
               requests:

--- a/k8s/production/custom/runner-node-certificate-controller/service-accounts.yaml
+++ b/k8s/production/custom/runner-node-certificate-controller/service-accounts.yaml
@@ -12,7 +12,10 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list", "update"]
+  verbs: ["get", "list", "update", "patch"]
+- apiGroups: [""]
+  resources: ["nodes/status"]
+  verbs: ["get"]
 - apiGroups: ["certificates.k8s.io"]
   resources: ["certificatesigningrequests"]
   verbs: ["get", "list"]


### PR DESCRIPTION
It seems I manually edited some of the service account permissions when I was testing this in staging, and neglected to commit them to the service-accounts.yaml. This fixes that, plus removes all the exception handling that was suppressing these errors from the log output and erroneously claiming no nodes were ready. Instead, any errors will trigger a sentry alert