### PR TITLE
Windows: Stop using PSScriptRoot

### DIFF
--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -67,7 +67,7 @@ spec:
             exit 1
           }
 
-          $scriptPath = Join-Path $PSScriptRoot 'pre_build.py'
+          $scriptPath = Join-Path $HOME 'pre_build.py'
 
           $wc = New-Object System.Net.WebClient
           $wc.DownloadFile('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', $scriptPath)

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -69,7 +69,7 @@ spec:
             exit 1
           }
 
-          $scriptPath = Join-Path $PSScriptRoot 'pre_build.py'
+          $scriptPath = Join-Path $HOME 'pre_build.py'
 
           $wc = New-Object System.Net.WebClient
           $wc.DownloadFile('https://raw.githubusercontent.com/spack/spack-infrastructure/main/scripts/gitlab_runner_pre_build/pre_build.py', $scriptPath)


### PR DESCRIPTION
In some contexts PSScriptRoot is not set. So far given usage it appears to be safe, but in upcoming Gitlab updates, and for other runner configurations, this value isn't set during pre-script, and will break the pre-build behavior and prevent proper upload.

Use HOME which is always set and writable