### PR TITLE
Deploy the analytics stack to staging

### DIFF
--- a/k8s/staging/custom/webhook-handler/kustomization.yaml
+++ b/k8s/staging/custom/webhook-handler/kustomization.yaml
@@ -1,0 +1,46 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../production/custom/webhook-handler/deployments.yaml
+  - ../../../production/custom/webhook-handler/services.yaml
+  - ../../../production/custom/webhook-handler/service-accounts.yaml
+patches:
+  # Staging sees a small fraction of production's job volume; run single
+  # replicas with much smaller resource requests. Everything else (GitLab
+  # endpoint, DB hosts, celery broker) comes from the webhook-secrets and
+  # webhook-handler-db Secrets, which Terraform populates with
+  # staging-specific values.
+  - target:
+      kind: Deployment
+      name: webhook-handler
+      namespace: custom
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 500m
+            memory: 1G
+          limits:
+            cpu: 1
+            memory: 2G
+  - target:
+      kind: Deployment
+      name: webhook-handler-worker
+      namespace: custom
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 500m
+            memory: 1G
+          limits:
+            cpu: 1
+            memory: 1.5G

--- a/terraform/modules/spack_aws_k8s/analytics_db.tf
+++ b/terraform/modules/spack_aws_k8s/analytics_db.tf
@@ -1,13 +1,9 @@
 resource "aws_db_subnet_group" "analytics_db" {
-  count = var.enable_analytics_db ? 1 : 0
-
   name       = "spack-analytics${local.suffix}"
   subnet_ids = module.vpc.private_subnets
 }
 
 resource "random_password" "analytics_db_password" {
-  count = var.enable_analytics_db ? 1 : 0
-
   length           = 32
   override_special = "!#$%&*()-_=+[]{}<>:?"
 
@@ -17,8 +13,6 @@ resource "random_password" "analytics_db_password" {
 }
 
 module "analytics_db" {
-  count = var.enable_analytics_db ? 1 : 0
-
   source  = "terraform-aws-modules/rds/aws"
   version = "6.10.0"
 
@@ -33,11 +27,11 @@ module "analytics_db" {
   db_name                     = "analytics"
   username                    = "postgres"
   port                        = "5432"
-  password                    = random_password.analytics_db_password[0].result
+  password                    = random_password.analytics_db_password.result
   manage_master_user_password = false
 
   publicly_accessible  = false
-  db_subnet_group_name = aws_db_subnet_group.analytics_db[0].name
+  db_subnet_group_name = aws_db_subnet_group.analytics_db.name
 
   maintenance_window              = "Sun:00:00-Sun:03:00"
   backup_window                   = "03:00-06:00"
@@ -61,8 +55,6 @@ module "analytics_db" {
 }
 
 resource "kubectl_manifest" "webhook_analytics_db_secrets" {
-  count = var.enable_analytics_db ? 1 : 0
-
   yaml_body = <<-YAML
     apiVersion: v1
     kind: Secret
@@ -70,7 +62,29 @@ resource "kubectl_manifest" "webhook_analytics_db_secrets" {
       name: webhook-handler-db
       namespace: custom
     stringData:
-      analytics-postgresql-host: "${module.analytics_db[0].db_instance_address}"
-      analytics-postgresql-password: "${random_password.analytics_db_password[0].result}"
+      analytics-postgresql-host: "${module.analytics_db.db_instance_address}"
+      analytics-postgresql-password: "${random_password.analytics_db_password.result}"
   YAML
+}
+
+# These resources were previously gated behind an enable_analytics_db flag
+# (count = 0/1) and live at indexed addresses in the production state.
+moved {
+  from = aws_db_subnet_group.analytics_db[0]
+  to   = aws_db_subnet_group.analytics_db
+}
+
+moved {
+  from = random_password.analytics_db_password[0]
+  to   = random_password.analytics_db_password
+}
+
+moved {
+  from = module.analytics_db[0]
+  to   = module.analytics_db
+}
+
+moved {
+  from = kubectl_manifest.webhook_analytics_db_secrets[0]
+  to   = kubectl_manifest.webhook_analytics_db_secrets
 }

--- a/terraform/modules/spack_aws_k8s/variables.tf
+++ b/terraform/modules/spack_aws_k8s/variables.tf
@@ -10,12 +10,6 @@ variable "region" {
   type = string
 }
 
-variable "enable_analytics_db" {
-  description = "Whether to provision the analytics PostgreSQL database."
-  type        = bool
-  default     = true
-}
-
 variable "analytics_db_instance_class" {
   description = "AWS RDS DB instance class for the analytics PostgreSQL database."
   type        = string

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -8,7 +8,6 @@ module "spack_aws_k8s" {
   eks_cluster_role = var.eks_cluster_role
 
 
-  enable_analytics_db         = true
   analytics_db_instance_class = "db.t4g.xlarge"
 
   gitlab_db_instance_class    = "db.m7g.4xlarge"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -6,7 +6,7 @@ module "spack_aws_k8s" {
 
   region = "us-west-2"
 
-  enable_analytics_db = false
+  analytics_db_instance_class = "db.t4g.small"
 
   gitlab_db_instance_class    = "db.t4g.small"
   gitlab_redis_instance_class = "cache.t4g.small"


### PR DESCRIPTION
Provisions the staging analytics RDS instance (with a cheaper `db.t4g.small` instance type) and deploys the webhook-handler (web + celery worker) to the staging cluster as a kustomize overlay of the production manifests, scaled down to single replicas with small resource requests. The RDS instance adds approximately $23/month to our monthly costs, and the two additional pods for the webhook-handler should add virtually zero costs as they will fit on existing nodes.

This gives staging an end-to-end CI-analytics path, enabling development/testing of the new OpenSearch setup without affecting production (since the webhook-handler will likely be involved with GitLab job log ingestion).