### PR TITLE
Configure our RDS proxy to avoid session pinning

### DIFF
--- a/terraform/modules/spack_aws_k8s/gitlab_db.tf
+++ b/terraform/modules/spack_aws_k8s/gitlab_db.tf
@@ -111,6 +111,13 @@ module "gitlab_db_proxy" {
   engine_family = "POSTGRESQL"
   debug_logging = false
 
+  # Without this, RDS Proxy pins a client session to a dedicated backend
+  # connection as soon as it sees a SET statement, which Rails' pg gem issues
+  # on every connection checkout (e.g. statement_timeout). That defeats
+  # connection multiplexing and makes the proxy pass through ~1 backend
+  # connection per Puma/Sidekiq thread instead of pooling them.
+  session_pinning_filters = ["EXCLUDE_VARIABLE_SETS"]
+
   target_db_instance     = true
   db_instance_identifier = module.gitlab_db.db_instance_identifier
 }


### PR DESCRIPTION
By default, RDS Proxy pins a client session to a dedicated backend connection whenever a SET statement is executed.  Rails' pg gem issues SET statements on every connection, thwarting our attempts to multiplex connections using RDS proxy. As a result, the proxy uses a separate backend connection for each Puma/Sidekiq thread instead of pooling them.

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy-pinning.html#rds-proxy-pinning.postgres

This commit aims to improve this situation by using a *session pinning filter* to instruct the proxy to ignore SET statements when determining whether a session should be pinned or not.

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy-best-practices.configuration.html