### PR TITLE
Add a service_noop tag to service runners

### DIFF
--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -184,7 +184,7 @@ spec:
       imagePullPolicy: "if-not-present"
       locked: false
 
-      tags: "x86_64,x86_64_v2,small,medium,large,huge,public,aws,spack,service"
+      tags: "x86_64,x86_64_v2,small,medium,large,huge,public,aws,spack,service,service_noop"
       runUntagged: false
       secret: spack-group-runner-secret
 


### PR DESCRIPTION
This should allow other sites to pick up only noop jobs if they want.