### PR TITLE
Bump gitlab webservice resource requests

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -155,7 +155,7 @@ spec:
         minReplicas: 4
         maxReplicas: 16
         resources:
-          # Requested values are based on the following Prometheus queries:
+          # Prometheus queries to check for usage values
           # cpu:
           #   sum(rate(container_cpu_usage_seconds_total{namespace="gitlab", pod=~"gitlab-webservice-.*"}[5m])) by (pod)
           # memory:
@@ -164,7 +164,7 @@ spec:
             cpu: 12
             memory: 20G
           requests:
-            cpu: 1250m
+            cpu: 3
             memory: 10G
         nodeSelector:
           spack.io/node-pool: gitlab


### PR DESCRIPTION
It seems our webservice pods are using more than they're requesting, potentially causing slowdowns. 