### PR TITLE
Prune the public buildcache more frequently

### DIFF
--- a/k8s/production/custom/prune-buildcache/cron-jobs.yaml
+++ b/k8s/production/custom/prune-buildcache/cron-jobs.yaml
@@ -5,7 +5,8 @@ metadata:
   name: prune-buildcache-v3
   namespace: custom
 spec:
-  schedule: "0 0 * * 6"
+  # Run at midnight UTC on every even-numbered day of the month.
+  schedule: "0 0 2-30/2 * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
Update our pruning cron to run every other day, rather than once a week