### PR TITLE
SpackCIBridge: don't post status when required label is missing

### DIFF
--- a/.github/images.yml
+++ b/.github/images.yml
@@ -1,6 +1,6 @@
 images:
   - path: ./images/gh-gl-sync
-    image: ghcr.io/spack/ci-bridge:0.0.50
+    image: ghcr.io/spack/ci-bridge:0.0.51
 
   - path: ./images/ci-key-clear
     image: ghcr.io/spack/ci-key-clear:0.0.4

--- a/images/gh-gl-sync/SpackCIBridge.py
+++ b/images/gh-gl-sync/SpackCIBridge.py
@@ -215,8 +215,8 @@ class SpackCIBridge(object):
                 if not backlogged and self.required_label:
                     if not any(label.name == self.required_label for label in pull.labels):
                         push = False
-                        backlogged = f"Missing label '{self.required_label}'"
-                        print("Skip pushing {0} because of {1}".format(pr_string, backlogged))
+                        backlogged = "missing_label"
+                        print("Skip pushing {0} because of missing label '{1}'".format(pr_string, self.required_label))
 
                 if not backlogged:
                     check_for_deferral = not any(label.name == 'pipelines:urgent' for label in pull.labels)
@@ -603,6 +603,9 @@ class SpackCIBridge(object):
         for branch, head_sha, reason in backlog_branches:
             if reason == "stale":
                 print("Skip posting status for {} because it has not been updated recently".format(branch))
+                continue
+            elif reason == "missing_label":
+                print("Skip posting status for {} because required label is not present".format(branch))
                 continue
             elif reason == "base":
                 desc = base_backlog_desc

--- a/images/gh-gl-sync/test_SpackCIBridge.py
+++ b/images/gh-gl-sync/test_SpackCIBridge.py
@@ -584,3 +584,32 @@ def test_pipeline_status_backlogged_for_draft_PR(capfd):
   pr1_readme -> shabaz"""
     assert expected_content in out
     del os.environ["GITHUB_TOKEN"]
+
+
+def test_pipeline_status_not_posted_for_missing_label(capfd):
+    """Test that post_pipeline_status posts no status when required_label is not found on the PR."""
+    open_prs = {
+        "pr_strings": ["pr1_readme"],
+        "base_shas": ["shafoo"],
+        "head_shas": ["shabaz"],
+        "backlogged": ["missing_label"]
+    }
+
+    gh_commit = Mock()
+    gh_commit.get_combined_status.return_value = AttrDict({'statuses': []})
+    gh_commit.create_status.return_value = AttrDict({"state": "pending"})
+    gh_repo = Mock()
+    gh_repo.get_commit.return_value = gh_commit
+
+    bridge = SpackCIBridge.SpackCIBridge(gitlab_host="https://gitlab.spack.io",
+                                         gitlab_project="zack/my_test_proj",
+                                         github_project="zack/my_test_proj",
+                                         main_branch="develop")
+    bridge.py_gh_repo = gh_repo
+    os.environ["GITHUB_TOKEN"] = "my_github_token"
+
+    bridge.post_pipeline_status(open_prs, [])
+    assert gh_commit.create_status.call_count == 0
+    out, err = capfd.readouterr()
+    assert "Skip posting status for pr1_readme because required label is not present" in out
+    del os.environ["GITHUB_TOKEN"]

--- a/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
+++ b/k8s/production/custom/gh-gl-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.50
+            image: ghcr.io/spack/ci-bridge:0.0.51
             imagePullPolicy: IfNotPresent
             resources:
               requests:
@@ -69,7 +69,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.50
+            image: ghcr.io/spack/ci-bridge:0.0.51
             imagePullPolicy: IfNotPresent
             resources:
               requests:

--- a/k8s/production/custom/kokkos-sync/cron-jobs.yaml
+++ b/k8s/production/custom/kokkos-sync/cron-jobs.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: sync
-            image: ghcr.io/spack/ci-bridge:0.0.50
+            image: ghcr.io/spack/ci-bridge:0.0.51
             imagePullPolicy: IfNotPresent
             resources:
               requests:


### PR DESCRIPTION
Prior to this commit, the sync script would post a pending status to PRs on GitHub that are missing the project-specific label that's required for GitLab CI testing to start.

Users found this confusing because it makes it appear as if CI has not finished running yet. Instead we now opt not to post any status at all in this situation A skipped status would be better, but that is only supported from "checks" (GitHub Actions), not "statuses".