### PR TITLE
Update clear-admin-keys service account

### DIFF
--- a/terraform/modules/spack_aws_k8s/iam_service_accounts.tf
+++ b/terraform/modules/spack_aws_k8s/iam_service_accounts.tf
@@ -242,7 +242,7 @@ module "rotate_keys" {
             "iam:DeleteAccessKey"
           ],
           "Resource" : [
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:group/Administrators",
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:group/Custodians",
             "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/*"
           ]
         }


### PR DESCRIPTION
Update this service account to be able to list members of the 'Custodians' group. This change was originally overlooked in #1321 .