### PR TITLE
Cleanup incomplete multipart uploads

### DIFF
--- a/terraform/modules/spack_aws_k8s/modules/binary_mirror/binary_mirror_bucket.tf
+++ b/terraform/modules/spack_aws_k8s/modules/binary_mirror/binary_mirror_bucket.tf
@@ -44,13 +44,17 @@ resource "aws_s3_bucket_lifecycle_configuration" "binary_mirror" {
   bucket = aws_s3_bucket.binary_mirror.id
 
   rule {
-    id     = "Delete non-current versions after 30 days"
+    id     = "Delete non-current versions after 7 days"
     status = "Enabled"
 
     filter {}
 
     noncurrent_version_expiration {
       noncurrent_days = 7
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 3
     }
 
     expiration {


### PR DESCRIPTION
This should reclaim ~200GB or so of wasted S3 storage.

Relevant docs:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#abort_incomplete_multipart_upload