### PR TITLE
Ignore VSCode and PyCharm config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ __pycache__/
 
 # Spack secret files
 private.key
+
+# Editor config files
+.vscode
+.idea


### PR DESCRIPTION
Adds common IDE config files to the `.gitignore`.