### PR TITLE
Add `no_space` error

### DIFF
--- a/.github/images.yml
+++ b/.github/images.yml
@@ -30,7 +30,7 @@ images:
     image: ghcr.io/spack/cache-indexer:0.0.6
 
   - path: ./analytics
-    image: ghcr.io/spack/django:0.5.14
+    image: ghcr.io/spack/django:0.5.15
 
   - path: ./images/ci-prune-buildcache
     image: ghcr.io/spack/ci-prune-buildcache:0.0.5

--- a/analytics/analytics/job_processor/error_taxonomy.yaml
+++ b/analytics/analytics/job_processor/error_taxonomy.yaml
@@ -89,6 +89,10 @@ taxonomy:
       grep_for:
         - "fatal: unable to access 'https://github.com"
 
+    no_space:
+      grep_for:
+        - "No space left on device"
+
     module_not_found:
       grep_for:
         - 'ModuleNotFoundError: No module named'
@@ -273,6 +277,8 @@ taxonomy:
     - 'network_error'
     # API Scrape erorrs
     - 'job_log_missing'
+    # System Errors that would otherwise get categorized as Spack Errors
+    - 'no_space'
     # Spack Errors
     - 'invalid_pipeline_yaml'
     - 'checksum_mismatch'

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.5.14
+          image: ghcr.io/spack/django:0.5.15
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.5.14
+          image: ghcr.io/spack/django:0.5.15
           command:
             [
               "celery",


### PR DESCRIPTION
We received a report of GitLab CI jobs failing with the following output:

```
[Errno 28] No space left on device
```

These are currently getting categorized as `spack_error` because the job output also contains  ```To reproduce this build locally, run:...```

Example:
https://gitlab.spack.io/spack/spack-packages/-/jobs/18991838