### PR TITLE
Encode s3 lifecycle rule in TF

### DIFF
--- a/terraform/modules/spack_aws_k8s/modules/binary_mirror/binary_mirror_bucket.tf
+++ b/terraform/modules/spack_aws_k8s/modules/binary_mirror/binary_mirror_bucket.tf
@@ -40,6 +40,20 @@ resource "aws_s3_bucket_versioning" "binary_mirror" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "binary_mirror" {
+  bucket = aws_s3_bucket.binary_mirror.id
+
+  rule {
+    id     = "Delete non-current versions after 30 days"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
 
 resource "aws_s3_bucket_acl" "binary_mirror" {
   bucket = aws_s3_bucket.binary_mirror.id


### PR DESCRIPTION
Encodes the existing "Delete non-current versions after 30 days" lifecycle rule on the `spack-binaries` and `spack-binaries-prs` buckets into Terraform.

This wasn't done originally and went unnoticed because these S3 buckets were set up prior to us adopting Terraform.

TF docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration