### PR TITLE
gitlab: add startupProbe and loosen readinessProbe

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -154,6 +154,23 @@ spec:
             secretName: tls-gitlab-webservice
         minReplicas: 4
         maxReplicas: 32
+        deployment:
+          # Use a startupProbe to gate liveness/readiness until Puma finishes
+          # booting.
+          startupProbe:
+            httpGet:
+              path: /-/readiness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 30  # Give Puma 5 minutes (30 * 10s) to boot
+            timeoutSeconds: 5
+          readinessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 4   # Consider pod unready after 20 seconds (5 * 4)
         resources:
           # Prometheus queries to check for usage values
           # cpu:


### PR DESCRIPTION
We've recently noticed webservice pods getting killed by kubelet before Puma finishes booting.

This commits add a startupProbe to give newly created webservice pods five minutes to complete the Puma bootup sequence before enabling the readiness and liveness probes.

This commit also increases the webservice readiness timeout from 10s to 20s.