### PR TITLE
Revert "Bump gitaly CPU request to 24"

### DIFF
--- a/k8s/production/gitlab/release.yaml
+++ b/k8s/production/gitlab/release.yaml
@@ -223,7 +223,7 @@ spec:
       gitaly:
         resources:
           requests:
-            cpu: 24
+            cpu: 15000m
             memory: 20Gi
         nodeSelector:
           spack.io/node-pool: gitlab


### PR DESCRIPTION
This reverts commit 9ef555fa99c3cfd9d29821bee0c7d8e42bcb4e7e.

This change had unintended consequences and so is being reverted.