### PR TITLE
Bump Gitlab DB instance to db.m7g.4xlarge

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -12,7 +12,7 @@ module "spack_aws_k8s" {
   enable_analytics_db         = true
   analytics_db_instance_class = "db.t4g.xlarge"
 
-  gitlab_db_instance_class    = "db.t4g.xlarge"
+  gitlab_db_instance_class    = "db.m7g.4xlarge"
   gitlab_redis_instance_class = "cache.m6g.xlarge"
 
   cdash_db_instance_class = "db.m6g.large"


### PR DESCRIPTION
We are routinely low on memory and see high CPU spikes in the gitlab database. The current gitlab DB instance type is `db.t4g.xlarge`, which has 4cpu and 16gb of memory. The new instance type of `db.m7g.4xlarge` has 16cpu and 64gb of memory.