### PR TITLE
Add WAF for spack cluster gateway

### DIFF
--- a/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
+++ b/terraform/modules/spack_aws_k8s/bootstrap_s3.tf
@@ -1,8 +1,3 @@
-locals {
-  domain_suffix      = var.deployment_name == "prod" ? "" : "${var.deployment_name}."
-  bucket_name_suffix = var.deployment_name == "prod" ? "" : "-${var.deployment_name}"
-}
-
 resource "aws_s3_bucket" "bootstrap" {
   bucket = "spack-bootstrap${local.bucket_name_suffix}"
 }

--- a/terraform/modules/spack_aws_k8s/locals.tf
+++ b/terraform/modules/spack_aws_k8s/locals.tf
@@ -1,5 +1,7 @@
 locals {
-  suffix = "${var.deployment_name != "prod" ? "-${var.deployment_name}" : ""}-${var.deployment_stage}"
+  suffix             = "${var.deployment_name != "prod" ? "-${var.deployment_name}" : ""}-${var.deployment_stage}"
+  domain_suffix      = var.deployment_name == "prod" ? "" : "${var.deployment_name}."
+  bucket_name_suffix = var.deployment_name == "prod" ? "" : "-${var.deployment_name}"
 }
 
 locals {

--- a/terraform/modules/spack_aws_k8s/waf.tf
+++ b/terraform/modules/spack_aws_k8s/waf.tf
@@ -5,6 +5,15 @@ resource "aws_wafv2_ip_set" "vpc_nat_ips" {
   addresses          = [for ip in module.vpc.nat_public_ips : "${ip}/32"]
 }
 
+resource "aws_wafv2_ip_set" "allowed_ips" {
+  name               = "allowed-ips${local.suffix}"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses = [
+    "128.223.202.0/24", # UO's IP block
+  ]
+}
+
 resource "aws_wafv2_web_acl" "gateway" {
   name        = "spack-gateway-waf${local.suffix}"
   scope       = "REGIONAL"
@@ -36,9 +45,31 @@ resource "aws_wafv2_web_acl" "gateway" {
     }
   }
 
+  # Allow requests from trusted IP ranges
+  rule {
+    name     = "AllowTrustedIps"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.allowed_ips.arn
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AllowTrustedIps"
+    }
+  }
+
   rule {
     name     = "AWS-AWSManagedRulesAmazonIpReputationList"
-    priority = 1
+    priority = 2
 
     override_action {
       none {}
@@ -81,7 +112,7 @@ resource "aws_wafv2_web_acl" "gateway" {
 
   rule {
     name     = "AWS-AWSManagedRulesCommonRuleSet"
-    priority = 2
+    priority = 3
 
     override_action {
       none {}
@@ -103,7 +134,7 @@ resource "aws_wafv2_web_acl" "gateway" {
 
   rule {
     name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
-    priority = 3
+    priority = 4
 
     override_action {
       none {}
@@ -125,7 +156,7 @@ resource "aws_wafv2_web_acl" "gateway" {
 
   rule {
     name     = "AWS-AWSManagedRulesBotControlRuleSet"
-    priority = 4
+    priority = 5
 
     override_action {
       none {}
@@ -147,7 +178,7 @@ resource "aws_wafv2_web_acl" "gateway" {
 
   rule {
     name     = "AWS-AWSManagedRulesAnonymousIpList"
-    priority = 5
+    priority = 6
 
     override_action {
       none {}
@@ -170,7 +201,7 @@ resource "aws_wafv2_web_acl" "gateway" {
   # Issue a javascript-based challenge to any remaining requests
   rule {
     name     = "gitlab-challenge"
-    priority = 6
+    priority = 7
 
     action {
       challenge {}

--- a/terraform/modules/spack_aws_k8s/waf.tf
+++ b/terraform/modules/spack_aws_k8s/waf.tf
@@ -11,6 +11,7 @@ resource "aws_wafv2_ip_set" "allowed_ips" {
   ip_address_version = "IPV4"
   addresses = [
     "128.223.202.0/24", # UO's IP block
+    "66.194.253.20/32"  # Kitware's VPN
   ]
 }
 

--- a/terraform/modules/spack_aws_k8s/waf.tf
+++ b/terraform/modules/spack_aws_k8s/waf.tf
@@ -156,30 +156,8 @@ resource "aws_wafv2_web_acl" "gateway" {
   }
 
   rule {
-    name     = "AWS-AWSManagedRulesBotControlRuleSet"
-    priority = 5
-
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        vendor_name = "AWS"
-        name        = "AWSManagedRulesBotControlRuleSet"
-      }
-    }
-
-    visibility_config {
-      sampled_requests_enabled   = true
-      cloudwatch_metrics_enabled = true
-      metric_name                = "AWS-AWSManagedRulesBotControlRuleSet"
-    }
-  }
-
-  rule {
     name     = "AWS-AWSManagedRulesAnonymousIpList"
-    priority = 6
+    priority = 5
 
     override_action {
       none {}
@@ -196,6 +174,32 @@ resource "aws_wafv2_web_acl" "gateway" {
       sampled_requests_enabled   = true
       cloudwatch_metrics_enabled = true
       metric_name                = "AWS-AWSManagedRulesAnonymousIpList"
+    }
+  }
+
+  # BotControl is a paid rule group (charged per request inspected). It runs last among the
+  # managed rule groups so that cheaper rules (IP reputation, common, anonymous IP) can block
+  # requests before they reach it. The scope-down statement further excludes health-check and
+  # static asset requests that don't need bot inspection.
+  rule {
+    name     = "AWS-AWSManagedRulesBotControlRuleSet"
+    priority = 6
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesAnonymousIpList"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesBotControlRuleSet"
     }
   }
 

--- a/terraform/modules/spack_aws_k8s/waf.tf
+++ b/terraform/modules/spack_aws_k8s/waf.tf
@@ -1,0 +1,212 @@
+resource "aws_wafv2_ip_set" "vpc_nat_ips" {
+  name               = "vpc-nat-ips${local.suffix}"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = [for ip in module.vpc.nat_public_ips : "${ip}/32"]
+}
+
+resource "aws_wafv2_web_acl" "gateway" {
+  name        = "spack-gateway-waf${local.suffix}"
+  scope       = "REGIONAL"
+  description = "WAF protection for the spack Gateway ALB"
+
+  default_action {
+    allow {}
+  }
+
+  # Allow requests originating from inside the cluster VPC
+  rule {
+    name     = "AllowVpcNatIps"
+    priority = 0
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.vpc_nat_ips.arn
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AllowVpcNatIps"
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesAmazonIpReputationList"
+
+        rule_action_override {
+          name = "AWSManagedIPReputationList"
+          action_to_use {
+            block {}
+          }
+        }
+
+        rule_action_override {
+          name = "AWSManagedReconnaissanceList"
+          action_to_use {
+            block {}
+          }
+        }
+
+        rule_action_override {
+          name = "AWSManagedIPDDoSList"
+          action_to_use {
+            count {}
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAmazonIpReputationList"
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 3
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesBotControlRuleSet"
+    priority = 4
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesBotControlRuleSet"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesBotControlRuleSet"
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAnonymousIpList"
+    priority = 5
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesAnonymousIpList"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAnonymousIpList"
+    }
+  }
+
+  # Issue a javascript-based challenge to any remaining requests
+  rule {
+    name     = "gitlab-challenge"
+    priority = 6
+
+    action {
+      challenge {}
+    }
+
+    statement {
+      byte_match_statement {
+        search_string = "gitlab.${local.domain_suffix}spack.io"
+        field_to_match {
+          single_header {
+            name = "host"
+          }
+        }
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+        positional_constraint = "EXACTLY"
+      }
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "gitlab-challenge"
+    }
+  }
+
+  visibility_config {
+    sampled_requests_enabled   = true
+    cloudwatch_metrics_enabled = true
+    metric_name                = "spack-gateway-waf${local.suffix}"
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "gateway" {
+  resource_arn = data.aws_lb.gateway.arn
+  web_acl_arn  = aws_wafv2_web_acl.gateway.arn
+}


### PR DESCRIPTION
This change configures the staging and prod application load balancers (ALBs) with a [Web Application Firewall](https://aws.amazon.com/waf/) (WAF).

The current configuration allows for all traffic that originates from the following sources:

1. From within the respective cluster (to allow internal services to run)
2. From the University of Oregon IP block (to allow runners to register)
3. From within Kitware's VPN (to allow Terraform and/or other admin operations)

If traffic does not originate from those sources, it goes through several AWS managed rules (geared towards bot detection), before finally going through a [challenge](https://docs.aws.amazon.com/waf/latest/developerguide/waf-captcha-and-challenge.html). The challenge is run in the background of the browser, so it does not impact real users. I do believe this is a weaker gate than a CAPTCHA, and if required, we could change this to a CAPTCHA.