### PR TITLE
Enable consolidation on Gitlab nodes

### DIFF
--- a/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
+++ b/k8s/production/karpenter/provisioners/gitlab/provisioner.yaml
@@ -33,7 +33,7 @@ spec:
         name: default
         group: karpenter.k8s.aws
 
-  # Terminate nodes after 5 minutes of idle time
+  # Terminate nodes after 5 minutes of under-utilization
   disruption:
-    consolidationPolicy: WhenEmpty
+    consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 5m


### PR DESCRIPTION
Since gitlab pods can be scaled in response to load, we're in a situation where new nodes can be spun up to handle this load, but it's difficult to fully drain the node, to allow it to terminate. 