### PR TITLE
Another regex for 'spot_reclamation' error class

### DIFF
--- a/.github/images.yml
+++ b/.github/images.yml
@@ -30,7 +30,7 @@ images:
     image: ghcr.io/spack/cache-indexer:0.0.6
 
   - path: ./analytics
-    image: ghcr.io/spack/django:0.5.19
+    image: ghcr.io/spack/django:0.5.20
 
   - path: ./images/ci-prune-buildcache
     image: ghcr.io/spack/ci-prune-buildcache:0.0.5

--- a/analytics/analytics/job_processor/error_taxonomy.yaml
+++ b/analytics/analytics/job_processor/error_taxonomy.yaml
@@ -113,6 +113,7 @@ taxonomy:
     spot_reclamation:
       grep_for:
         - 'node no longer exists'
+        - 'Pod was terminated in response to imminent node shutdown'
 
     pod_cleanup:
       grep_for:

--- a/k8s/production/custom/webhook-handler/deployments.yaml
+++ b/k8s/production/custom/webhook-handler/deployments.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler
-          image: ghcr.io/spack/django:0.5.19
+          image: ghcr.io/spack/django:0.5.20
           imagePullPolicy: Always
           resources:
             requests:
@@ -146,7 +146,7 @@ spec:
       serviceAccountName: webhook-handler
       containers:
         - name: webhook-handler-worker
-          image: ghcr.io/spack/django:0.5.19
+          image: ghcr.io/spack/django:0.5.20
           command:
             [
               "celery",


### PR DESCRIPTION
Example job:
https://gitlab.spack.io/spack/spack-packages/-/jobs/19893800

Using the analytics database, I was able to determine that this builder pod was scheduled on `ip-10-0-101-113.ec2.internal`. From there, I found the following message in the karpenter pod logs:

```json
{
  "message": "initiating delete from interruption message",
  "controller": "interruption",
  "messageKind": "spot_interrupted",
  "action": "CordonAndDrain",
  "Node": {
    "name": "ip-10-0-101-113.ec2.internal"
  }
}
```