### PR TITLE
Scope down runner service account permissions

### DIFF
--- a/k8s/production/runners/service-accounts.yaml
+++ b/k8s/production/runners/service-accounts.yaml
@@ -11,8 +11,14 @@ kind: ServiceAccount
 metadata:
   name: runner
   namespace: pipeline
+automountServiceAccountToken: false
 
 ---
+# Permissions for the GitLab Kubernetes executor *manager* to create/exec/attach job pods and
+# manage the ConfigMaps/Secrets it mounts into them. Bound ONLY to the manager SA
+# (gitlab/runner) below - never to the build-pod SA (pipeline/runner).
+# TODO: narrow from a ClusterRole to a Role scoped to the `pipeline` namespace (jobs only run
+# there) once we've confirmed the executor needs nothing cluster-wide.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -31,9 +37,6 @@ subjects:
   - kind: ServiceAccount
     name: runner
     namespace: gitlab
-  - kind: ServiceAccount
-    name: runner
-    namespace: pipeline
 roleRef:
   kind: ClusterRole
   name: gitlab-runner


### PR DESCRIPTION
Only the executor/manager (gitlab/runner) needs permissions to create and drive job pods. This removes pipeline/runner from the binding so build pods have no Kubernetes API access, and sets automountServiceAccountToken: false on that SA so a job has no token to present even if a binding is reintroduced by mistake. The manager SA and the pipeline/runner SA itself (which job pods still reference) are unchanged, so CI is unaffected.