### PR TITLE
Use boolean for `suspend` field

### DIFF
--- a/k8s/production/custom/prune-buildcache/cron-jobs.yaml
+++ b/k8s/production/custom/prune-buildcache/cron-jobs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: prune-buildcache-v3
   namespace: custom
 spec:
-  suspend: "true"
+  suspend: true
   schedule: "0 0 * * 6"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
#1277 used a value of `"true"` instead of `true`, causing flux to error, ultimately not suspending the cron job.