### PR TITLE
Remove the unused EFS CSI driver

### DIFF
--- a/terraform/modules/spack_aws_k8s/eks.tf
+++ b/terraform/modules/spack_aws_k8s/eks.tf
@@ -91,10 +91,6 @@ module "eks" {
       addon_version            = "v1.51.1-eksbuild.1"
       service_account_role_arn = aws_iam_role.ebs_csi_driver.arn
     }
-    aws-efs-csi-driver = {
-      addon_version            = "v2.1.13-eksbuild.1"
-      service_account_role_arn = aws_iam_role.efs_csi_driver.arn
-    }
   }
 
   iam_role_additional_policies = {
@@ -171,33 +167,6 @@ resource "aws_iam_role" "ebs_csi_driver" {
 resource "aws_iam_role_policy_attachment" "ebs_csi_driver" {
   role       = aws_iam_role.ebs_csi_driver.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy" # AWS managed policy
-}
-
-resource "aws_iam_role" "efs_csi_driver" {
-  name = "AmazonEKS_EFS_CSI_DriverRole-${var.deployment_name}"
-  assume_role_policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Effect" : "Allow",
-        "Principal" : {
-          "Federated" : module.eks.oidc_provider_arn
-        },
-        "Action" : "sts:AssumeRoleWithWebIdentity",
-        "Condition" : {
-          "StringEquals" : {
-            "${module.eks.oidc_provider}:sub" : "system:serviceaccount:kube-system:efs-csi-*",
-            "${module.eks.oidc_provider}:aud" : "sts.amazonaws.com"
-          }
-        }
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "efs_csi_driver" {
-  role       = aws_iam_role.efs_csi_driver.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy" # AWS managed policy
 }
 
 resource "aws_iam_role" "eks_cluster_access" {


### PR DESCRIPTION
Removes the `aws-efs-csi-driver` EKS addon along with its IAM role and policy attachment. Nothing in either cluster uses EFS.

## Evidence

| Check | Result |
|---|---|
| EFS filesystems in the account | **none** in `us-east-1`, **none** in `us-west-2` |
| EFS StorageClass | none in either cluster (only `gp2` and `gp3`, both EBS) |
| PersistentVolumes | 5 prod / 4 staging, **all** `ebs.csi.aws.com` |
| EFS PVCs | none |
| Inline `efs.csi.aws.com` volumes on any pod | none |

There is no filesystem in the account for the driver to mount. It was nonetheless running a two-replica controller Deployment plus a node DaemonSet on every node — roughly **103 pods in production and 33 in staging** — and placing one more pod on every new Karpenter node as the cluster scales.

## The role's trust policy never worked anyway

```hcl
"${module.eks.oidc_provider}:sub" : "system:serviceaccount:kube-system:efs-csi-*"
```

This is `StringEquals`, where `*` is a literal character rather than a wildcard, so it never matched `efs-csi-controller-sa` or `efs-csi-node-sa`. Those pods have never been able to assume the role. That is corroborating evidence for "unused" — anything genuinely depending on EFS would have been failing loudly.

## Checks

- No residual `efs` references remain in the Terraform
- `terraform fmt` clean
- `terraform validate` passes for both `terraform/production` and `terraform/staging`

## Before merging

Applying this destroys `AmazonEKS_EFS_CSI_DriverRole-prod` / `-staging` and deletes the addon's DaemonSet and controller. Since zero EFS filesystems exist, re-adding it later is a clean re-add rather than a migration. If you would rather stage it, removing the addon alone is the safe half and the roles can follow in a second apply.

A `terraform plan` should show exactly three destroys and nothing else — worth confirming against staging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
