### PR TITLE
Disable GitLab CI pipelines for spack/spack

### DIFF
--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -59,6 +59,7 @@ metadata:
   namespace: custom
 spec:
   schedule: "3-59/5 * * * *"
+  suspend: true
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
Temporarily suspend the non-required GitLab CI pipelines for spack/spack.

We will re-enable them after we get them passing more reliably.