### PR TITLE
Add `user/mike` to readonly cluster role

### DIFF
--- a/terraform/modules/spack_aws_k8s/eks.tf
+++ b/terraform/modules/spack_aws_k8s/eks.tf
@@ -226,6 +226,7 @@ resource "aws_iam_role" "readonly_clusterrole" {
           "AWS" : [
             "arn:aws:iam::588562868276:user/alecscott",
             "arn:aws:iam::588562868276:user/tgamblin",
+            "arn:aws:iam::588562868276:user/mike",
           ]
         },
         "Action" : "sts:AssumeRole"


### PR DESCRIPTION
Just adding myself to the trust policy on this so I can use the viewer-only role when needed.