### PR TITLE
Grant prune-buildcache role access to spack-binaries-prs bucket

### DIFF
--- a/terraform/modules/spack_aws_k8s/iam_service_accounts.tf
+++ b/terraform/modules/spack_aws_k8s/iam_service_accounts.tf
@@ -15,6 +15,16 @@ module "build_cache_pruner" {
             "s3:DeleteObject"
           ],
           "Resource" : "${module.protected_binary_mirror.bucket_arn}/develop/*"
+        },
+        {
+          "Effect" : "Allow",
+          "Action" : "s3:ListBucket",
+          "Resource" : module.pr_binary_mirror.bucket_arn
+        },
+        {
+          "Effect" : "Allow",
+          "Action" : "s3:DeleteObject",
+          "Resource" : "${module.pr_binary_mirror.bucket_arn}/*"
         }
       ]
     }),


### PR DESCRIPTION
This fixes AccessDenied errors we were seeing in the prune-buildcache-v3 CronJob when attempting to s3:DeleteObject against the spack-binaries-prs bucket.

This was caused by the fact that the relevant IAM policy only granted this action on the develop/* prefix of the protected mirror.

Resolve this error by adding ListBucket/PutObject/DeleteObject on the PR binary mirror bucket to the same statement.