### PR TITLE
Bump Gitlab DB IOPS to 24,000, throughput to 1,000

### DIFF
--- a/terraform/modules/spack_aws_k8s/gitlab_db.tf
+++ b/terraform/modules/spack_aws_k8s/gitlab_db.tf
@@ -44,8 +44,8 @@ module "gitlab_db" {
   allocated_storage     = 500
   max_allocated_storage = 1000
   storage_type          = "gp3"
-  iops                  = 12000 # 12,000 is the minimum IOPs for gp3 storage. We can increase this as needed.
-  storage_throughput    = 500   # 500 is the minimum throughput for gp3 storage. We can increase this as needed.
+  iops                  = 24000 # 12,000 is the minimum IOPs for gp3 storage.
+  storage_throughput    = 1000  # 500 is the minimum throughput for gp3 storage.
 
   vpc_security_group_ids = [module.postgres_security_group.security_group_id]
 }


### PR DESCRIPTION
I believe our Gitlab RDS instance is under-provisioned in these configuration values, both from observing the metrics, as well as a warning in the AWS console.