### PR TITLE
Allow github actions to put objects to source mirror

### DIFF
--- a/terraform/modules/spack_aws_k8s/eks.tf
+++ b/terraform/modules/spack_aws_k8s/eks.tf
@@ -44,7 +44,7 @@ module "eks" {
     var.deployment_name == "prod" ? {
       github_actions_drift_detection = {
         kubernetes_groups = []
-        principal_arn     = aws_iam_role.github_actions[0].arn
+        principal_arn     = aws_iam_role.github_actions_readonly[0].arn
 
         policy_associations = {
           cluster = {

--- a/terraform/modules/spack_aws_k8s/github_actions_iam.tf
+++ b/terraform/modules/spack_aws_k8s/github_actions_iam.tf
@@ -74,3 +74,60 @@ resource "aws_iam_role_policy_attachment" "github_actions_readonly" {
   role       = aws_iam_role.github_actions_readonly[0].name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
+
+
+# Allow github actions run from the develop branch of spack/spack to put objects into the source mirror
+resource "aws_iam_role" "github_actions_put_to_source_mirror" {
+  count = var.deployment_name == "prod" ? 1 : 0
+
+  name = "GitHubLLNLSourceMirror"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_actions[0].arn
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:spack/spack:ref:refs/heads/develop"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "github_actions_put_to_source_mirror" {
+  count = var.deployment_name == "prod" ? 1 : 0
+
+  name = "PutToSpackLLNLSourceMirror"
+  role = aws_iam_role.github_actions_put_to_source_mirror[0].name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "PutToSpackLLNLSourceMirror"
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = "arn:aws:s3:::spack-llnl-mirror/_source-cache/*"
+      },
+      {
+        Sid      = "ListSpackLLNLSourceMirror"
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = "arn:aws:s3:::spack-llnl-mirror"
+        Condition = {
+          StringLike = {
+            "s3:prefix" = ["_source-cache/*"]
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/modules/spack_aws_k8s/github_actions_iam.tf
+++ b/terraform/modules/spack_aws_k8s/github_actions_iam.tf
@@ -1,7 +1,3 @@
-locals {
-  iam_role_name = "GitHubActionsReadonlyRole"
-}
-
 data "tls_certificate" "github_actions" {
   url = "https://token.actions.githubusercontent.com"
 }
@@ -14,10 +10,10 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
   thumbprint_list = [data.tls_certificate.github_actions.certificates.0.sha1_fingerprint]
 }
 
-resource "aws_iam_role" "github_actions" {
+resource "aws_iam_role" "github_actions_readonly" {
   count = var.deployment_name == "prod" ? 1 : 0
 
-  name        = local.iam_role_name
+  name        = "GitHubActionsReadonlyRole"
   description = "Managed by Terraform. IAM Role that a GitHub Actions runner can assume to authenticate with AWS."
 
   assume_role_policy = jsonencode({
@@ -50,11 +46,11 @@ resource "aws_iam_role" "github_actions" {
 }
 
 # The `ReadOnlyAccess` managed policy doesn't include secretsmanager, so we explicitly grant it here.
-resource "aws_iam_role_policy" "github_actions" {
+resource "aws_iam_role_policy" "github_actions_readonly" {
   count = var.deployment_name == "prod" ? 1 : 0
 
   name = "read-secrets"
-  role = aws_iam_role.github_actions[0].id
+  role = aws_iam_role.github_actions_readonly[0].id
 
   policy = jsonencode({
     "Version" : "2012-10-17",
@@ -72,9 +68,9 @@ resource "aws_iam_role_policy" "github_actions" {
 
 # This policy grants the GitHub Actions role read-only access to most resources in the AWS account.
 # There are some exceptions, such as secretsmanager (see inline_policy above)
-resource "aws_iam_role_policy_attachment" "github_actions" {
+resource "aws_iam_role_policy_attachment" "github_actions_readonly" {
   count = var.deployment_name == "prod" ? 1 : 0
 
-  role       = aws_iam_role.github_actions[0].name
+  role       = aws_iam_role.github_actions_readonly[0].name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }


### PR DESCRIPTION
Supersedes #1343 

cc @alecbcs 