### PR TITLE
Bump windows-build value in windows x86-v2 runners

### DIFF
--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -113,9 +113,9 @@ spec:
             poll_timeout = 1800
             service_account = "runner"
 
-            # Image for windows 2022, runner helper
-            image = "mcr.microsoft.com/windows/servercore:ltsc2022"
-            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v19.2.0-servercore21H2"
+            # Image for windows 2025, runner helper
+            image = "mcr.microsoft.com/windows/servercore:ltsc2025"
+            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v19.2.0-servercore24H2"
 
             ephemeral_storage_request = "500M"
             helper_ephemeral_storage_request = "500M"
@@ -171,7 +171,7 @@ spec:
               read_only = true
 
       # default image
-      image: "mcr.microsoft.com/windows/servercore:ltsc2022"
+      image: "mcr.microsoft.com/windows/servercore:ltsc2025"
       imagePullPolicy: "if-not-present"
 
       locked: true

--- a/k8s/production/runners/protected/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/protected/x86_64/v2-win/release.yaml
@@ -158,9 +158,9 @@ spec:
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/os" = "windows"
-              # This is required to match the helper image based on this table
+              # This is required to match the helper image (currently 24H2) based on this table:
               # https://gitlab.com/gitlab-org/gitlab-runner/-/blob/main/helpers/container/windows/version.go?ref_type=heads#L19-32
-              "node.kubernetes.io/windows-build" = "10.0.20348"
+              "node.kubernetes.io/windows-build" = "10.0.26100"
             [runners.kubernetes.node_tolerations]
               "spack.io/runner-taint=true" = "NoSchedule"
               "windows=true" = "NoSchedule"

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -159,9 +159,9 @@ spec:
               "metrics/spack_spec_needs_rebuild" = "$SPACK_SPEC_NEEDS_REBUILD"
             [runners.kubernetes.node_selector]
               "kubernetes.io/os" = "windows"
-              # This is required to match the helper image based on this table
+              # This is required to match the helper image (currently 24H2) based on this table:
               # https://gitlab.com/gitlab-org/gitlab-runner/-/blob/main/helpers/container/windows/version.go?ref_type=heads#L19-32
-              "node.kubernetes.io/windows-build" = "10.0.20348"
+              "node.kubernetes.io/windows-build" = "10.0.26100"
             [runners.kubernetes.node_tolerations]
               "spack.io/runner-taint=true" = "NoSchedule"
               "windows=true" = "NoSchedule"

--- a/k8s/production/runners/public/x86_64/v2-win/release.yaml
+++ b/k8s/production/runners/public/x86_64/v2-win/release.yaml
@@ -114,9 +114,9 @@ spec:
             poll_timeout = 1800
             service_account = "runner"
 
-            # Image for windows 2022, runner helper
-            image = "mcr.microsoft.com/windows/servercore:ltsc2022"
-            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v19.2.0-servercore21H2"
+            # Image for windows 2025, runner helper
+            image = "mcr.microsoft.com/windows/servercore:ltsc2025"
+            helper_image = "registry.gitlab.com/gitlab-org/gitlab-runner/gitlab-runner-helper:x86_64-v19.2.0-servercore24H2"
 
             ephemeral_storage_request = "500M"
             helper_ephemeral_storage_request = "500M"
@@ -167,7 +167,7 @@ spec:
               "windows=true" = "NoSchedule"
 
       # default image
-      image: "mcr.microsoft.com/windows/servercore:ltsc2022"
+      image: "mcr.microsoft.com/windows/servercore:ltsc2025"
       imagePullPolicy: "if-not-present"
       locked: false
 

--- a/terraform/modules/spack_aws_k8s/karpenter.tf
+++ b/terraform/modules/spack_aws_k8s/karpenter.tf
@@ -109,9 +109,9 @@ resource "kubectl_manifest" "karpenter_windows_node_class" {
     metadata:
       name: windows
     spec:
-      amiFamily: Windows2022
+      amiFamily: Windows2025
       amiSelectorTerms:
-        - alias: windows2022@latest
+        - alias: windows2025@latest
       role: ${module.karpenter_windows.node_iam_role_name}
       subnetSelectorTerms:
         - tags:


### PR DESCRIPTION
Depends on #1416

Follow-up to #1400 and #1414 

That PR never bumped this `windows-build` value, so it was _exclusively_ selecting nodes that had a windows server version of 2022.