### PR TITLE
Enable auto-scaling for CoreDNS pods

### DIFF
--- a/terraform/modules/spack_aws_k8s/eks.tf
+++ b/terraform/modules/spack_aws_k8s/eks.tf
@@ -48,6 +48,21 @@ module "eks" {
     coredns = {
       # https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html#coredns-versions
       addon_version = "v1.12.4-eksbuild.1"
+      # Based on this example of CoreDNS configuration
+      # https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#what-configuration-values-are-available-for-an-add-on
+      configuration_values = jsonencode({
+        replicaCount = 4,
+        resources = {
+          requests = {
+            cpu    = "200m"
+            memory = "128Mi"
+          },
+          limits = {
+            cpu    = "400m"
+            memory = "256Mi"
+          }
+        }
+      })
     }
     eks-pod-identity-agent = {
       addon_version = "v1.3.9-eksbuild.3"

--- a/terraform/modules/spack_aws_k8s/eks.tf
+++ b/terraform/modules/spack_aws_k8s/eks.tf
@@ -51,7 +51,11 @@ module "eks" {
       # Based on this example of CoreDNS configuration
       # https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#what-configuration-values-are-available-for-an-add-on
       configuration_values = jsonencode({
-        replicaCount = 4,
+        autoScaling = {
+          enabled     = true
+          minReplicas = 2
+          maxReplicas = 10
+        },
         resources = {
           requests = {
             cpu    = "200m"
@@ -61,7 +65,7 @@ module "eks" {
             cpu    = "400m"
             memory = "256Mi"
           }
-        }
+        },
       })
     }
     eks-pod-identity-agent = {


### PR DESCRIPTION
The goal of this is to reduce flakiness in host name resolution by ensuring that CoreDNS isn't overloaded.