### PR TITLE
SpackCIBridge: improve error handling

### DIFF
--- a/.github/images.yml
+++ b/.github/images.yml
@@ -1,6 +1,6 @@
 images:
   - path: ./images/gh-gl-sync
-    image: ghcr.io/spack/ci-bridge:0.0.48
+    image: ghcr.io/spack/ci-bridge:0.0.49
 
   - path: ./images/ci-key-clear
     image: ghcr.io/spack/ci-key-clear:0.0.4

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -178,13 +178,16 @@ class SpackCIBridge(object):
                 try:
                     merge_commit_msg = subprocess.run(
                         log_args, check=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout
-                    match = self.merge_msg_regex.match(merge_commit_msg.decode("utf-8"))
+                    match = self.merge_msg_regex.match(merge_commit_msg[:128].decode("utf-8"))
                     if match and (match.group(1) == pull.head.sha or match.group(2) == pull.head.sha):
                         print("Skip pushing {0} because GitLab already has HEAD {1}".format(pr_string, pull.head.sha))
                         push = False
                 except subprocess.CalledProcessError:
                     # This occurs when it's a new PR that hasn't been pushed to GitLab yet.
                     pass
+                except UnicodeDecodeError:
+                    print(f"Failed to UTF-8 decode commit msg for {pr_string}:\n{merge_commit_msg}")
+                    continue
 
             if push:
                 # Check the PRs-to-be-pushed to see if any of them should be considered "backlogged".
@@ -281,6 +284,11 @@ class SpackCIBridge(object):
                         # If the --main-branch CLI argument wasn't passed, or if this PR doesn't target that branch,
                         # then we will push the merge commit that was automatically created by GitHub to GitLab
                         # where it will kick off a CI pipeline.
+                        if not pull.merge_commit_sha:
+                            print("PR {0} has merge conflicts. Skipping".format(pull.number))
+                            backlogged = "merge conflicts with target branch"
+                            push = False
+                            continue
                         try:
                             _durable_subprocess_run(["git", "fetch", "--depth=2147483647", "github",
                                                     f"{pull.merge_commit_sha}:{pr_string}"])

--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.48
+            image: ghcr.io/spack/ci-bridge:0.0.49
             imagePullPolicy: IfNotPresent
             resources:
               requests:
@@ -69,7 +69,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.48
+            image: ghcr.io/spack/ci-bridge:0.0.49
             imagePullPolicy: IfNotPresent
             resources:
               requests:

--- a/k8s/production/custom/kokkos-sync/cron-jobs.yaml
+++ b/k8s/production/custom/kokkos-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.48
+            image: ghcr.io/spack/ci-bridge:0.0.49
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
This commit address a couple error conditions we encountered while setting up the SpackCIBridge for papi. In particular:

* More gracefully handle UTF-8 decoding errors when attempting to parse the merge commit message. We also attempt to avoid the issue entirely by only parsing the first 128 characters of the message.

* Better handling for the case where the GitHub PR has a merge commit when we're not using the `--main-branch` option.