### PR TITLE
Remove temporary pin to gitlab-exporter image

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -169,11 +169,6 @@ spec:
         nodeSelector:
           spack.io/node-pool: gitlab
       gitlab-exporter:
-        # The gitlab helm chart bumped the image version of gitlab-exporter they use to 16.8.0, but 16.8.0 is not
-        # published here https://gitlab.com/gitlab-org/build/CNG/container_registry/673222
-        # Once 16.8.0 is published, we can use that and remove this image tag specifier
-        image:
-          tag: 16.7.0
         nodeSelector:
           spack.io/node-pool: gitlab
 


### PR DESCRIPTION
Follow up to #1363 