### PR TITLE
Scope down the notary service account's S3 access

### DIFF
--- a/terraform/modules/spack_aws_k8s/iam_service_accounts.tf
+++ b/terraform/modules/spack_aws_k8s/iam_service_accounts.tf
@@ -219,14 +219,38 @@ module "notary" {
           ],
           "Resource" : "arn:aws:kms:us-east-1:588562868276:key/e811e4c5-ea63-4da3-87d4-664dc5395169"
         },
-        # S3 Full Access
+        # The signing job needs to list the spec manifests it is about to sign,
+        # and (via `spack gpg publish --update-index`) every spec manifest in the
+        # stack mirror in order to rebuild the buildcache index.
+        {
+          "Effect" : "Allow",
+          "Action" : "s3:ListBucket",
+          "Resource" : module.protected_binary_mirror.bucket_arn
+        },
+        # The signing job syncs unsigned `*.spec.manifest.json` files down from
+        # the stack mirror, re-signs them with the reputational key, syncs them
+        # back up, then publishes the public key and regenerates the key and
+        # buildcache indices (each a blob write plus a manifest write). Reads
+        # cover the spec manifests and the blobs they point at; writes cover
+        # `v3/manifests/{spec,key,index}/`, `blobs/`, and `v3/layout.json`.
+        #
+        # Signing only ever runs in protected-branch pipelines, whose mirrors
+        # live at s3://spack-binaries/<ref>/<stack> for ref `develop` or
+        # `releases/v*` -- so release tag prefixes (`v0.23.1/`), develop
+        # snapshots (`develop-YYYY-MM-DD/`) and everything else in the bucket
+        # stay out of reach. AbortMultipartUpload is only needed so that a
+        # failed multipart upload of a large index can clean up after itself.
         {
           "Effect" : "Allow",
           "Action" : [
-            "s3:*",
-            "s3-object-lambda:*"
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:AbortMultipartUpload"
           ],
-          "Resource" : "*"
+          "Resource" : [
+            "${module.protected_binary_mirror.bucket_arn}/develop/*",
+            "${module.protected_binary_mirror.bucket_arn}/releases/*"
+          ]
         }
       ]
     })


### PR DESCRIPTION
The notary service account, used by the package signing runner, held `s3:*` and `s3-object-lambda:*` on `*`. That is full read/write/delete on every bucket in the account. It appears that it was originally copy-pasted from the [AmazonS3FullAccess](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonS3FullAccess.html) managed policy. 

What the signing job actually touches, from the job definition in spack-packages (`.ci/gitlab/configs/ci.yaml`) and the spack code it calls:

  - `aws s3 sync` pulls `*.spec.manifest.json` down from `s3://spack-binaries/<ref>/<stack>/v3/manifests/spec`, and pushes the re-signed copies back to the same prefix.
  - `/sign.sh` itself does no S3 at all -- it is GPG plus a KMS decrypt.
  - `spack gpg publish --update-index` lists and reads every spec manifest (and the blobs they reference) to rebuild the index, then writes `v3/manifests/{spec,key,index}/`, `blobs/`, and `v3/layout.json`.

`spack ci` only emits a signing job for protected-branch pipelines, so `<ref>` is only ever `develop` or `releases/v*`. Release tag prefixes and develop snapshots are populated by copy-only pipelines, which have no signing job.

`AbortMultipartUpload` is included because spack pushes the index via `s3.upload_file`, which goes multipart above 8MB and cleans up after itself on failure.

Obviously, we'll want to keep a close eye on signing jobs for a while after applying this.