### PR TITLE
Set slackin polling interval to five minutes

### DIFF
--- a/k8s/production/spack/slack-spack-io/deployments.yaml
+++ b/k8s/production/spack/slack-spack-io/deployments.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       app: slack-spack-io
       svc: web
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
@@ -37,6 +37,8 @@ spec:
           value: "UA-101208306-3"
         - name: SLACKIN_PORT
           value: "80"
+        - name: SLACKIN_INTERVAL
+          value: "300000"
         - name: SLACKIN_COC
           value: "https://github.com/spack/spack/blob/develop/.github/CODE_OF_CONDUCT.md"
         - name: SLACK_API_TOKEN


### PR DESCRIPTION
Users have recently reported problems signing up for Slack via slack.spack.io.

We noticed the following error in the pod logs:
```
slackin:slack Error: Error: Too Many Requests
```

Increases the polling interval from 1 second to 5 minutes based on recommendations from the [relevant upstream issue](https://github.com/emedvedev/slackin-extended/issues/20).

This PR also reduces the number of replicas in this deployment from 2 to 1.