### PR TITLE
Wire the staging custom overlays into Flux

### DIFF
--- a/k8s/staging/custom/kustomization.yaml
+++ b/k8s/staging/custom/kustomization.yaml
@@ -2,4 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../production/custom/namespace.yaml
+  - cache-indexer
+  - gitlab-setting-updater
+  - prune-buildcache
   - webhook-handler

--- a/k8s/staging/custom/kustomization.yaml
+++ b/k8s/staging/custom/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../production/custom/namespace.yaml
+  - webhook-handler


### PR DESCRIPTION
## Problem

#1464 added a `webhook-handler` overlay under `k8s/staging/custom/`, but the analytics pods never showed up on staging.

Flux's staging `Kustomization` points at `./k8s/staging/`, which has no top-level `kustomization.yaml`. Flux's auto-generated kustomization walks that directory and, for any subdirectory that contains its own `kustomization.yaml`, adds the directory as a single resource and stops descending. `k8s/staging/custom/kustomization.yaml` exists and only listed `../../production/custom/namespace.yaml`, so nothing under `custom/` other than the namespace was ever rendered.

This has been the case since the file was created in 2023: the `cache-indexer`, `gitlab-setting-updater` and `prune-buildcache` overlays that live alongside `webhook-handler` were never applied to staging either.

## Change

Add the four overlay directories to `k8s/staging/custom/kustomization.yaml`. Two commits: the first wires in `webhook-handler` (the analytics fix), the second wires in the three pre-existing overlays.

## Verification

Local dry-run build of the staging tree:

```
flux build kustomization flux-system \
  --kustomization-file k8s/staging/flux-system/gotk-sync.yaml \
  --path ./k8s/staging --dry-run
```

Before: zero namespaced objects in `custom`. After, the build additionally renders:

- `Deployment/webhook-handler` and `Deployment/webhook-handler-worker` (1 replica each, reduced resources per the staging patches), plus the `Service`, `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding`
- `CronJob/index-binary-caches` in `custom` (bucket name and Sentry config come from ConfigMaps the shared Terraform module already creates for staging)
- `CronJob/prune-buildcache-v3` in `custom`, patched to `gitlab.staging.spack.io` and `s3://spack-binaries-staging/develop`
- `CronJob`, `ServiceAccount`, `Role` and `RoleBinding` for `gitlab-setting-updater` in `gitlab` (runs a rails command against the local toolbox pod; nothing production-specific is hardcoded)

## Notes

- The webhook-handler Deployments read the `webhook-secrets` and `webhook-handler-db` Secrets. The latter is created by the Terraform change in #1464, so a staging `terraform apply` must have run for the pods to start.
- The production deployment hardcodes `DJANGO_SETTINGS_MODULE=analytics.settings.production` and the staging overlay does not patch it. Left as-is here; worth confirming that module is env-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
