### PR TITLE
Update S3 lifecycle rules for buildcache buckets

### DIFF
--- a/terraform/modules/spack_aws_k8s/modules/binary_mirror/binary_mirror_bucket.tf
+++ b/terraform/modules/spack_aws_k8s/modules/binary_mirror/binary_mirror_bucket.tf
@@ -50,7 +50,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "binary_mirror" {
     filter {}
 
     noncurrent_version_expiration {
-      noncurrent_days = 30
+      noncurrent_days = 7
     }
 
     expiration {


### PR DESCRIPTION
- Updates rule to also remove expired delete markers (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lifecycle-config-conceptual-ex7 for more info)
- Shortens noncurrent version expiration from 30 days to 7 days. 7 days should be enough time to debug if something gets pruned that we don't expect.