### PR TITLE
Enable adaptive request concurrency for runners

### DIFF
--- a/k8s/production/runners/protected/graviton/3/release.yaml
+++ b/k8s/production/runners/protected/graviton/3/release.yaml
@@ -77,7 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm-latest"
             privileged = false

--- a/k8s/production/runners/protected/graviton/4/release.yaml
+++ b/k8s/production/runners/protected/graviton/4/release.yaml
@@ -77,7 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm64-latest"
             privileged = false

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -92,6 +92,7 @@ spec:
 
           # Ensure windows paths are used
           [runners.feature_flags]
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
             FF_USE_POWERSHELL_PATH_RESOLVER = true
 
           [runners.kubernetes]

--- a/k8s/production/runners/protected/x86_64/v2/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2/release.yaml
@@ -77,7 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/protected/x86_64/v3/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v3/release.yaml
@@ -77,7 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/protected/x86_64/v4/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v4/release.yaml
@@ -77,7 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/graviton/3/release.yaml
+++ b/k8s/production/runners/public/graviton/3/release.yaml
@@ -77,7 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm-latest"
             privileged = false

--- a/k8s/production/runners/public/graviton/4/release.yaml
+++ b/k8s/production/runners/public/graviton/4/release.yaml
@@ -77,7 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:arm64-latest"
             privileged = false

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -93,6 +93,7 @@ spec:
 
           # Ensure windows paths are used
           [runners.feature_flags]
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
             FF_USE_POWERSHELL_PATH_RESOLVER = true
 
           [runners.kubernetes]

--- a/k8s/production/runners/public/x86_64/v2/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2/release.yaml
@@ -79,7 +79,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/x86_64/v3/release.yaml
+++ b/k8s/production/runners/public/x86_64/v3/release.yaml
@@ -77,7 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/public/x86_64/v4/release.yaml
+++ b/k8s/production/runners/public/x86_64/v4/release.yaml
@@ -77,7 +77,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"

--- a/k8s/production/runners/signing/release.yaml
+++ b/k8s/production/runners/signing/release.yaml
@@ -78,7 +78,11 @@ spec:
           """
 
           output_limit = 20480
-          environment = ["FF_GITLAB_REGISTRY_HELPER_IMAGE=1"]
+
+          [runners.feature_flags]
+            FF_GITLAB_REGISTRY_HELPER_IMAGE = true
+            FF_USE_ADAPTIVE_REQUEST_CONCURRENCY = true
+
           [runners.kubernetes]
             privileged = false
             helper_memory_request = "512M"


### PR DESCRIPTION
Many runners are throwing warnings about request bottlenecks. The docs suggest enabling this setting, which will automatically scale the request concurrency value based on load.