### PR TITLE
Bump Gitlab DB instance to db.r8gd.xlarge

### DIFF
--- a/terraform/modules/spack_aws_k8s/analytics_db.tf
+++ b/terraform/modules/spack_aws_k8s/analytics_db.tf
@@ -17,7 +17,7 @@ module "analytics_db" {
   engine               = "postgres"
   family               = "postgres15"
   major_engine_version = "15"
-  instance_class       = var.gitlab_db_instance_class
+  instance_class       = "db.t4g.xlarge"
 
   # Credentials
   db_name                     = "analytics"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -9,7 +9,7 @@ module "spack_aws_k8s" {
 
   flux_path = "k8s/production/"
 
-  gitlab_db_instance_class    = "db.t4g.xlarge"
+  gitlab_db_instance_class    = "db.r8gd.xlarge"
   gitlab_redis_instance_class = "cache.m6g.xlarge"
   cdash_db_instance_class     = "db.m6g.large"
   opensearch_instance_type    = "r6g.xlarge.search"


### PR DESCRIPTION
The gitlab database seems overloaded in terms of both CPU usage, and disk usage (high writes). Upgrading to this new instance type attempts to address both, with more of a bias towards disk write performance. 