### PR TITLE
Disable snapshot cron

### DIFF
--- a/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
+++ b/k8s/production/custom/snapshot-release-tags/cron-jobs.yaml
@@ -5,6 +5,7 @@ metadata:
   name: snapshot-release-tags
   namespace: custom
 spec:
+  suspend: true
   schedule: "0 1 * * 0" # 1am on Sunday
   concurrencyPolicy: Forbid
   jobTemplate:


### PR DESCRIPTION
This cron is wrong and the rest of the infra for it does not currently work. Disable to remove noise.