### PR TITLE
Fix common bot control rule config

### DIFF
--- a/terraform/modules/spack_aws_k8s/waf.tf
+++ b/terraform/modules/spack_aws_k8s/waf.tf
@@ -192,7 +192,13 @@ resource "aws_wafv2_web_acl" "gateway" {
     statement {
       managed_rule_group_statement {
         vendor_name = "AWS"
-        name        = "AWSManagedRulesAnonymousIpList"
+        name        = "AWSManagedRulesBotControlRuleSet"
+
+        managed_rule_group_configs {
+          aws_managed_rules_bot_control_rule_set {
+            inspection_level = "COMMON"
+          }
+        }
       }
     }
 


### PR DESCRIPTION
This enables count mode for the aws managed bot control rule set. It was previously misconfigured.