### PR TITLE
Handle exception when GitHub can't find a commit

### DIFF
--- a/.github/images.yml
+++ b/.github/images.yml
@@ -1,6 +1,6 @@
 images:
   - path: ./images/gh-gl-sync
-    image: ghcr.io/spack/ci-bridge:0.0.46
+    image: ghcr.io/spack/ci-bridge:0.0.47
 
   - path: ./images/ci-key-clear
     image: ghcr.io/spack/ci-key-clear:0.0.3

--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.46
+            image: ghcr.io/spack/ci-bridge:0.0.47
             imagePullPolicy: IfNotPresent
             resources:
               requests:
@@ -69,7 +69,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.46
+            image: ghcr.io/spack/ci-bridge:0.0.47
             imagePullPolicy: IfNotPresent
             resources:
               requests:

--- a/k8s/production/custom/kokkos-sync/cron-jobs.yaml
+++ b/k8s/production/custom/kokkos-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.46
+            image: ghcr.io/spack/ci-bridge:0.0.47
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
More graceful error handling in the case that we attempt to retrieve a nonexistent commit from GitHub.