### PR TITLE
Fix deprecated Terraform resource

### DIFF
--- a/terraform/modules/spack_aws_k8s/github_actions_iam.tf
+++ b/terraform/modules/spack_aws_k8s/github_actions_iam.tf
@@ -47,23 +47,27 @@ resource "aws_iam_role" "github_actions" {
       },
     ]
   })
+}
 
-  # The `ReadOnlyAccess` managed policy doesn't include secretsmanager, so we explicitly grant it here.
-  inline_policy {
-    name = "read-secrets"
-    policy = jsonencode({
-      "Version" : "2012-10-17",
-      "Statement" : [
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "secretsmanager:GetSecretValue"
-          ],
-          "Resource" : "*"
-        }
-      ]
-    })
-  }
+# The `ReadOnlyAccess` managed policy doesn't include secretsmanager, so we explicitly grant it here.
+resource "aws_iam_role_policy" "github_actions" {
+  count = var.deployment_name == "prod" ? 1 : 0
+
+  name = "${local.iam_role_name}-policy"
+  role = aws_iam_role.github_actions[0].id
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "secretsmanager:GetSecretValue"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
 }
 
 # This policy grants the GitHub Actions role read-only access to most resources in the AWS account.


### PR DESCRIPTION
This fixes this warning that always gets logged by Terraform due to the `inline_policy` block in the `aws_iam_role` resource being deprecated:

```
│ Warning: Argument is deprecated
│
│   with module.spack_aws_k8s.aws_iam_role.github_actions,
│   on ../modules/spack_aws_k8s/github_actions_iam.tf line 17, in
|   resource "aws_iam_role" "github_actions":
│   17: resource "aws_iam_role" "github_actions" {
│
│ The inline_policy argument is deprecated. Use the aws_iam_role_policy
| resource instead. If Terraform should exclusively manage all inline
| policy associations (the current behavior of this argument), use the
| aws_iam_role_policies_exclusive resource as well.
```

Docs, including note about deprecation of `inline_policy` - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#example-of-exclusive-inline-policies