### PR TITLE
Improve definition of human IAM users and groups

### DIFF
--- a/terraform/production/iam.tf
+++ b/terraform/production/iam.tf
@@ -252,17 +252,6 @@ moved {
   to   = aws_iam_user.human["tgamblin"]
 }
 
-# TODO: can we remove these?
-resource "aws_iam_user_policy_attachment" "tgamblin_route53" {
-  user       = aws_iam_user.human["tgamblin"].name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53FullAccess"
-}
-resource "aws_iam_user_policy_attachment" "tgamblin_s3" {
-  user       = aws_iam_user.human["tgamblin"].name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
-}
-
-
 # Robot IAM users
 resource "aws_iam_user" "e4s_cache" {
   name = "e4s-cache"

--- a/terraform/production/iam.tf
+++ b/terraform/production/iam.tf
@@ -111,83 +111,99 @@ resource "aws_iam_group_policy_attachment" "e4s_cache_allow_bucket_list" {
   group      = aws_iam_group.e4s_cache.name
   policy_arn = aws_iam_policy.allow_group_to_see_bucket_list_in_the_console.arn
 }
-resource "aws_iam_user_group_membership" "alecscott" {
-  user = aws_iam_user.human["alecscott"].name
-  groups = [
-    aws_iam_group.eks_users.name,
-  ]
-}
-resource "aws_iam_user_group_membership" "dan" {
-  user = aws_iam_user.human["dan"].name
-  groups = [
-    aws_iam_group.eks_users.name,
-  ]
-}
 resource "aws_iam_user_group_membership" "e4s_cache" {
   user = aws_iam_user.e4s_cache.name
   groups = [
     aws_iam_group.e4s_cache.name,
   ]
 }
-resource "aws_iam_user_group_membership" "jacob" {
-  user = aws_iam_user.human["jacob"].name
-  groups = [
-    aws_iam_group.custodians.name,
-  ]
-}
-resource "aws_iam_user_group_membership" "krattiger1" {
-  user = aws_iam_user.human["krattiger1"].name
-  groups = [
-    aws_iam_group.eks_users.name,
-  ]
-}
-resource "aws_iam_user_group_membership" "krattiger1_eks_user" {
-  user = aws_iam_user.human["krattiger1-eks-user"].name
-  groups = [
-    aws_iam_group.eks_users.name,
-  ]
-}
-resource "aws_iam_user_group_membership" "mike" {
-  user = aws_iam_user.human["mike"].name
-  groups = [
-    aws_iam_group.custodians.name,
-    aws_iam_group.eks_users.name,
-  ]
-}
-resource "aws_iam_user_group_membership" "tgamblin" {
-  user = aws_iam_user.human["tgamblin"].name
-  groups = [
-    aws_iam_group.eks_users.name,
-  ]
-}
-resource "aws_iam_user_group_membership" "zack" {
-  user = aws_iam_user.human["zack"].name
-  groups = [
-    aws_iam_group.custodians.name,
-    aws_iam_group.eks_users.name,
-  ]
-}
 
+# ############################
+# Human IAM user definitions
+# ############################
 
-# Human IAM users
 locals {
-  human_iam_users = [
-    "dan",
+  custodians = [
     "jacob",
-    "john",
-    "peter",
+    "mike",
+    "zack",
+  ]
+  eks_users = [
+    "alecscott",
+    "dan",
     "krattiger1",
     "krattiger1-eks-user",
     "mike",
-    "zack",
-    "alecscott",
-    "lpeyrala",
     "tgamblin",
+    "zack",
   ]
+  # These users aren't in any groups.
+  extra_users = [
+    "john",
+    "peter",
+    "lpeyrala",
+  ]
+
+  all_human_users = distinct(concat(local.custodians, local.eks_users, local.extra_users))
+
+  human_user_groups = {
+    for user in distinct(concat(local.custodians, local.eks_users)) :
+    user => concat(
+      contains(local.custodians, user) ? [aws_iam_group.custodians.name] : [],
+      contains(local.eks_users, user) ? [aws_iam_group.eks_users.name] : [],
+    )
+  }
+}
+
+resource "aws_iam_user_group_membership" "human" {
+  for_each = local.human_user_groups
+
+  user   = aws_iam_user.human[each.key].name
+  groups = each.value
+}
+
+moved {
+  from = aws_iam_user_group_membership.alecscott
+  to   = aws_iam_user_group_membership.human["alecscott"]
+}
+
+moved {
+  from = aws_iam_user_group_membership.dan
+  to   = aws_iam_user_group_membership.human["dan"]
+}
+
+moved {
+  from = aws_iam_user_group_membership.jacob
+  to   = aws_iam_user_group_membership.human["jacob"]
+}
+
+moved {
+  from = aws_iam_user_group_membership.krattiger1
+  to   = aws_iam_user_group_membership.human["krattiger1"]
+}
+
+moved {
+  from = aws_iam_user_group_membership.krattiger1_eks_user
+  to   = aws_iam_user_group_membership.human["krattiger1-eks-user"]
+}
+
+moved {
+  from = aws_iam_user_group_membership.mike
+  to   = aws_iam_user_group_membership.human["mike"]
+}
+
+moved {
+  from = aws_iam_user_group_membership.tgamblin
+  to   = aws_iam_user_group_membership.human["tgamblin"]
+}
+
+moved {
+  from = aws_iam_user_group_membership.zack
+  to   = aws_iam_user_group_membership.human["zack"]
 }
 
 resource "aws_iam_user" "human" {
-  for_each = toset(local.human_iam_users)
+  for_each = toset(local.all_human_users)
   name     = each.value
 
   lifecycle {

--- a/terraform/production/iam.tf
+++ b/terraform/production/iam.tf
@@ -112,13 +112,13 @@ resource "aws_iam_group_policy_attachment" "e4s_cache_allow_bucket_list" {
   policy_arn = aws_iam_policy.allow_group_to_see_bucket_list_in_the_console.arn
 }
 resource "aws_iam_user_group_membership" "alecscott" {
-  user = aws_iam_user.alecscott.name
+  user = aws_iam_user.human["alecscott"].name
   groups = [
     aws_iam_group.eks_users.name,
   ]
 }
 resource "aws_iam_user_group_membership" "dan" {
-  user = aws_iam_user.dan.name
+  user = aws_iam_user.human["dan"].name
   groups = [
     aws_iam_group.eks_users.name,
   ]
@@ -130,38 +130,38 @@ resource "aws_iam_user_group_membership" "e4s_cache" {
   ]
 }
 resource "aws_iam_user_group_membership" "jacob" {
-  user = aws_iam_user.jacob.name
+  user = aws_iam_user.human["jacob"].name
   groups = [
     aws_iam_group.custodians.name,
   ]
 }
 resource "aws_iam_user_group_membership" "krattiger1" {
-  user = aws_iam_user.krattiger1.name
+  user = aws_iam_user.human["krattiger1"].name
   groups = [
     aws_iam_group.eks_users.name,
   ]
 }
 resource "aws_iam_user_group_membership" "krattiger1_eks_user" {
-  user = aws_iam_user.krattiger1_eks_user.name
+  user = aws_iam_user.human["krattiger1-eks-user"].name
   groups = [
     aws_iam_group.eks_users.name,
   ]
 }
 resource "aws_iam_user_group_membership" "mike" {
-  user = aws_iam_user.mike.name
+  user = aws_iam_user.human["mike"].name
   groups = [
     aws_iam_group.custodians.name,
     aws_iam_group.eks_users.name,
   ]
 }
 resource "aws_iam_user_group_membership" "tgamblin" {
-  user = aws_iam_user.tgamblin.name
+  user = aws_iam_user.human["tgamblin"].name
   groups = [
     aws_iam_group.eks_users.name,
   ]
 }
 resource "aws_iam_user_group_membership" "zack" {
-  user = aws_iam_user.zack.name
+  user = aws_iam_user.human["zack"].name
   groups = [
     aws_iam_group.custodians.name,
     aws_iam_group.eks_users.name,
@@ -170,46 +170,95 @@ resource "aws_iam_user_group_membership" "zack" {
 
 
 # Human IAM users
-resource "aws_iam_user" "dan" {
-  name = "dan"
+locals {
+  human_iam_users = [
+    "dan",
+    "jacob",
+    "john",
+    "peter",
+    "krattiger1",
+    "krattiger1-eks-user",
+    "mike",
+    "zack",
+    "alecscott",
+    "lpeyrala",
+    "tgamblin",
+  ]
 }
-resource "aws_iam_user" "jacob" {
-  name = "jacob"
+
+resource "aws_iam_user" "human" {
+  for_each = toset(local.human_iam_users)
+  name     = each.value
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
-resource "aws_iam_user" "john" {
-  name = "john"
+
+moved {
+  from = aws_iam_user.dan
+  to   = aws_iam_user.human["dan"]
 }
-resource "aws_iam_user" "peter" {
-  name = "peter"
+
+moved {
+  from = aws_iam_user.jacob
+  to   = aws_iam_user.human["jacob"]
 }
-resource "aws_iam_user" "krattiger1" {
-  name = "krattiger1"
+
+moved {
+  from = aws_iam_user.john
+  to   = aws_iam_user.human["john"]
 }
-resource "aws_iam_user" "krattiger1_eks_user" {
-  name = "krattiger1-eks-user"
+
+moved {
+  from = aws_iam_user.peter
+  to   = aws_iam_user.human["peter"]
 }
-resource "aws_iam_user" "mike" {
-  name = "mike"
+
+moved {
+  from = aws_iam_user.krattiger1
+  to   = aws_iam_user.human["krattiger1"]
 }
-resource "aws_iam_user" "zack" {
-  name = "zack"
+
+moved {
+  from = aws_iam_user.krattiger1_eks_user
+  to   = aws_iam_user.human["krattiger1-eks-user"]
 }
-resource "aws_iam_user" "alecscott" {
-  name = "alecscott"
+
+moved {
+  from = aws_iam_user.mike
+  to   = aws_iam_user.human["mike"]
 }
-resource "aws_iam_user" "lpeyrala" {
-  name = "lpeyrala"
+
+moved {
+  from = aws_iam_user.zack
+  to   = aws_iam_user.human["zack"]
 }
-resource "aws_iam_user" "tgamblin" {
-  name = "tgamblin"
+
+moved {
+  from = aws_iam_user.alecscott
+  to   = aws_iam_user.human["alecscott"]
 }
+
+moved {
+  from = aws_iam_user.lpeyrala
+  to   = aws_iam_user.human["lpeyrala"]
+}
+
+moved {
+  from = aws_iam_user.tgamblin
+  to   = aws_iam_user.human["tgamblin"]
+}
+
 # TODO: can we remove these?
 resource "aws_iam_user_policy_attachment" "tgamblin_route53" {
-  user       = aws_iam_user.tgamblin.name
+  user       = aws_iam_user.human["tgamblin"].name
   policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53FullAccess"
 }
 resource "aws_iam_user_policy_attachment" "tgamblin_s3" {
-  user       = aws_iam_user.tgamblin.name
+  user       = aws_iam_user.human["tgamblin"].name
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 


### PR DESCRIPTION
This has a few benefits:

1. Adds an ignore to user tags so IAM keys don't disrupt state.
2. Slims down the code (once I remove those moved blocks)
3. Provides a list of IAM users and group memberships in one spot, making it easy to view and modify.

I also included the removal of a couple of permissions given to todd explicitly. I can't imagine he uses these permissions much, as one is for Route53, and the other is for S3 access (shouldn't be necessary much from an IAM users as the buckets are public). However, we should still confirm with him.

@mvandenburgh If this looks good to you (or once we make changes) I'll apply the terraform and remove the moved blocks before merging.