### PR TITLE
Add analytics DB variables to spack_aws_k8s module

### DIFF
--- a/terraform/modules/spack_aws_k8s/analytics_db.tf
+++ b/terraform/modules/spack_aws_k8s/analytics_db.tf
@@ -1,14 +1,20 @@
 resource "aws_db_subnet_group" "analytics_db" {
+  count = var.enable_analytics_db ? 1 : 0
+
   name       = "spack-analytics${local.suffix}"
   subnet_ids = module.vpc.private_subnets
 }
 
 resource "random_password" "analytics_db_password" {
+  count = var.enable_analytics_db ? 1 : 0
+
   length           = 32
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
 module "analytics_db" {
+  count = var.enable_analytics_db ? 1 : 0
+
   source  = "terraform-aws-modules/rds/aws"
   version = "6.10.0"
 
@@ -17,17 +23,17 @@ module "analytics_db" {
   engine               = "postgres"
   family               = "postgres15"
   major_engine_version = "15"
-  instance_class       = var.gitlab_db_instance_class
+  instance_class       = var.analytics_db_instance_class
 
   # Credentials
   db_name                     = "analytics"
   username                    = "postgres"
   port                        = "5432"
-  password                    = random_password.analytics_db_password.result
+  password                    = random_password.analytics_db_password[0].result
   manage_master_user_password = false
 
   publicly_accessible  = false
-  db_subnet_group_name = aws_db_subnet_group.analytics_db.name
+  db_subnet_group_name = aws_db_subnet_group.analytics_db[0].name
 
   maintenance_window              = "Sun:00:00-Sun:03:00"
   backup_window                   = "03:00-06:00"
@@ -51,6 +57,8 @@ module "analytics_db" {
 }
 
 resource "kubectl_manifest" "webhook_analytics_db_secrets" {
+  count = var.enable_analytics_db ? 1 : 0
+
   yaml_body = <<-YAML
     apiVersion: v1
     kind: Secret
@@ -58,7 +66,7 @@ resource "kubectl_manifest" "webhook_analytics_db_secrets" {
       name: webhook-handler-db
       namespace: custom
     stringData:
-      analytics-postgresql-host: "${module.analytics_db.db_instance_address}"
-      analytics-postgresql-password: "${random_password.analytics_db_password.result}"
+      analytics-postgresql-host: "${module.analytics_db[0].db_instance_address}"
+      analytics-postgresql-password: "${random_password.analytics_db_password[0].result}"
   YAML
 }

--- a/terraform/modules/spack_aws_k8s/prometheus.tf
+++ b/terraform/modules/spack_aws_k8s/prometheus.tf
@@ -38,17 +38,5 @@ resource "kubectl_manifest" "prometheus_additional_datasources_secret" {
                 password: "${jsondecode(data.aws_secretsmanager_secret_version.gitlab_db_ro_credentials.secret_string)["password"]}"
               jsonData:
                 postgresVersion: 14
-            - name: AnalyticsDB
-              type: postgres
-              uid: XCh6DDkSz
-              access: proxy
-              url: ${module.analytics_db.db_instance_address}
-              user: postgres
-              database: analytics
-              secureJsonData:
-                password: "${random_password.analytics_db_password.result}"
-              jsonData:
-                postgresVersion: 15
-
   YAML
 }

--- a/terraform/modules/spack_aws_k8s/variables.tf
+++ b/terraform/modules/spack_aws_k8s/variables.tf
@@ -15,6 +15,18 @@ variable "flux_path" {
   type        = string
 }
 
+variable "enable_analytics_db" {
+  description = "Whether to provision the analytics PostgreSQL database."
+  type        = bool
+  default     = true
+}
+
+variable "analytics_db_instance_class" {
+  description = "AWS RDS DB instance class for the analytics PostgreSQL database."
+  type        = string
+  default     = "db.t4g.xlarge"
+}
+
 variable "gitlab_db_instance_class" {
   description = "AWS RDS DB instance class for the Spack GitLab PostgreSQL database."
   type        = string

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -9,11 +9,16 @@ module "spack_aws_k8s" {
 
   flux_path = "k8s/production/"
 
+  enable_analytics_db         = true
+  analytics_db_instance_class = "db.t4g.xlarge"
+
   gitlab_db_instance_class    = "db.t4g.xlarge"
   gitlab_redis_instance_class = "cache.m6g.xlarge"
-  cdash_db_instance_class     = "db.m6g.large"
-  opensearch_instance_type    = "r6g.xlarge.search"
-  opensearch_volume_size      = 500
+
+  cdash_db_instance_class = "db.m6g.large"
+
+  opensearch_instance_type = "r6g.xlarge.search"
+  opensearch_volume_size   = 500
 }
 
 module "spack_gitlab" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -8,11 +8,15 @@ module "spack_aws_k8s" {
 
   flux_path = "k8s/staging/"
 
+  enable_analytics_db = false
+
   gitlab_db_instance_class    = "db.t4g.small"
   gitlab_redis_instance_class = "cache.t4g.small"
-  cdash_db_instance_class     = "db.t4g.small"
-  opensearch_instance_type    = "t3.small.search"
-  opensearch_volume_size      = 100
+
+  cdash_db_instance_class = "db.t4g.small"
+
+  opensearch_instance_type = "t3.small.search"
+  opensearch_volume_size   = 100
 }
 
 module "spack_gitlab" {


### PR DESCRIPTION
This refactors the analytics db terraform configuration to skip provisioning in staging, since we don't use it. It also removes the inclusion of the analytics database in the list of grafana datasources, because we don't use that either.

This terraform refactor is applied in staging and prod.