### PR TITLE
Increase max_session_duration for GitLab runner IAM roles

### DIFF
--- a/scripts/gitlab_runner_pre_build/pre_build.py
+++ b/scripts/gitlab_runner_pre_build/pre_build.py
@@ -9,7 +9,7 @@ S3 bucket prefix for the relevant PR.
 import os, sys, json, base64, time
 import urllib.request, urllib.parse, urllib.error
 
-TEMPORARY_CREDENTIALS_DURATION = 3600 * 6  # 6 hours
+TEMPORARY_CREDENTIALS_DURATION = 3600 * 12  # 12 hours, max allowed by AWS
 
 
 def _token_to_sts_request(raw_jwt, decoded_jwt):

--- a/terraform/modules/spack_gitlab/runner_iam.tf
+++ b/terraform/modules/spack_gitlab/runner_iam.tf
@@ -85,7 +85,7 @@ resource "aws_iam_role" "gitlab_runner" {
 
   name                 = "GitLabRunner${local.mirror_roles[each.key].role_name_suffix}"
   assume_role_policy   = each.value.json
-  max_session_duration = 3600 * 6 # only allow a max of 6 hours for a session to be active
+  max_session_duration = 3600 * 12 # allow a max of 12 hours for a session to be active. This is the max value allowed by AWS.
 }
 
 data "aws_iam_policy_document" "gitlab_runner" {


### PR DESCRIPTION
The error message we're trying to fix is:

[An error occurred (ExpiredToken) when calling the CreateMultipartUpload operation: The provided token has expired](https://gitlab.spack.io/spack/spack-packages/-/jobs/19586738#L1872).

The relevant PR in spack-packages is [#1582](https://github.com/spack/spack-packages/pull/1582/files#diff-dd2631a41ae816b427928b391b39c6e61cc3381a9464c9672859810eb4edaaa1R16).
