### PR TITLE
Temporarily disable pruning cron

### DIFF
--- a/k8s/production/custom/prune-buildcache/cron-jobs.yaml
+++ b/k8s/production/custom/prune-buildcache/cron-jobs.yaml
@@ -5,6 +5,7 @@ metadata:
   name: prune-buildcache-v3
   namespace: custom
 spec:
+  suspend: "true"
   schedule: "0 0 * * 6"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
Disable this cron job while we more closely investigate cases of blobs going missing when they shouldn't.