### PR TITLE
Remove staging kustomization for VPC CNI configmap

### DIFF
--- a/k8s/staging/kube-system/kustomization.yaml
+++ b/k8s/staging/kube-system/kustomization.yaml
@@ -3,4 +3,3 @@ kind: Kustomization
 resources:
 - ../../production/kube-system/metrics-server.yaml
 - ../../production/kube-system/gp3-storage-class.yaml
-- ../../production/kube-system/enable-windows-ipam.yaml


### PR DESCRIPTION
This configmap was removed in https://github.com/spack/spack-infrastructure/pull/1240, but the corresponding kustomization was not removed.