### PR TITLE
Update image check workflow to see newly added PR labels

### DIFF
--- a/.github/workflows/check_docker_image_versions.yml
+++ b/.github/workflows/check_docker_image_versions.yml
@@ -2,6 +2,15 @@ name: Check Docker Image Versions
 
 on:
   pull_request:
+    types:
+      # Default values
+      - opened
+      - synchronize
+      - reopened
+      # Re-run if labels change
+      - labeled
+      - unlabeled
+
 
 jobs:
   check-image:


### PR DESCRIPTION
Right now, the `check_docker_image_versions` workflow operates in such a way that if someone adds the `no-image-bump` label to a PR _after_ it is opened, it won't have access to that newly added label. Simply re-running the job doesn't fix the issue, as it will still only refer to the original labels. I believe pushing a commit may re-trigger the labels for that workflow, but that's not something we'd like to rely on.

This PR updates that workflow to always retrieve the current list of PR labels. It also updates the workflow to re-run if labels are added/removed.