### PR TITLE
Bump gitaly CPU request to 24

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -223,7 +223,7 @@ spec:
       gitaly:
         resources:
           requests:
-            cpu: 15000m
+            cpu: 24
             memory: 20Gi
         nodeSelector:
           spack.io/node-pool: gitlab


### PR DESCRIPTION
I noticed the gitaly pod exceeding it's CPU request (in a spike), so I bumped the request to 24 vCPU. This is one of the services we run that if anything, we should over-provision.